### PR TITLE
Fix parameters parsing when there is a note or warning inside

### DIFF
--- a/src/doc_builder/commands/convert_doc_file.py
+++ b/src/doc_builder/commands/convert_doc_file.py
@@ -19,7 +19,13 @@ import re
 from pathlib import Path
 
 from doc_builder.autodoc import is_rst_docstring, remove_example_tags
-from doc_builder.convert_rst_to_mdx import base_rst_to_mdx, convert_rst_to_mdx, find_indent, is_empty_line
+from doc_builder.convert_rst_to_mdx import (
+    apply_min_indent,
+    base_rst_to_mdx,
+    convert_rst_to_mdx,
+    find_indent,
+    is_empty_line,
+)
 
 
 def find_docstring_indent(docstring):
@@ -29,28 +35,6 @@ def find_docstring_indent(docstring):
     for line in docstring.split("\n"):
         if not is_empty_line(line):
             return find_indent(line)
-
-
-def apply_min_indent(text, min_indent):
-    """
-    Make sure all lines in a text are have a minimum indentation.
-
-    Args:
-        text (`str`): The text to treat.
-        min_indent (`int`): The minimal indentation.
-
-    Returns:
-        `str`: The processed text.
-    """
-    lines = text.split("\n")
-    for idx, line in enumerate(lines):
-        if is_empty_line(line):
-            continue
-        indent = find_indent(line)
-        if indent < min_indent:
-            lines[idx] = " " * (min_indent - indent) + line
-
-    return "\n".join(lines)
 
 
 def find_root_git(folder):

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -184,6 +184,28 @@ def parse_options(block_content):
     return result
 
 
+def apply_min_indent(text, min_indent):
+    """
+    Make sure all lines in a text are have a minimum indentation.
+
+    Args:
+        text (`str`): The text to treat.
+        min_indent (`int`): The minimal indentation.
+
+    Returns:
+        `str`: The processed text.
+    """
+    lines = text.split("\n")
+    for idx, line in enumerate(lines):
+        if is_empty_line(line):
+            continue
+        indent = find_indent(line)
+        if indent < min_indent:
+            lines[idx] = " " * (min_indent - indent) + line
+
+    return "\n".join(lines)
+
+
 def convert_rst_blocks(text, page_info):
     """
     Converts rst special blocks (examples, notes) into MDX.
@@ -239,9 +261,11 @@ def convert_rst_blocks(text, page_info):
                 prefix = f"<example>```{block_info}"
                 new_lines.append(f"{prefix}\n{block_content.strip()}\n```\n</example>")
             elif block_type == "note":
-                new_lines.append(f"<Tip>\n\n{block_content.strip()}\n\n</Tip>\n")
+                new_lines.append(apply_min_indent(f"<Tip>\n\n{block_content.strip()}\n\n</Tip>\n", block_indent))
             elif block_type == "warning":
-                new_lines.append("<Tip warning={true}>\n\n" + f"{block_content.strip()}\n\n</Tip>\n")
+                new_lines.append(
+                    apply_min_indent("<Tip warning={true}>\n\n" + f"{block_content.strip()}\n\n</Tip>\n", block_indent)
+                )
             elif block_type == "raw":
                 new_lines.append(block_content.strip() + "\n")
             elif block_type == "math":

--- a/tests/test_convert_doc_file.py
+++ b/tests/test_convert_doc_file.py
@@ -12,7 +12,7 @@
 
 import unittest
 
-from doc_builder.commands.convert_doc_file import apply_min_indent, shorten_internal_refs
+from doc_builder.commands.convert_doc_file import shorten_internal_refs
 
 
 class ConvertDocFileTester(unittest.TestCase):
@@ -22,6 +22,3 @@ class ConvertDocFileTester(unittest.TestCase):
             shorten_internal_refs("Look at the [`~transformers.PreTrainedModel.generate`] method."),
             "Look at the [`~PreTrainedModel.generate`] method.",
         )
-
-    def test_apply_min_indent(self):
-        self.assertEqual(apply_min_indent("aaa\n  bb\n\n    ccc\ndd", 4), "    aaa\n    bb\n\n    ccc\n    dd")

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -38,6 +38,7 @@ from doc_builder.convert_rst_to_mdx import (
     _re_simple_doc,
     _re_simple_ref,
     _re_single_backquotes,
+    apply_min_indent,
     convert_rst_blocks,
     convert_rst_formatting,
     convert_rst_links,
@@ -426,6 +427,27 @@ $$formula$$
 
         self.assertEqual(convert_rst_blocks(original_rst, page_info), expected_conversion)
 
+        rst_with_indent = """
+    This is inside a docstring, so we have some indent.
+
+    .. note::
+        There is a note in the middle.
+
+    We should keep the indent for the note.
+"""
+        expected_conversion = """
+    This is inside a docstring, so we have some indent.
+
+    <Tip>
+
+    There is a note in the middle.
+
+    </Tip>
+
+    We should keep the indent for the note.
+"""
+        self.assertEqual(convert_rst_blocks(rst_with_indent, page_info), expected_conversion)
+
     def test_split_return_line(self):
         self.assertEqual(
             split_return_line("A :obj:`str` or a :obj:`bool`: the result"),
@@ -602,3 +624,6 @@ bli
 """
 
         self.assertEqual(split_pt_tf_code_blocks(content), expected)
+
+    def test_apply_min_indent(self):
+        self.assertEqual(apply_min_indent("aaa\n  bb\n\n    ccc\ndd", 4), "    aaa\n    bb\n\n    ccc\n    dd")


### PR DESCRIPTION
This fixes a current bug where the parameters description is not properly parsed if a parameters as a note or a warning inside its description. The problem comes from the fact we remove indentation there, so this PR retains it so we don't leave the parameter block.

For regular rst files, the conversion remove all needless indentation later on, so this is safe to do.