### PR TITLE
Add Arguments: to the supported parameters introduction

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -291,7 +291,7 @@ def convert_rst_blocks(text, page_info):
 
 
 # Re pattern that catches rst args blocks of the form `Parameters:`.
-_re_args = re.compile("^\s*(Args?|Parameters?):\s*$")
+_re_args = re.compile("^\s*(Args?|Arguments?|Parameters?):\s*$")
 # Re pattern that catches return blocks of the form `Return:`.
 _re_returns = re.compile("^\s*Returns?:\s*$")
 

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -142,6 +142,10 @@ class ConvertRstToMdxTester(unittest.TestCase):
         self.assertIsNotNone(_re_args.search("  Arg:"))
         self.assertIsNone(_re_args.search("  Arg: lala"))
 
+        self.assertIsNotNone(_re_args.search("  Arguments:"))
+        self.assertIsNotNone(_re_args.search("  Argument:"))
+        self.assertIsNone(_re_args.search("  Argument: lala"))
+
         self.assertIsNotNone(_re_args.search("  Parameters:"))
         self.assertIsNotNone(_re_args.search("  Parameter:"))
         self.assertIsNone(_re_args.search("  Parameter: lala"))


### PR DESCRIPTION
This fixes the issue with some parameters not being recognized because they are introduced with "Arguments:" (cf problem [here](https://github.com/huggingface/transformers/issues/14613#issuecomment-985538424)).