### PR TITLE
Fix unindent in code examples

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -376,6 +376,8 @@ def remove_indent(text):
     current_indents = []
     # List of new indents to remember for nested lists
     new_indents = []
+    is_inside_code = False
+    code_indent = 0
     for idx, line in enumerate(lines):
         # Line is an item in a list.
         if _re_list.search(line) is not None:
@@ -410,6 +412,16 @@ def remove_indent(text):
         # Deal with empty lines separately
         elif is_empty_line(line):
             lines[idx] = ""
+
+        # Code blocks
+        elif line.lstrip().startswith("```"):
+            is_inside_code = not is_inside_code
+            if is_inside_code:
+                code_indent = find_indent(line)
+            lines[idx] = line[code_indent:]
+        elif is_inside_code:
+            lines[idx] = line[code_indent:]
+
         else:
             indent = find_indent(line)
             if len(current_indents) > 0 and indent > current_indents[-1]:

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -525,8 +525,29 @@ Now we are out of the list.
     - all
 """
 
+        example3 = """
+  Lala
+  
+  ```python
+  def function(x):
+      return x
+  ```
+  
+  Loulou
+"""
+        expected3 = """
+Lala
+
+```python
+def function(x):
+    return x
+```
+
+Loulou
+"""
         self.assertEqual(remove_indent(example1), expected1)
         self.assertEqual(remove_indent(example2), expected2)
+        self.assertEqual(remove_indent(example3), expected3)
     
     def test_process_titles(self):
         self.assertListEqual(


### PR DESCRIPTION
Currently, code examples ends up unindented. This PR fixes that.