### PR TITLE
Ignore property in docstrings

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -248,6 +248,11 @@ def document_object(object_name, package, page_info, full_name=True):
             f"Unable to find {object_name} in {package.__name__}. Make sure the path to that object is correct."
         )
 
+    # TODO: handle class properties in docstring
+    # being ignored currently
+    if isinstance(obj, property):
+        return "", None
+
     anchor_name = get_shortest_path(obj, package)
     if full_name and anchor_name is not None:
         name = anchor_name


### PR DESCRIPTION
Currently, ignoring if a method is @property method. Will need to handle it in a separate repo since we cannot use `inspect` on `property` type 
[internal discussion](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1644339518387909)