### PR TITLE
Only add version if it's not there already

### DIFF
--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -38,7 +38,10 @@ def update_versions_file(build_path, version):
         new_version = {"version": version}
         did_insert = False
         for i, value in enumerate(sem_versions):
-            if package_version.parse(new_version["version"]) > package_version.parse(value["version"]):
+            if package_version.parse(new_version["version"]) == package_version.parse(value["version"]):
+                # Nothing to do, the version is here already.
+                return
+            elif package_version.parse(new_version["version"]) > package_version.parse(value["version"]):
                 sem_versions.insert(i, new_version)
                 did_insert = True
                 break


### PR DESCRIPTION
This makes sure the version is not added to `_versions.yml` if it's already there, to avoid duplicates (like in [this commit](https://github.com/huggingface/doc-build/commit/f3c1b81c9967d09cf0f1c56c80977aca2bb8ece0)).