### PR TITLE
Add a check for the ToC

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -370,14 +370,14 @@ def check_all_doc_files_are_in_toc(doc_folder, output_dir):
     if len(files_not_in_toc) > 0:
         message = "\n".join([f"- {f}" for f in files_not_in_toc])
         raise RuntimeError(
-            f"The following files are not present in the table of contents:\n" + message + f"\nAdd them to {toc_file}."
+            "The following files are not present in the table of contents:\n" + message + f"\nAdd them to {toc_file}."
         )
 
     files_not_exist = [f for f in toc_sections if f not in doc_files]
     if len(files_not_exist) > 0:
         message = "\n".join([f"- {f}" for f in files_not_exist])
         raise RuntimeError(
-            f"The following files are present in the table of contents but do not exist:\n"
+            "The following files are present in the table of contents but do not exist:\n"
             + message
             + f"\nRemove them from {toc_file}."
         )

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -372,3 +372,12 @@ def check_all_doc_files_are_in_toc(doc_folder, output_dir):
         raise RuntimeError(
             f"The following files are not present in the table of contents:\n" + message + f"\nAdd them to {toc_file}."
         )
+
+    files_not_exist = [f for f in toc_sections if f not in doc_files]
+    if len(files_not_exist) > 0:
+        message = "\n".join([f"- {f}" for f in files_not_exist])
+        raise RuntimeError(
+            f"The following files are present in the table of contents but do not exist:\n"
+            + message
+            + f"\nRemove them from {toc_file}."
+        )


### PR DESCRIPTION
This PR adds a check for the ToC, specifically that it contains all the doc-generated files. If it does not, the `doc-builder` will now error (like sphinx used to).

As a result this PR shouldn't be merged without its [counterpart](https://github.com/huggingface/transformers/pull/14755) on the Transformers side (which adds missing files in the ToC).