### PR TITLE
Docstring MD to MDX conversion fixes

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -159,6 +159,9 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
                 match = _match
         return object_doc, match
 
+    if anchor == "transformers.BertForPreTraining.forward":
+        print(object_doc)
+
     object_doc = _re_returns.sub(lambda m: inside_example_finder_closure(m, "returns"), object_doc)
     object_doc = _re_parameters.sub(lambda m: inside_example_finder_closure(m, "parameters"), object_doc)
 
@@ -258,10 +261,15 @@ def document_object(object_name, package, page_info, full_name=True):
     signature = format_signature(obj)
     if getattr(obj, "__doc__", None) is not None and len(obj.__doc__) > 0:
         object_doc = obj.__doc__
+        if anchor_name == "transformers.BertForPreTraining.forward":
+            print(object_doc)
         if is_rst_docstring(object_doc):
             object_doc = convert_rst_docstring_to_mdx(obj.__doc__, page_info)
         else:
             object_doc = convert_md_docstring_to_mdx(obj.__doc__, page_info)
+        
+        if anchor_name == "transformers.BertForPreTraining.forward":
+            print(object_doc)
         source_link = get_source_link(obj, page_info)
         component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
         documentation += "\n" + component + "\n"

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -159,9 +159,6 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
                 match = _match
         return object_doc, match
 
-    if anchor == "transformers.BertForPreTraining.forward":
-        print(object_doc)
-
     object_doc = _re_returns.sub(lambda m: inside_example_finder_closure(m, "returns"), object_doc)
     object_doc = _re_parameters.sub(lambda m: inside_example_finder_closure(m, "parameters"), object_doc)
 
@@ -261,15 +258,11 @@ def document_object(object_name, package, page_info, full_name=True):
     signature = format_signature(obj)
     if getattr(obj, "__doc__", None) is not None and len(obj.__doc__) > 0:
         object_doc = obj.__doc__
-        if anchor_name == "transformers.BertForPreTraining.forward":
-            print(object_doc)
         if is_rst_docstring(object_doc):
             object_doc = convert_rst_docstring_to_mdx(obj.__doc__, page_info)
         else:
             object_doc = convert_md_docstring_to_mdx(obj.__doc__, page_info)
-        
-        if anchor_name == "transformers.BertForPreTraining.forward":
-            print(object_doc)
+
         source_link = get_source_link(obj, page_info)
         component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
         documentation += "\n" + component + "\n"

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -16,7 +16,7 @@
 
 import re
 
-from .convert_rst_to_mdx import parse_rst_docstring
+from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
 
 
 def convert_md_to_mdx(md_text, page_info):
@@ -73,6 +73,7 @@ def convert_md_docstring_to_mdx(docstring, page_info):
     Convert a docstring written in Markdown to mdx.
     """
     text = parse_rst_docstring(docstring)
+    text = remove_indent(text)
     return process_md(text, page_info)
 
 


### PR DESCRIPTION
This PR fixes a little bit the conversion MD to MDX by removing the indent (that stays for all the arguments otherwise). It's all whitespace, so not sure it has a real impact on moon-landing, but it removes the diff I get when converting docstrings of the models from rst to MarkDown.