### PR TITLE
Support numbers in anchors

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -243,7 +243,7 @@ def generate_frontmatter_in_text(text, file_name=None):
             title = re.sub(r"\[\[(.*)]]", "", title)
         else:
             # create id/local
-            local = re.sub(r"[^a-z\s]+", "", title.lower())
+            local = re.sub(r"[^a-z0-9\s]+", "", title.lower())
             local = re.sub(r"\s{2,}", " ", local.strip()).replace(" ", "-")
         text[idx] = f'<h{header_level} id="{local}">{title}</h{header_level}>'
         node = FrontmatterNode(title, local)

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -170,3 +170,9 @@ class BuildDocTester(unittest.TestCase):
             generate_frontmatter_in_text("# Bert[[id1]]\n## BertTokenizer[[id2]]\n### BertTokenizerMethod"),
             '---\nlocal: id1\nsections:\n- local: id2\n  sections:\n  - local: berttokenizermethod\n    title: BertTokenizerMethod\n  title: BertTokenizer\ntitle: Bert\n---\n<h1 id="id1">Bert</h1>\n<h2 id="id2">BertTokenizer</h2>\n<h3 id="berttokenizermethod">BertTokenizerMethod</h3>',
         )
+
+        # test headers with numbers
+        self.assertEqual(
+            generate_frontmatter_in_text("# Bert 1\n## BertTokenizer 2 3\n### BertTokenizer 4 5 6 Method"),
+            '---\nlocal: bert-1\nsections:\n- local: berttokenizer-2-3\n  sections:\n  - local: berttokenizer-4-5-6-method\n    title: BertTokenizer 4 5 6 Method\n  title: BertTokenizer 2 3\ntitle: Bert 1\n---\n<h1 id="bert-1">Bert 1</h1>\n<h2 id="berttokenizer-2-3">BertTokenizer 2 3</h2>\n<h3 id="berttokenizer-4-5-6-method">BertTokenizer 4 5 6 Method</h3>',
+        )


### PR DESCRIPTION
Currently numbers are stripped from anchor links.
This PR fixes this issue

cc: @stas00 