### PR TITLE
Add open-in-colab syntax and fixes to conversion

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -41,9 +41,9 @@ def resolve_open_in_colab(content, page_info):
         page_info (`Dict[str, str]`, *optional*): Some information about the page.
     """
     if "[[open-in-colab]]" not in content:
-        return
+        return content
 
-    page_name = page_info["page"].split("/")[-1].replace(".html", "")
+    page_name = Path(page_info["page"]).stem
     nb_prefix = "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/"
     links = {
         "Mixed": f"{nb_prefix}{page_name}.ipynb",

--- a/src/doc_builder/commands/convert_doc_file.py
+++ b/src/doc_builder/commands/convert_doc_file.py
@@ -68,8 +68,14 @@ def convert_command(args):
     with open(source_file, "r", encoding="utf-8") as f:
         text = f.read()
 
-    page_info = {"package_name": package_name, "page": source_file.with_suffix(".html").relative_to(doc_folder)}
+    page_info = {
+        "package_name": package_name,
+        "page": source_file.with_suffix(".html").relative_to(doc_folder),
+        "no_prefix": True,
+    }
     text = convert_rst_to_mdx(text, page_info, add_imports=False)
+    text = text.replace("&amp;lcub;", "{")
+    text = text.replace("&amp;lt;", "<")
     text = re.sub(r"^\[\[autodoc\]\](\s+)(transformers\.)", r"[[autodoc]]\1", text, flags=re.MULTILINE)
 
     with open(output_file, "w", encoding="utf-8") as f:

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -94,14 +94,15 @@ def convert_rst_links(text, page_info):
     package_name = page_info["package_name"]
     version = page_info.get("version", "master")
     language = page_info.get("language", "en")
+    no_prefix = page_info.get("no_prefix", False)
 
-    prefix = f"/docs/{package_name}/{version}/{language}/"
+    prefix = "" if no_prefix else f"/docs/{package_name}/{version}/{language}/"
     # Links of the form :doc:`page`
     text = _re_simple_doc.sub(rf"[\1]({prefix}\1)", text)
     # Links of the form :doc:`text <page>`
     text = _re_doc_with_description.sub(rf"[\1]({prefix}\2)", text)
 
-    if "page" in page_info:
+    if "page" in page_info and not no_prefix:
         page = str(page_info["page"])
         if page.endswith(".html"):
             page = page[:-5]

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 
+import re
 import unittest
 
 import transformers
-from doc_builder.build_doc import _re_autodoc, _re_list_item, generate_frontmatter_in_text, resolve_links_in_text
+from doc_builder.build_doc import _re_autodoc, _re_list_item, generate_frontmatter_in_text, resolve_links_in_text, resolve_open_in_colab
 
 
 class BuildDocTester(unittest.TestCase):
@@ -29,6 +30,18 @@ class BuildDocTester(unittest.TestCase):
 
     def test_re_list_item(self):
         self.assertEqual(_re_list_item.search("   - forward").groups(), ("forward",))
+    
+    def test_resolve_open_in_colab(self):
+        expected = """
+<ColabDropdown hydrate-props={{
+  classNames: "absolute z-10 right-0 top-0",
+  options:[
+    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/quicktour.ipynb"},
+]}} />
+"""
+        self.assertEqual(resolve_open_in_colab("\n[[open-in-colab]]\n", {"page": "quicktour.html"}), expected)
 
     def test_resolve_links_in_text(self):
         page_info = {"package_name": "transformers"}

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -18,7 +18,13 @@ import re
 import unittest
 
 import transformers
-from doc_builder.build_doc import _re_autodoc, _re_list_item, generate_frontmatter_in_text, resolve_links_in_text, resolve_open_in_colab
+from doc_builder.build_doc import (
+    _re_autodoc,
+    _re_list_item,
+    generate_frontmatter_in_text,
+    resolve_links_in_text,
+    resolve_open_in_colab,
+)
 
 
 class BuildDocTester(unittest.TestCase):
@@ -30,7 +36,7 @@ class BuildDocTester(unittest.TestCase):
 
     def test_re_list_item(self):
         self.assertEqual(_re_list_item.search("   - forward").groups(), ("forward",))
-    
+
     def test_resolve_open_in_colab(self):
         expected = """
 <ColabDropdown hydrate-props={{

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import re
 import unittest
 
 import transformers


### PR DESCRIPTION
This PR adds the syntax to resolve [[open-in-colab]] in doc files to the proper svelte component.

It also introduces a few fixes used when converting some rst files.