### PR TITLE
Group parameter blocks into one

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -358,6 +358,9 @@ class InvalidRstDocstringError(ValueError):
     pass
 
 
+_re_parameters = re.compile(r"<parameters>(((?!<parameters>).)*)</parameters>", re.DOTALL)
+
+
 def parse_rst_docstring(docstring):
     """
     Parses a docstring written in rst, in particular the list of arguments and the return type.
@@ -416,7 +419,17 @@ def parse_rst_docstring(docstring):
         else:
             idx += 1
 
-    return "\n".join(lines)
+    result = "\n".join(lines)
+
+    # combine multiple <parameters> blocks into one block
+    if result.count("<parameters>") > 1:
+        parameters_blocks = _re_parameters.findall(result)
+        parameters_blocks = [pb[0].strip() for pb in parameters_blocks]
+        parameters_str = '\n'.join(parameters_blocks)
+        result = _re_parameters.sub("", result)
+        result +=  f'\n<parameters>{parameters_str}</parameters>\n'
+
+    return result
 
 
 _re_list = re.compile("^\s*(-|\*|\d+\.)\s")

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -425,9 +425,9 @@ def parse_rst_docstring(docstring):
     if result.count("<parameters>") > 1:
         parameters_blocks = _re_parameters.findall(result)
         parameters_blocks = [pb[0].strip() for pb in parameters_blocks]
-        parameters_str = '\n'.join(parameters_blocks)
+        parameters_str = "\n".join(parameters_blocks)
         result = _re_parameters.sub("", result)
-        result +=  f'\n<parameters>{parameters_str}</parameters>\n'
+        result += f"\n<parameters>{parameters_str}</parameters>\n"
 
     return result
 

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -516,6 +516,31 @@ End of the arg section.
 """
         self.assertEqual(parse_rst_docstring(rst_docstring), expected_conversion)
 
+        # test multiple parameter blocks
+        rst_docstring = """Args:
+    a (:obj:`str` or :obj:`bool`): some parameter
+    b (:obj:`str` or :obj:`bool`):
+        Another parameter with the description below
+
+Parameters:
+    a (:obj:`str` or :obj:`bool`): some parameter
+    b (:obj:`str` or :obj:`bool`):
+        Another parameter with the description below
+"""
+        expected_conversion = """
+
+
+
+<parameters>- **a** (:obj:`str` or :obj:`bool`) -- some parameter
+- **b** (:obj:`str` or :obj:`bool`) --
+        Another parameter with the description below
+- **a** (:obj:`str` or :obj:`bool`) -- some parameter
+- **b** (:obj:`str` or :obj:`bool`) --
+        Another parameter with the description below</parameters>
+"""
+        self.assertEqual(parse_rst_docstring(rst_docstring), expected_conversion)
+
+
     def test_remove_indent(self):
         example1 = """
     Lala

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -540,7 +540,6 @@ Parameters:
 """
         self.assertEqual(parse_rst_docstring(rst_docstring), expected_conversion)
 
-
     def test_remove_indent(self):
         example1 = """
     Lala


### PR DESCRIPTION
Problem: some docstrings can produce multiple `parameters` blocks like[ RealmScorer here](https://github.com/huggingface/transformers/blob/22454ae492eca4bb749fa6d770dffc91d17dab87/src/transformers/models/realm/modeling_realm.py#L1222-L1226), which was producing something that looks like:
```
docstring

Args:
    ....
Parameters:
    ....

end
```
, which was causing the problem on the parsing side since only one param block is expected.

This PR solves this issue by combining multiple parameters blocks into one block if there are multiple parameter blocks.

```
Args:                                                Args:
    ....                                   --->           param1 --
Parameters:                                               param2 --
    ....                                                     ....
```