### PR TITLE
Fix links to remove .html

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -81,11 +81,17 @@ def convert_rst_links(text, page_info):
 
     prefix = f"/docs/{package_name}/{version}/{language}/"
     # Links of the form :doc:`page`
-    text = _re_simple_doc.sub(rf'[\1]({prefix}\1.html)', text)
+    text = _re_simple_doc.sub(rf'[\1]({prefix}\1)', text)
     # Links of the form :doc:`text <page>`
-    text = _re_doc_with_description.sub(rf'[\1]({prefix}\2.html)', text)
+    text = _re_doc_with_description.sub(rf'[\1]({prefix}\2)', text)
 
-    prefix = f"{prefix}{page_info['page']}" if "page" in page_info else ""
+    if "page" in page_info:
+        page = page_info['page']
+        if page.endswith(".html"):
+            page = page[:-5]
+        prefix = f"{prefix}{page}"
+    else:
+        prefix = ""
     # Refs of the form :ref:`page`
     text = _re_simple_ref.sub(rf'[\1]({prefix}#\1)', text)
     # Refs of the form :ref:`text <page>`
@@ -97,6 +103,9 @@ def convert_rst_links(text, page_info):
     text = _re_prefix_links.sub(fr'[\1]({prefix}\2)', text)
     # Other links
     text = _re_links.sub(r"[\1](\2)", text)
+    # Relative links or Transformers links need to remove the .html
+    if "(https://https://huggingface.co/" in text or re.search("\(\.+/", text) is not None:
+        text = text.replace(".html", "")
     return text
 
 

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -203,11 +203,11 @@ third line``.
 
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page`.", page_info),
-            "This is a link to an inner page [page](/docs/transformers/master/en/page.html).",
+            "This is a link to an inner page [page](/docs/transformers/master/en/page).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page name <page ref>`.", page_info),
-            "This is a link to an inner page [page name](/docs/transformers/master/en/page ref.html).",
+            "This is a link to an inner page [page name](/docs/transformers/master/en/page ref).",
         )
 
         self.assertEqual(
@@ -222,11 +222,11 @@ third line``.
         page_info["page"] = "model_doc/bert.html"
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section`.", page_info),
-            "This is a link to an inner section [section](/docs/transformers/master/en/model_doc/bert.html#section).",
+            "This is a link to an inner section [section](/docs/transformers/master/en/model_doc/bert#section).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section name <section ref>`.", page_info),
-            "This is a link to an inner section [section name](/docs/transformers/master/en/model_doc/bert.html#section ref).",
+            "This is a link to an inner section [section name](/docs/transformers/master/en/model_doc/bert#section ref).",
         )
     
     def test_convert_rst_links_with_version_and_lang(self):
@@ -234,11 +234,11 @@ third line``.
 
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page`.", page_info),
-            "This is a link to an inner page [page](/docs/transformers/v4.10.0/fr/page.html).",
+            "This is a link to an inner page [page](/docs/transformers/v4.10.0/fr/page).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page name <page ref>`.", page_info),
-            "This is a link to an inner page [page name](/docs/transformers/v4.10.0/fr/page ref.html).",
+            "This is a link to an inner page [page name](/docs/transformers/v4.10.0/fr/page ref).",
         )
 
         self.assertEqual(
@@ -253,11 +253,15 @@ third line``.
         page_info["page"] = "model_doc/bert.html"
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section`.", page_info),
-            "This is a link to an inner section [section](/docs/transformers/v4.10.0/fr/model_doc/bert.html#section).",
+            "This is a link to an inner section [section](/docs/transformers/v4.10.0/fr/model_doc/bert#section).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section name <section ref>`.", page_info),
-            "This is a link to an inner section [section name](/docs/transformers/v4.10.0/fr/model_doc/bert.html#section ref).",
+            "This is a link to an inner section [section name](/docs/transformers/v4.10.0/fr/model_doc/bert#section ref).",
+        )
+        self.assertEqual(
+            convert_rst_links("`What are input IDs? <../glossary.html#input-ids>`__", page_info),
+            "[What are input IDs?](../glossary#input-ids)",
         )
 
     def test_is_empty_line(self):


### PR DESCRIPTION
This removes the .html from generated links in the covnersion RST to Markdown and in links provided that:
- point to the huggingface.co website
or
- are relative