### PR TITLE
Convert doc page to notebooks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = ["tqdm", "pyyaml", "packaging"]
 extras = {}
 
 extras["transformers"] = ["transformers[dev]"]
-extras["testing"] = ["pytest", "pytest-xdist", "torch", "transformers"]
+extras["testing"] = ["nbformat", "pytest", "pytest-xdist", "torch", "transformers"]
 extras["quality"] = ["black==21.4b0", "isort>=5.5.4", "flake8>=3.8.3"]
 
 extras["all"] = extras["testing"] + extras["quality"]

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -36,7 +36,7 @@ def build_command(args):
     output_path = os.path.join(args.build_dir, os.path.sep.join([args.library_name, version, args.language]))
 
     print("Building docs for", args.library_name, args.path_to_docs, output_path)
-    build_doc(args.library_name, args.path_to_docs, output_path)
+    build_doc(args.library_name, args.path_to_docs, output_path, notebook_dir=args.notebook_dir)
     update_versions_file(f"./build/{args.library_name}", version)
 
 
@@ -61,6 +61,7 @@ def build_command_parser(subparsers=None):
         help="Version under which to push the files. Will not affect the actual files generated, as these are"
         " generated according to the `path_to_docs` argument.",
     )
+    parser.add_argument("--notebook_dir", type=str, help="Where to save the generated notebooks.", default=None)
 
     if subparsers is not None:
         parser.set_defaults(func=build_command)

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -1,0 +1,301 @@
+# coding=utf-8
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from pathlib import Path
+
+import nbformat
+
+from .autodoc import resolve_links_in_text
+
+
+# Re pattern that matches inline math in MDX: \\(formula\\)
+_re_math_delimiter = re.compile(r"\\\\\((.*?)\\\\\)")
+# Re pattern that matches the copyright paragraph in an MDX file
+_re_copyright = re.compile("<!--\s*Copyright(.*?)-->", flags=re.DOTALL)
+# Re pattern that matches YouTube Svelte components and extract the id
+_re_youtube = re.compile(r'<Youtube id="([^"]+)"/>')
+# Re pattern matching header lines in Markdown
+_re_header = re.compile("^#+\s+\S+")
+# Re pattern matching Python code samples
+_re_python_code = re.compile("^```\s*(py|python)\s*$")
+# Re pattern matching markdown links
+_re_markdown_links = re.compile(r"\[([^\]]*)\]\(([^\)]*)\)")
+
+
+def expand_links(content, page_info):
+    """
+    Expand links relative to the documentation to full links to the hf.co website.
+    """
+    package_name = page_info["package_name"]
+    version = page_info.get("version", "master")
+    language = page_info.get("language", "en")
+    page = str(page_info["page"])
+
+    prefix = f"https://huggingface.co/docs/{package_name}/{version}/{language}"
+
+    def _replace_link(match):
+        description, link = match.groups()
+        if link.startswith("http") or link.startswith("#"):
+            return f"[{description}]({link})"
+        elif link.startswith("/docs/"):
+            return f"[{description}](https://huggingface.co{link})"
+        link = "/".join([prefix] + page.split("/")[:-1] + [link])
+        return f"[{description}]({link})"
+
+    return _re_markdown_links.sub(_replace_link, content)
+
+
+def clean_content(content, package=None, mapping=None, page_info=None):
+    """
+    Clean the content of the doc file to be pure Markdown.
+    """
+    # Remove copyright
+    content = _re_copyright.sub("", content)
+    # Remove [[open-in-colab]] marker
+    content = content.replace("[[open-in-colab]]\n", "")
+    # Replace our special syntax for math formula with the one expected in a notebook.
+    content = _re_math_delimiter.sub(r"$\1$", content)
+    # Resolve the doc links if possible
+    if package is not None and mapping is not None and page_info is not None:
+        content = resolve_links_in_text(content, package, mapping, page_info)
+        content = expand_links(content, page_info)
+
+    return content.strip()
+
+
+def split_frameworks(content):
+    """
+    Split a given doc content in three to extract the Mixed, PyTorch and TensorFlow content.
+    """
+    split_pattern = "===PT-TF-SPLIT==="
+    new_lines = {"mixed": [], "pt": [], "tf": []}
+    lines = content.split("\n")
+    idx = 0
+    while idx < len(lines):
+        if lines[idx].startswith("```"):
+            code_lines = [lines[idx]]
+            idx += 1
+            has_split = False
+            while idx < len(lines) and lines[idx].strip() != "```":
+                if lines[idx].strip() == split_pattern:
+                    new_lines["pt"].extend(code_lines + ["```"])
+                    new_lines["mixed"].extend(code_lines + ["```", ""])
+                    code_lines = [code_lines[0]]
+                    has_split = True
+                else:
+                    code_lines.append(lines[idx])
+                idx += 1
+
+            new_lines["mixed"].extend(code_lines + ["```"])
+            new_lines["tf"].extend(code_lines + ["```"])
+            if not has_split:
+                new_lines["pt"].extend(code_lines + ["```"])
+            idx += 1
+        else:
+            for key in new_lines.keys():
+                new_lines[key].append(lines[idx])
+            idx += 1
+    return ["\n".join(l) for l in new_lines.values()]
+
+
+def markdown_cell(content):
+    """
+    Create a markdown cell with a given content.
+    """
+    return nbformat.notebooknode.NotebookNode({"cell_type": "markdown", "source": content, "metadata": {}})
+
+
+def parse_input_output(code_lines):
+    """
+    Parse a code sample written in doctest syntax to extract input code and expected output.
+    """
+    has_output = False
+    output = None
+    input_lines = []
+    for idx, line in enumerate(code_lines):
+        if line.startswith(">>> "):
+            has_output = True
+            input_lines.append(line[4:])
+        elif has_output and line.startswith("... "):
+            input_lines.append(line[4:])
+        elif has_output and line[:4] not in [">>> ", "... "]:
+            output = "\n".join(code_lines[idx:])
+            break
+        else:
+            input_lines.append(line)
+
+    return "\n".join(input_lines), output
+
+
+def code_cell(code, output=None):
+    """
+    Create a code cell with some `code` and optionally, `output`.
+    """
+    if output is None or len(output) == 0:
+        outputs = []
+    else:
+        outputs = [
+            nbformat.notebooknode.NotebookNode(
+                {
+                    "data": {"text/plain": output},
+                    "execution_count": None,
+                    "metadata": {},
+                    "output_type": "execute_result",
+                }
+            )
+        ]
+    return nbformat.notebooknode.NotebookNode(
+        {"cell_type": "code", "execution_count": None, "source": code, "metadata": {}, "outputs": outputs}
+    )
+
+
+def youtube_cell(youtube_id):
+    """
+    Create a "YouTube" cell for a given ID. It's actually a code cell with input hidden (requires the hide_input
+    extension in regular notebooks and works out of the box on Colab) and the output being the widget with the video.
+
+    Widgets won't be shown by default in a regular notebook unless the user clicks Trust notebook.
+    """
+    html_code = f'<iframe width="560" height="315" src="https://www.youtube.com/embed/{youtube_id}?rel=0&amp;controls=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>'
+    cell_dict = {
+        "cell_type": "code",
+        "metadata": {"cellView": "form", "hide_input": True},
+        "source": ["#@title\n", "from IPython.display import HTML\n", "\n", f"HTML('{html_code}')"],
+        "execution_count": None,
+    }
+    output_dict = {
+        "data": {"text/html": [html_code], "text/plain": ["<IPython.core.display.HTML object>"]},
+        "execution_count": None,
+        "metadata": {},
+        "output_type": "execute_result",
+    }
+    cell_dict["outputs"] = [nbformat.notebooknode.NotebookNode(output_dict)]
+    return nbformat.notebooknode.NotebookNode(cell_dict)
+
+
+def parse_doc_into_cells(content):
+    """
+    Split a documentation content into cells.
+    """
+    cells = []
+    current_lines = []
+    cell_type = "markdown"
+    # We keep track of whether we are in a general code block (not necessarily in a code cell) as a line with a comment
+    # would be detected as a header.
+    in_code = False
+
+    for line in content.split("\n"):
+        # Look if we've got a special line.
+        special_line = None
+        if _re_header.search(line) is not None and not in_code:
+            special_line = "header"
+        elif _re_python_code.search(line) is not None:
+            special_line = "begin_code"
+        elif line.rstrip() == "```" and cell_type == "code":
+            special_line = "end_code"
+        elif line.startswith("```"):
+            special_line = "other_code"
+        elif _re_youtube.search(line) is not None:
+            special_line = "youtube"
+
+        # Some of those special lines mean we have to process the current cell.
+        process_current_cell = False
+        if cell_type == "markdown":
+            process_current_cell = special_line in ["header", "begin_code", "youtube"]
+        elif cell_type == "code":
+            process_current_cell = special_line == "end_code"
+
+        # Add the current cell to the list
+        if process_current_cell:
+            if cell_type == "markdown":
+                content = "\n".join(current_lines).strip()
+                if len(content) > 0:
+                    cells.append(markdown_cell(content))
+            elif cell_type == "code" and len(current_lines) > 0:
+                code, output = parse_input_output(current_lines)
+                cells.append(code_cell(code, output=output))
+            current_lines = []
+
+        if special_line == "header":
+            # Header go on their separate Markdown cell, as it plays nicely with the collapsible headers extension.
+            cells.append(markdown_cell(line))
+        elif special_line == "begin_code":
+            cell_type = "code"
+            in_code = True
+        elif special_line == "end_code":
+            cell_type = "markdown"
+            in_code = False
+        elif special_line == "other_code":
+            current_lines.append(line)
+            in_code = not in_code
+        elif special_line == "youtube":
+            # YouTube cells are their own separate cell for proper showing
+            youtube_id = _re_youtube.search(line).groups()[0]
+            cells.append(youtube_cell(youtube_id))
+        else:
+            current_lines.append(line)
+
+    # Now that we're done, we just have to process the remainder.
+    if cell_type == "markdown":
+        content = "\n".join(current_lines).strip()
+        if len(content) > 0:
+            cells.append(markdown_cell(content))
+
+    return cells
+
+
+def create_notebook(cells):
+    """
+    Create a notebook object with `cells`.
+    """
+    return nbformat.notebooknode.NotebookNode(
+        {
+            "cells": cells,
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 4,
+        }
+    )
+
+
+def generate_notebooks_from_file(file_name, output_dir, package=None, mapping=None, page_info=None):
+    """
+    Generate the notebooks for a given doc file.
+
+    Args:
+        file_name (`str` or `os.PathLike`): The doc file to convert.
+        output_dir (`str` or `os.PathLike`): Where to save the generated notebooks
+        package (`types.ModuleType`, *optional*):
+            The package in which to search objects for (needs to be passed to resolve doc links).
+        mapping (`Dict[str, str]`, *optional*):
+            The map from anchor names of objects to their page in the documentation (needs to be passed to resolve doc
+            links).
+        page_info (`Dict[str, str]`, *optional*):
+            Some information about the page (needs to be passed to resolve doc links).
+    """
+    output_dirs = [output_dir, os.path.join(output_dir, "pytorch"), os.path.join(output_dir, "tensorflow")]
+    output_name = Path(file_name).with_suffix(".ipynb").name
+    with open(file_name, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    content = clean_content(content, package=package, mapping=mapping, page_info=page_info)
+
+    for folder, content in zip(output_dirs, split_frameworks(content)):
+        cells = parse_doc_into_cells(content)
+        notebook = create_notebook(cells)
+        os.makedirs(folder, exist_ok=True)
+        nbformat.write(notebook, os.path.join(folder, output_name), version=4)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -30,6 +30,7 @@ from doc_builder.autodoc import (
     get_source_link,
     get_type_name,
     remove_example_tags,
+    resolve_links_in_text,
 )
 from transformers import BertModel, BertTokenizer, BertTokenizerFast
 from transformers.file_utils import PushToHubMixin
@@ -303,3 +304,101 @@ method to convert it to a tuple before.
 
         _, anchors = autodoc("BertTokenizer", transformers, methods=["__call__"], return_anchors=True)
         self.assertListEqual(anchors, ["transformers.BertTokenizer", "transformers.BertTokenizer.__call__"])
+
+    def test_resolve_links_in_text(self):
+        page_info = {"package_name": "transformers"}
+        small_mapping = {
+            "transformers.BertModel": "model_doc/bert.html",
+            "transformers.BertModel.forward": "model_doc/bert.html",
+            "transformers.BertTokenizer": "bert.html",
+        }
+
+        self.maxDiff = None
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`BertModel`], [`BertModel.forward`] and [`BertTokenizer`] as well as [`SomeClass`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
+                "[BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward) "
+                "and [BertTokenizer](/docs/transformers/master/en/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
+            ),
+        )
+
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`~transformers.BertModel`], [`~transformers.BertModel.forward`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
+                "[forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
+            ),
+        )
+
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`transformers.BertModel`], [`transformers.BertModel.forward`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [transformers.BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
+                "[transformers.BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
+            ),
+        )
+
+    def test_resolve_links_in_text_custom_version_lang(self):
+        page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
+        small_mapping = {
+            "transformers.BertModel": "model_doc/bert.html",
+            "transformers.BertModel.forward": "model_doc/bert.html",
+            "transformers.BertTokenizer": "bert.html",
+        }
+
+        self.maxDiff = None
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`BertModel`], [`BertModel.forward`] and [`BertTokenizer`] as well as [`SomeClass`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
+                "[BertModel.forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward) "
+                "and [BertTokenizer](/docs/transformers/v4.10.0/fr/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
+            ),
+        )
+
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`~transformers.BertModel`], [`~transformers.BertModel.forward`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
+                "[forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward)."
+            ),
+        )
+
+        self.assertEqual(
+            resolve_links_in_text(
+                "Link to [`transformers.BertModel`], [`transformers.BertModel.forward`].",
+                transformers,
+                small_mapping,
+                page_info,
+            ),
+            (
+                "Link to [transformers.BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
+                "[transformers.BertModel.forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward)."
+            ),
+        )

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -15,14 +15,7 @@
 
 import unittest
 
