### PR TITLE
Dev build should not update _versions.yml file

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -46,7 +46,7 @@ def build_command(args):
         notebook_dir=args.notebook_dir,
     )
 
-    # dev build should not uodate _versions.yml
+    # dev build should not update _versions.yml
     package_doc_path = os.path.join(args.build_dir, args.library_name)
     if "dev" not in version and os.path.isfile(os.path.join(package_doc_path, "_versions.yml")):
         update_versions_file(os.path.join(args.build_dir, args.library_name), version)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -46,8 +46,9 @@ def build_command(args):
         notebook_dir=args.notebook_dir,
     )
 
+    # dev build should not uodate _versions.yml
     package_doc_path = os.path.join(args.build_dir, args.library_name)
-    if os.path.isfile(os.path.join(package_doc_path, "_versions.yml")):
+    if "dev" not in version and os.path.isfile(os.path.join(package_doc_path, "_versions.yml")):
         update_versions_file(os.path.join(args.build_dir, args.library_name), version)
 
 

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -48,7 +48,7 @@ def build_command(args):
 
     # dev build should not update _versions.yml
     package_doc_path = os.path.join(args.build_dir, args.library_name)
-    if "dev" not in version and os.path.isfile(os.path.join(package_doc_path, "_versions.yml")):
+    if "pr_" not in version and os.path.isfile(os.path.join(package_doc_path, "_versions.yml")):
         update_versions_file(os.path.join(args.build_dir, args.library_name), version)
 
 


### PR DESCRIPTION
Dev build should not update _versions.yml file

Reusing this bool/flag https://github.com/huggingface/doc-builder/blob/0e9fffb822ef46edc5aa10c0f44baa6193e41732/src/doc_builder/commands/build.py#L29

We can add other agument like `if arg PR_number exists` wdyt