### PR TITLE
Don't error if package has no doc config

### DIFF
--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -59,10 +59,11 @@ def read_doc_config(doc_folder):
     """
     global doc_config
 
-    loader = importlib.machinery.SourceFileLoader("doc_config", os.path.join(doc_folder, "_config.py"))
-    spec = importlib.util.spec_from_loader("doc_config", loader)
-    doc_config = importlib.util.module_from_spec(spec)
-    loader.exec_module(doc_config)
+    if os.path.isfile(os.path.join(doc_folder, "_config.py")):
+        loader = importlib.machinery.SourceFileLoader("doc_config", os.path.join(doc_folder, "_config.py"))
+        spec = importlib.util.spec_from_loader("doc_config", loader)
+        doc_config = importlib.util.module_from_spec(spec)
+        loader.exec_module(doc_config)
 
 
 def get_doc_config():


### PR DESCRIPTION
As seen in Transformers earlier today, the doc building will fail if there is no config file in the doc folder, which shouldn't be the case since users are allowed to not want to customize their doc building.