### PR TITLE
Add framewotkswtich svelte

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -31,6 +31,7 @@ import CodeBlock from "./CodeBlock.svelte";
 import CodeBlockFw from "./CodeBlockFw.svelte";
 import ColabDropdown from "./ColabDropdown.svelte";
 import IconCopyLink from "./IconCopyLink.svelte";
+import FrameworkSwitch from "./FrameworkSwitch.svelte";
 export let fw: "pt" | "tf"
 </script>\n""" + process_md(
         md_text, page_info
@@ -43,7 +44,9 @@ def convert_special_chars(text):
     """
     text = text.replace("{", "&amp;lcub;")
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
-    text = re.sub(r"<(img|br|hr|Youtube)", r"LTHTML\1", text)  # html void elements with no closing counterpart
+    text = re.sub(
+        r"<(img|br|hr|Youtube|FrameworkSwitch)", r"LTHTML\1", text
+    )  # html void elements with no closing counterpart
     _re_lt_html = re.compile(r"<(\S+)([^>]*>)(((?!</\1>).)*)<(/\1>)", re.DOTALL)
     while _re_lt_html.search(text):
         text = _re_lt_html.sub(r"LTHTML\1\2\3LTHTML\5", text)

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -157,7 +157,9 @@ def convert_special_chars(text):
     """
     text = text.replace("{", "&amp;lcub;")
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
-    text = re.sub(r"<(img|br|hr|Youtube)", r"LTHTML\1", text)  # html void elements with no closing counterpart
+    text = re.sub(
+        r"<(img|br|hr|Youtube|FrameworkSwitch)", r"LTHTML\1", text
+    )  # html void elements with no closing counterpart
     _re_lt_html = re.compile(r"<(\S+)([^>]*>)(((?!</\1>).)*)<(/\1>)", re.DOTALL)
     while _re_lt_html.search(text):
         text = _re_lt_html.sub(r"LTHTML\1\2\3LTHTML\5", text)
@@ -579,6 +581,7 @@ def convert_rst_to_mdx(rst_text, page_info, add_imports=True):
             '	import CodeBlockFw from "./CodeBlockFw.svelte";',
             '	import ColabDropdown from "./ColabDropdown.svelte";',
             '	import IconCopyLink from "./IconCopyLink.svelte";',
+            '	import FrameworkSwitch from "./FrameworkSwitch.svelte";',
             "	",
             '	export let fw: "pt" | "tf"',
             "</script>",

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -23,7 +23,7 @@ class ConvertMdToMdxTester(unittest.TestCase):
     def test_convert_md_to_mdx(self):
         page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
         md_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-        expected_conversion = '<script>\nimport Tip from "./Tip.svelte";\nimport Youtube from "./Youtube.svelte";\nimport Docstring from "./Docstring.svelte";\nimport CodeBlock from "./CodeBlock.svelte";\nimport CodeBlockFw from "./CodeBlockFw.svelte";\nimport ColabDropdown from "./ColabDropdown.svelte";\nimport IconCopyLink from "./IconCopyLink.svelte";\nexport let fw: "pt" | "tf"\n</script>\nLorem ipsum dolor sit amet, consectetur adipiscing elit'
+        expected_conversion = '<script>\nimport Tip from "./Tip.svelte";\nimport Youtube from "./Youtube.svelte";\nimport Docstring from "./Docstring.svelte";\nimport CodeBlock from "./CodeBlock.svelte";\nimport CodeBlockFw from "./CodeBlockFw.svelte";\nimport ColabDropdown from "./ColabDropdown.svelte";\nimport IconCopyLink from "./IconCopyLink.svelte";\nimport FrameworkSwitch from "./FrameworkSwitch.svelte";\nexport let fw: "pt" | "tf"\n</script>\nLorem ipsum dolor sit amet, consectetur adipiscing elit'
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)
 
     def test_convert_special_chars(self):
@@ -31,6 +31,7 @@ class ConvertMdToMdxTester(unittest.TestCase):
         self.assertEqual(convert_special_chars("< blo"), "&amp;lt; blo")
         self.assertEqual(convert_special_chars("<source></source>"), "<source></source>")
         self.assertEqual(convert_special_chars("<Youtube id='my_vid' />"), "<Youtube id='my_vid' />")
+        self.assertEqual(convert_special_chars("<FrameworkSwitch />"), "<FrameworkSwitch />")
 
         longer_test = """<script>
 import Tip from "./Tip.svelte";

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -298,6 +298,7 @@ third line``.
         self.assertEqual(convert_special_chars("< blo"), "&amp;lt; blo")
         self.assertEqual(convert_special_chars("<source></source>"), "<source></source>")
         self.assertEqual(convert_special_chars("<Youtube id='my_vid' />"), "<Youtube id='my_vid' />")
+        self.assertEqual(convert_special_chars("<FrameworkSwitch />"), "<FrameworkSwitch />")
 
         longer_test = """<script>
 import Tip from "./Tip.svelte";


### PR DESCRIPTION
Companion pr to https://github.com/huggingface/moon-landing/pull/1641

Adds svelte imports for FrameworkSwitch svelte component

@sgugger when writing FrameWork specific text, you need to do 2 things:
1. Put `<FrameworkSwitch {fw} />` after title, can be before or after  `opne-in-colab`, see [example here](https://github.com/huggingface/doc-builder/blame/demo_fwswitch_colab/build/transformers/master/en/quicktour.mdx#L43-L53)
2. Write framework specific text/content using svelte if else statements, see [example here](https://github.com/huggingface/huggingface-course/blame/402565b43df4ecbd477136e16d35922ab41ad6c5/chapters/chapter2/section3.mdx#L9-L13)
3. Svelte if else condition supports [else-if](https://svelte.dev/tutorial/else-if-blocks), therefore, we are future-proof for flax additions