### PR TITLE
Add custom first cell

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -27,6 +27,7 @@ from .convert_md_to_mdx import convert_md_to_mdx
 from .convert_rst_to_mdx import convert_rst_to_mdx, find_indent, is_empty_line
 from .convert_to_notebook import generate_notebooks_from_file
 from .frontmatter_node import FrontmatterNode
+from .utils import read_doc_config
 
 
 _re_autodoc = re.compile("^\s*\[\[autodoc\]\]\s+(\S+)\s*$")
@@ -331,6 +332,8 @@ def build_doc(package_name, doc_folder, output_dir, clean=True, version="master"
     page_info = {"version": version, "language": language, "package_name": package_name}
     if clean and Path(output_dir).exists():
         shutil.rmtree(output_dir)
+
+    read_doc_config(doc_folder)
 
     package = importlib.import_module(package_name)
     anchors_mapping = build_mdx_files(package, doc_folder, output_dir, page_info)

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -342,6 +342,6 @@ def build_doc(package_name, doc_folder, output_dir, clean=True, version="master"
 
     if notebook_dir is not None:
         if clean and Path(notebook_dir).exists():
-            for nb_file in notebook_dir.glob("**/*.ipynb"):
+            for nb_file in Path(notebook_dir).glob("**/*.ipynb"):
                 os.remove(nb_file)
         build_notebooks(doc_folder, notebook_dir, package=package, mapping=anchors_mapping, page_info=page_info)

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -342,5 +342,6 @@ def build_doc(package_name, doc_folder, output_dir, clean=True, version="master"
 
     if notebook_dir is not None:
         if clean and Path(notebook_dir).exists():
-            shutil.rmtree(notebook_dir)
+            for nb_file in notebook_dir.glob("**/*.ipynb"):
+                os.remove(nb_file)
         build_notebooks(doc_folder, notebook_dir, package=package, mapping=anchors_mapping, page_info=page_info)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -62,7 +62,7 @@ def build_command_parser(subparsers=None):
         "documentation files should be indicated here.",
     )
     parser.add_argument("--build_dir", type=str, help="Where the built documentation will be.", default="./build/")
-    parser.add_argument("--clean", action="store-true", help="Whether or not to clean the output dir before building.")
+    parser.add_argument("--clean", action="store_true", help="Whether or not to clean the output dir before building.")
     parser.add_argument("--language", type=str, help="Language of the documentation to generate", default="en")
     parser.add_argument(
         "--version",

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import nbformat
 
 from .autodoc import resolve_links_in_text
+from .convert_rst_to_mdx import is_empty_line
 from .utils import get_doc_config
 
 
@@ -124,22 +125,36 @@ def parse_input_output(code_lines):
     """
     Parse a code sample written in doctest syntax to extract input code and expected output.
     """
-    has_output = False
-    output = None
-    input_lines = []
-    for idx, line in enumerate(code_lines):
-        if line.startswith(">>> "):
-            has_output = True
-            input_lines.append(line[4:])
-        elif has_output and line.startswith("... "):
-            input_lines.append(line[4:])
-        elif has_output and line[:4] not in [">>> ", "... "]:
-            output = "\n".join(code_lines[idx:])
-            break
-        else:
-            input_lines.append(line)
+    current_lines = []
+    in_input = True
+    cells = []
 
-    return "\n".join(input_lines), output
+    for idx, line in enumerate(code_lines):
+        if is_empty_line(line):
+            current_lines.append(line)
+        elif not in_input and line.startswith(">>> "):
+            in_input = True
+            cells[-1] = (cells[-1][0], "\n".join(current_lines).strip())
+            current_lines = [line[4:]]
+        elif in_input and line[:4] not in [">>> ", "... "]:
+            in_input = False
+            cells.append(("\n".join(current_lines).strip(), None))
+            current_lines = [line]
+        else:
+            if line.startswith(">>> ") or line.startswith("... "):
+                current_lines.append(line[4:])
+            else:
+                current_lines.append(line)
+
+    if in_input:
+        cells.append(("\n".join(current_lines).strip(), None))
+    else:
+        cells[-1] = (cells[-1][0], "\n".join(current_lines).strip())
+
+    if len(cells) == 1 and len(cells[0][0]) == 0:
+        return [(cells[0][1], None)]
+
+    return cells
 
 
 def code_cell(code, output=None):
@@ -235,8 +250,8 @@ def parse_doc_into_cells(content):
                 if len(content) > 0:
                     cells.append(markdown_cell(content))
             elif cell_type == "code" and len(current_lines) > 0:
-                code, output = parse_input_output(current_lines)
-                cells.append(code_cell(code, output=output))
+                for code, output in parse_input_output(current_lines):
+                    cells.append(code_cell(code, output=output))
             current_lines = []
 
         if special_line == "header":

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import nbformat
 
 from .autodoc import resolve_links_in_text
+from .utils import get_doc_config
 
 
 # Re pattern that matches inline math in MDX: \\(formula\\)
@@ -192,6 +193,14 @@ def parse_doc_into_cells(content):
     Split a documentation content into cells.
     """
     cells = []
+    doc_config = get_doc_config()
+    if doc_config is not None:
+        for cell in doc_config.notebook_first_cells:
+            if cell["type"] == "markdown":
+                cells.append(markdown_cell(cell["content"].strip()))
+            elif cell["type"] == "code":
+                cells.append(code_cell(cell["content"].strip()))
+
     current_lines = []
     cell_type = "markdown"
     # We keep track of whether we are in a general code block (not necessarily in a code cell) as a line with a comment
@@ -262,14 +271,7 @@ def create_notebook(cells):
     """
     Create a notebook object with `cells`.
     """
-    return nbformat.notebooknode.NotebookNode(
-        {
-            "cells": cells,
-            "metadata": {},
-            "nbformat": 4,
-            "nbformat_minor": 4,
-        }
-    )
+    return nbformat.notebooknode.NotebookNode({"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 4})
 
 
 def generate_notebooks_from_file(file_name, output_dir, package=None, mapping=None, page_info=None):

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -55,7 +55,7 @@ doc_config = None
 
 def read_doc_config(doc_folder):
     """
-    Execute the `_config.py` file inside the doc source directory and returns it as a Python module.
+    Execute the `_config.py` file inside the doc source directory and executes it as a Python module.
     """
     global doc_config
 
@@ -66,4 +66,7 @@ def read_doc_config(doc_folder):
 
 
 def get_doc_config():
+    """
+    Returns the `doc_config` if it has been loaded.
+    """
     return doc_config

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.machinery
+import importlib.util
+import os
 
 import yaml
 from packaging import version as package_version
@@ -45,3 +48,22 @@ def update_versions_file(build_path, version):
     with open(f"{build_path}/_versions.yml", "w") as versions_file:
         versions_updated = [master_version] + sem_versions
         yaml.dump(versions_updated, versions_file)
+
+
+doc_config = None
+
+
+def read_doc_config(doc_folder):
+    """
+    Execute the `_config.py` file inside the doc source directory and returns it as a Python module.
+    """
+    global doc_config
+
+    loader = importlib.machinery.SourceFileLoader("doc_config", os.path.join(doc_folder, "_config.py"))
+    spec = importlib.util.spec_from_loader("doc_config", loader)
+    doc_config = importlib.util.module_from_spec(spec)
+    loader.exec_module(doc_config)
+
+
+def get_doc_config():
+    return doc_config

--- a/tests/test_convert_to_notebook.py
+++ b/tests/test_convert_to_notebook.py
@@ -49,21 +49,48 @@ class ConvertToNotebookTester(unittest.TestCase):
         self.assertIsNone(_re_python_code.search("```"))
 
     def test_parse_inputs_output(self):
-        expected = "from transformers import pipeline\nclassifier = pipeline('sentiment-analysis')"
+        expected = "from transformers import pipeline\n\nclassifier = pipeline('sentiment-analysis')"
         doctest_lines_no_output = [
             ">>> from transformers import pipeline",
+            "",
             ">>> classifier = pipeline('sentiment-analysis')",
         ]
         doctest_lines_with_output = [
             ">>> from transformers import pipeline",
+            "",
             ">>> classifier = pipeline('sentiment-analysis')",
             "output",
         ]
-        regular_lines = ["from transformers import pipeline", "classifier = pipeline('sentiment-analysis')"]
+        regular_lines = ["from transformers import pipeline", "", "classifier = pipeline('sentiment-analysis')"]
 
-        self.assertEqual(parse_input_output(regular_lines), (expected, None))
-        self.assertEqual(parse_input_output(doctest_lines_no_output), (expected, None))
-        self.assertEqual(parse_input_output(doctest_lines_with_output), (expected, "output"))
+        self.assertListEqual(parse_input_output(regular_lines), [(expected, None)])
+        self.assertListEqual(parse_input_output(doctest_lines_no_output), [(expected, None)])
+        self.assertListEqual(parse_input_output(doctest_lines_with_output), [(expected, "output")])
+
+    def test_parse_inputs_output_multiple_outputs(self):
+        expected_1 = "from transformers import pipeline"
+        expected_2 = "classifier = pipeline('sentiment-analysis')"
+
+        doctest_lines_with_output = [
+            ">>> from transformers import pipeline",
+            "output 1",
+            ">>> classifier = pipeline('sentiment-analysis')",
+            "output 2",
+        ]
+
+        self.assertListEqual(
+            parse_input_output(doctest_lines_with_output), [(expected_1, "output 1"), (expected_2, "output 2")]
+        )
+
+        doctest_lines_with_one_output = [
+            ">>> from transformers import pipeline",
+            "output 1",
+            ">>> classifier = pipeline('sentiment-analysis')",
+        ]
+
+        self.assertListEqual(
+            parse_input_output(doctest_lines_with_one_output), [(expected_1, "output 1"), (expected_2, None)]
+        )
 
     def test_split_framewors(self):
         test_content = """


### PR DESCRIPTION
This PR adds the ability to customize the first cell(s) of auto-generated notebooks. For transformers we want to install `transformers` and `datasets`  but for other packages we will want something different.

I took the approach of using a `_config.py` file (a bit like the old conf.py for Sphinx or the one used in pytest) that would look like this for Transformers (see [this PR](https://github.com/huggingface/transformers/pull/14718)):
```
INSTALL_CONTENT = """
# Transformers installation
! pip install transformers datasets
# To install from source instead of the last release, comment the command above and uncomment the following one.
# ! pip install git+https://github.com/huggingface/transformers.git
"""

notebook_first_cells = [{"type": "code", "content": INSTALL_CONTENT}]
```

And since we might add other customizable things in the future, I made the architecture to get that config as a Python module.