### PR TITLE
Repalce `ColabDropdown` with `DocNotebookDropdown`

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -55,7 +55,7 @@ def resolve_open_in_colab(content, page_info):
     }
     formatted_links = ['    {label: "' + key + '", value: "' + value + '"},' for key, value in links.items()]
 
-    svelte_component = """<ColabDropdown hydrate-props={{
+    svelte_component = """<DocNotebookDropdown hydrate-props={{
   classNames: "absolute z-10 right-0 top-0",
   options:[
 """

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -29,7 +29,7 @@ import Youtube from "./Youtube.svelte";
 import Docstring from "./Docstring.svelte";
 import CodeBlock from "./CodeBlock.svelte";
 import CodeBlockFw from "./CodeBlockFw.svelte";
-import ColabDropdown from "./ColabDropdown.svelte";
+import DocNotebookDropdown from "./DocNotebookDropdown.svelte";
 import IconCopyLink from "./IconCopyLink.svelte";
 export let fw: "pt" | "tf"
 </script>\n""" + process_md(

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -624,7 +624,7 @@ def convert_rst_to_mdx(rst_text, page_info, add_imports=True):
             '	import Docstring from "./Docstring.svelte";',
             '	import CodeBlock from "./CodeBlock.svelte";',
             '	import CodeBlockFw from "./CodeBlockFw.svelte";',
-            '	import ColabDropdown from "./ColabDropdown.svelte";',
+            '	import DocNotebookDropdown from "./DocNotebookDropdown.svelte";',
             '	import IconCopyLink from "./IconCopyLink.svelte";',
             "	",
             '	export let fw: "pt" | "tf"',

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -30,7 +30,7 @@ class BuildDocTester(unittest.TestCase):
 
     def test_resolve_open_in_colab(self):
         expected = """
-<ColabDropdown hydrate-props={{
+<DocNotebookDropdown hydrate-props={{
   classNames: "absolute z-10 right-0 top-0",
   options:[
     {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/quicktour.ipynb"},

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -23,7 +23,7 @@ class ConvertMdToMdxTester(unittest.TestCase):
     def test_convert_md_to_mdx(self):
         page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
         md_text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-        expected_conversion = '<script>\nimport Tip from "./Tip.svelte";\nimport Youtube from "./Youtube.svelte";\nimport Docstring from "./Docstring.svelte";\nimport CodeBlock from "./CodeBlock.svelte";\nimport CodeBlockFw from "./CodeBlockFw.svelte";\nimport ColabDropdown from "./ColabDropdown.svelte";\nimport IconCopyLink from "./IconCopyLink.svelte";\nexport let fw: "pt" | "tf"\n</script>\nLorem ipsum dolor sit amet, consectetur adipiscing elit'
+        expected_conversion = '<script>\nimport Tip from "./Tip.svelte";\nimport Youtube from "./Youtube.svelte";\nimport Docstring from "./Docstring.svelte";\nimport CodeBlock from "./CodeBlock.svelte";\nimport CodeBlockFw from "./CodeBlockFw.svelte";\nimport DocNotebookDropdown from "./DocNotebookDropdown.svelte";\nimport IconCopyLink from "./IconCopyLink.svelte";\nexport let fw: "pt" | "tf"\n</script>\nLorem ipsum dolor sit amet, consectetur adipiscing elit'
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)
 
     def test_convert_special_chars(self):


### PR DESCRIPTION
As we discussed, adding aws studio lab option to notebooks dropdown.

Old syntax:
```
<ColabDropdown hydrate-props={{
  classNames: "absolute z-10 right-0 top-0",
  options:[
    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/training.ipynb"},
    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/training.ipynb"},
    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/training.ipynb"},
]}} />
```

New syntax:
```
<DocNotebookDropdown hydrate-props={{
  classNames: "absolute z-10 right-0 top-0",
  options:[
    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/training.ipynb"},
    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/training.ipynb"},
    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/training.ipynb"},
    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/training.ipynb"},
    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/training.ipynb"},
    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/training.ipynb"},
]}} />
```

Specifically, the changes are:
1. Replace `ColabDropdown` with `DocNotebookDropdown`
2. Add mote entires to the `options` attribute array where `value` contains `studiolab.sagemaker.aws` urls

Note: to be merged after https://github.com/huggingface/moon-landing/pull/2003 gets merged & deployed