-import transformers
-from doc_builder.build_doc import (
-    _re_autodoc,
-    _re_list_item,
-    generate_frontmatter_in_text,
-    resolve_links_in_text,
-    resolve_open_in_colab,
-)
+from doc_builder.build_doc import _re_autodoc, _re_list_item, generate_frontmatter_in_text, resolve_open_in_colab
 
 
 class BuildDocTester(unittest.TestCase):
@@ -46,104 +39,6 @@ class BuildDocTester(unittest.TestCase):
 ]}} />
 """
         self.assertEqual(resolve_open_in_colab("\n[[open-in-colab]]\n", {"page": "quicktour.html"}), expected)
-
-    def test_resolve_links_in_text(self):
-        page_info = {"package_name": "transformers"}
-        small_mapping = {
-            "transformers.BertModel": "model_doc/bert.html",
-            "transformers.BertModel.forward": "model_doc/bert.html",
-            "transformers.BertTokenizer": "bert.html",
-        }
-
-        self.maxDiff = None
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`BertModel`], [`BertModel.forward`] and [`BertTokenizer`] as well as [`SomeClass`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward) "
-                "and [BertTokenizer](/docs/transformers/master/en/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
-            ),
-        )
-
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`~transformers.BertModel`], [`~transformers.BertModel.forward`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
-            ),
-        )
-
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`transformers.BertModel`], [`transformers.BertModel.forward`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [transformers.BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[transformers.BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
-            ),
-        )
-
-    def test_resolve_links_in_text_custom_version_lang(self):
-        page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
-        small_mapping = {
-            "transformers.BertModel": "model_doc/bert.html",
-            "transformers.BertModel.forward": "model_doc/bert.html",
-            "transformers.BertTokenizer": "bert.html",
-        }
-
-        self.maxDiff = None
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`BertModel`], [`BertModel.forward`] and [`BertTokenizer`] as well as [`SomeClass`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
-                "[BertModel.forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward) "
-                "and [BertTokenizer](/docs/transformers/v4.10.0/fr/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
-            ),
-        )
-
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`~transformers.BertModel`], [`~transformers.BertModel.forward`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
-                "[forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward)."
-            ),
-        )
-
-        self.assertEqual(
-            resolve_links_in_text(
-                "Link to [`transformers.BertModel`], [`transformers.BertModel.forward`].",
-                transformers,
-                small_mapping,
-                page_info,
-            ),
-            (
-                "Link to [transformers.BertModel](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel), "
-                "[transformers.BertModel.forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward)."
-            ),
-        )
 
     def test_generate_frontmatter_in_text(self):
         # test canonical

--- a/tests/test_convert_to_notebook.py
+++ b/tests/test_convert_to_notebook.py
@@ -1,0 +1,143 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from doc_builder.convert_to_notebook import (
+    _re_copyright,
+    _re_header,
+    _re_math_delimiter,
+    _re_python_code,
+    _re_youtube,
+    expand_links,
+    parse_input_output,
+    split_frameworks,
+)
+
+
+class ConvertToNotebookTester(unittest.TestCase):
+    def test_re_math_delimiter(self):
+        self.assertEqual(_re_math_delimiter.search("\\\\(lala\\\\)").groups()[0], "lala")
+        self.assertListEqual(_re_math_delimiter.findall("\\\\(lala\\\\)xx\\\\(loulou\\\\)"), ["lala", "loulou"])
+
+    def test_re_copyright(self):
+        self.assertIsNotNone(
+            _re_copyright.search("<!--Copyright 2021 Hugging Face\n more more more\n--> rest of text")
+        )
+
+    def test_re_youtube(self):
+        self.assertEqual(_re_youtube.search('<Youtube id="tiZFewofSLM"/>').groups()[0], "tiZFewofSLM")
+
+    def test_re_header(self):
+        self.assertIsNotNone(_re_header.search("# Title"))
+        self.assertIsNotNone(_re_header.search("### Subesection"))
+        self.assertIsNone(_re_header.search("Title"))
+
+    def test_re_python(self):
+        self.assertIsNotNone(_re_python_code.search("```py"))
+        self.assertIsNotNone(_re_python_code.search("```python"))
+        self.assertIsNone(_re_python_code.search("```bash"))
+        self.assertIsNone(_re_python_code.search("```"))
+
+    def test_parse_inputs_output(self):
+        expected = "from transformers import pipeline\nclassifier = pipeline('sentiment-analysis')"
+        doctest_lines_no_output = [
+            ">>> from transformers import pipeline",
+            ">>> classifier = pipeline('sentiment-analysis')",
+        ]
+        doctest_lines_with_output = [
+            ">>> from transformers import pipeline",
+            ">>> classifier = pipeline('sentiment-analysis')",
+            "output",
+        ]
+        regular_lines = ["from transformers import pipeline", "classifier = pipeline('sentiment-analysis')"]
+
+        self.assertEqual(parse_input_output(regular_lines), (expected, None))
+        self.assertEqual(parse_input_output(doctest_lines_no_output), (expected, None))
+        self.assertEqual(parse_input_output(doctest_lines_with_output), (expected, "output"))
+
+    def test_split_framewors(self):
+        test_content = """
+Intro
+```py
+common_code_sample
+```
+Content
+```py
+pt_sample
+===PT-TF-SPLIT===
+tf_sample
+```
+End
+"""
+        mixed_content = """
+Intro
+```py
+common_code_sample
+```
+Content
+```py
+pt_sample
+```
+
+```py
+tf_sample
+```
+End
+"""
+        pt_content = """
+Intro
+```py
+common_code_sample
+```
+Content
+```py
+pt_sample
+```
+End
+"""
+        tf_content = """
+Intro
+```py
+common_code_sample
+```
+Content
+```py
+tf_sample
+```
+End
+"""
+        for expected, obtained in zip([mixed_content, pt_content, tf_content], split_frameworks(test_content)):
+            self.assertEqual(expected, obtained)
+
+    def test_expand_links(self):
+        page_info = {"package_name": "transformers", "page": "quicktour.html"}
+        self.assertEqual(
+            expand_links("Checkout the [task summary](task-summary)", page_info),
+            "Checkout the [task summary](https://huggingface.co/docs/transformers/master/en/task-summary)",
+        )
+        self.assertEqual(
+            expand_links("Checkout the [`Trainer`](/docs/transformers/master/en/trainer#Trainer)", page_info),
+            "Checkout the [`Trainer`](https://huggingface.co/docs/transformers/master/en/trainer#Trainer)",
+        )
+
+        page_info = {"package_name": "datasets", "page": "quicktour.html", "version": "stable", "language": "fr"}
+        self.assertEqual(
+            expand_links("Checkout the [task summary](task-summary)", page_info),
+            "Checkout the [task summary](https://huggingface.co/docs/datasetss/stable/fr/task-summary)",
+        )
+
+        page_info = {"package_name": "transformers", "page": "data/quicktour.html"}
+        self.assertEqual(
+            expand_links("Checkout the [task summary](task-summary)", page_info),
+            "Checkout the [task summary](https://huggingface.co/docs/transformers/master/en/data/task-summary)",
+        )

--- a/tests/test_convert_to_notebook.py
+++ b/tests/test_convert_to_notebook.py
@@ -133,7 +133,7 @@ End
         page_info = {"package_name": "datasets", "page": "quicktour.html", "version": "stable", "language": "fr"}
         self.assertEqual(
             expand_links("Checkout the [task summary](task-summary)", page_info),
-            "Checkout the [task summary](https://huggingface.co/docs/datasetss/stable/fr/task-summary)",
+            "Checkout the [task summary](https://huggingface.co/docs/datasets/stable/fr/task-summary)",
         )
 
         page_info = {"package_name": "transformers", "page": "data/quicktour.html"}


### PR DESCRIPTION
This PR adds the ability to convert doc pages to notebook auto-magically, as long as they have the `[[open-in-colab]]` marker: when building the documentation, a `notebook_dir` just has to be provided.

The generated notebooks look exactly like their doc page counterpart with a few exceptions:
- the code samples are parsed in proper code cells, and the doctest syntax is removed to separate inputs and outputs.
- the youtube svelte components are replaced by hidden cells displaying the videos
- all links are treated to point to the doc (links to an object in the package lie [`Trainer`] are of course properly resolved)
- LaTeX special syntax is changed to the usual $ $ 
- PT/TF content is split to generate one Mixed, one PyTorch-only and one TF-only notebook.

To test locally:
```
doc-builder build transformers transformers/docs/source/ --build_dir test-build --notebook_dir notebooks
```
(adapt the path to the Transformers docs source folder if necessary).

Note that notebooks generated need to be trusted before the videos are displayed properly (in colab it should be automatic but when using a jupyter notebook server, click File and Trust).