### PR TITLE
Add docstrings conversion to doc-builder convert

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -42,7 +42,7 @@ def convert_rst_formatting(text):
     # Remove :math: markers.
     text = _re_math.sub(r"\\\\(\1\\\\)", text)
     # Convert content in single backquotes to italic.
-    text = _re_single_backquotes.sub(r"\1_\2_\3", text)
+    text = _re_single_backquotes.sub(r"\1*\2*\3", text)
     # Convert content in double backquotes to single backquotes.
     text = _re_double_backquotes.sub(r"\1`\2`\3", text)
     # Remove remaining ::
@@ -468,7 +468,7 @@ def remove_indent(text):
     return "\n".join(lines)
 
 
-def base_rst_to_mdx(text, page_info):
+def base_rst_to_mdx(text, page_info, unindent=True):
     """
     Convert a text from rst to mdx, with the base operations necessary for both docstrings and rst docs.
     """
@@ -478,7 +478,7 @@ def base_rst_to_mdx(text, page_info):
     # Convert * in lists to - to avoid the formatting conversion treat them as bold.
     text = re.sub(r"^(\s*)\*(\s)", r"\1-\2", text, flags=re.MULTILINE)
     text = convert_rst_formatting(text)
-    return remove_indent(text)
+    return remove_indent(text) if unindent else text
 
 
 def convert_rst_docstring_to_mdx(docstring, page_info):

--- a/tests/test_convert_doc_file.py
+++ b/tests/test_convert_doc_file.py
@@ -12,7 +12,7 @@
 
 import unittest
 
-from doc_builder.commands.convert_doc_file import shorten_internal_refs
+from doc_builder.commands.convert_doc_file import apply_min_indent, shorten_internal_refs
 
 
 class ConvertDocFileTester(unittest.TestCase):
@@ -22,3 +22,6 @@ class ConvertDocFileTester(unittest.TestCase):
             shorten_internal_refs("Look at the [`~transformers.PreTrainedModel.generate`] method."),
             "Look at the [`~PreTrainedModel.generate`] method.",
         )
+
+    def test_apply_min_indent(self):
+        self.assertEqual(apply_min_indent("aaa\n  bb\n\n    ccc\ndd", 4), "    aaa\n    bb\n\n    ccc\n    dd")

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -173,7 +173,7 @@ This text comports a bit of everything: `italics`, *italics*, some ``code``. The
 some references to :obj:`objects`, :class:`~transformers.classes`, :meth:`methods` and :func:`funcs`. Also, we can find
 a :math:`formula`."""
         expected_converted_1 = """
-This text comports a bit of everything: _italics_, *italics*, some `code`. There is some already converted **bold** and
+This text comports a bit of everything: *italics*, *italics*, some `code`. There is some already converted **bold** and
 some references to `objects`, [`~transformers.classes`], [`methods`] and [`funcs`]. Also, we can find
 a \\\\(formula\\\\)."""
         self.assertEqual(convert_rst_formatting(test_text_1), expected_converted_1)


### PR DESCRIPTION
This PR adds a command to convert all the docstrings in a python file to Markdown. It uses the already existing command `doc-builder convert`, which has a different behavior for rst files (convert them to MDX) and py files (convert all the docstrings inside that are written in rst).

You can test this in the Transformers repo by running:
```bash
doc-builder convert src/transformers/models/bert/modeling_bert.py
make style
```
(make style is to re-organize the content with the 119 char limit) and enjoy the diff!