### PR TITLE
Catch raises section in docstring

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -120,6 +120,8 @@ _re_returns = re.compile(r"<returns>(.*)</returns>", re.DOTALL)
 _re_returntype = re.compile(r"<returntype>(.*)</returntype>", re.DOTALL)
 _re_example_tags = re.compile(r"(<exampletitle>|<example>)")
 _re_parameter_group = re.compile(r"^> (.*)$", re.MULTILINE)
+_re_raises = re.compile(r"<raises>(.*)</raises>", re.DOTALL)
+_re_raisederrors = re.compile(r"<raisederrors>(.*)</raisederrors>", re.DOTALL)
 
 
 def get_signature_component(name, anchor, signature, object_doc, source_link):
@@ -165,6 +167,8 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
     object_doc, parameters = regex_closure(object_doc, _re_parameters)
     object_doc, return_description = regex_closure(object_doc, _re_returns)
     object_doc, returntype = regex_closure(object_doc, _re_returntype)
+    object_doc, raise_description = regex_closure(object_doc, _re_raises)
+    object_doc, raisederrors = regex_closure(object_doc, _re_raisederrors)
 
     svelte_str = "<docstring>"
     svelte_str += f"<name>{name}</name>"
@@ -191,6 +195,12 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
         svelte_str += f"<rettype>{returntype}</rettype>"
     if return_description is not None:
         svelte_str += f"<retdesc>{return_description}</retdesc>"
+
+    if raise_description is not None:
+        svelte_str += f"<raises>{raise_description}</raises>"
+    if raisederrors is not None:
+        svelte_str += f"<raisederrors>{raisederrors}</raisederrors>"
+
     svelte_str += "</docstring>"
 
     return svelte_str + f"\n{object_doc}\n"

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -440,9 +440,10 @@ def parse_rst_docstring(docstring):
             # The line may contain the return type.
             return_type, lines[idx] = split_return_line(lines[idx])
             idx += 1
-            while idx < len(lines) and_re_raises.search(lines[idx]) is None and (
-                is_empty_line(lines[idx])
-                or find_indent(lines[idx]) >= return_indent
+            while (
+                idx < len(lines)
+                and _re_raises.search(lines[idx]) is None
+                and (is_empty_line(lines[idx]) or find_indent(lines[idx]) >= return_indent)
             ):
                 idx += 1
             lines.insert(idx, "</returns>\n")

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -382,7 +382,10 @@ def parse_rst_docstring(docstring):
             # Returns or Raises block.
             param_indent = find_indent(lines[idx])
             while (
-                idx < len(lines) and find_indent(lines[idx]) == param_indent and _re_returns.search(lines[idx]) is None
+                idx < len(lines)
+                and find_indent(lines[idx]) == param_indent
+                and _re_returns.search(lines[idx]) is None
+                and _re_raises.search(lines[idx]) is None
             ):
                 intro, doc = split_arg_line(lines[idx])
                 # Line starting with a > after indent indicate a "section title" in the parameters.
@@ -437,7 +440,11 @@ def parse_rst_docstring(docstring):
             # The line may contain the return type.
             return_type, lines[idx] = split_return_line(lines[idx])
             idx += 1
-            while idx < len(lines) and (is_empty_line(lines[idx]) or find_indent(lines[idx]) >= return_indent):
+            while idx < len(lines) and (
+                is_empty_line(lines[idx])
+                or find_indent(lines[idx]) >= return_indent
+                or _re_raises.search(lines[idx]) is not None
+            ):
                 idx += 1
             lines.insert(idx, "</returns>\n")
             idx += 1

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -326,6 +326,8 @@ def convert_rst_blocks(text, page_info):
 _re_args = re.compile("^\s*(Args?|Arguments?|Params?|Parameters?):\s*$")
 # Re pattern that catches return blocks of the form `Return:`.
 _re_returns = re.compile("^\s*Returns?:\s*$")
+# Re pattern that catches return blocks of the form `Raises:`.
+_re_raises = re.compile("^\s*Raises?:\s*$")
 
 
 def split_return_line(line):
@@ -377,7 +379,7 @@ def parse_rst_docstring(docstring):
             while is_empty_line(lines[idx]):
                 idx += 1
             # Grab the indent of the list of parameters, this block will stop when we unindent under it or we see the
-            # Returns block.
+            # Returns or Raises block.
             param_indent = find_indent(lines[idx])
             while (
                 idx < len(lines) and find_indent(lines[idx]) == param_indent and _re_returns.search(lines[idx]) is None
@@ -392,6 +394,34 @@ def parse_rst_docstring(docstring):
                 while idx < len(lines) and (is_empty_line(lines[idx]) or find_indent(lines[idx]) > param_indent):
                     idx += 1
             lines.insert(idx, "</parameters>\n")
+            idx += 1
+
+        # Raises section
+        elif _re_raises.search(lines[idx]) is not None:
+            # Title of the section.
+            lines[idx] = "<raises>\n"
+            # Raised errors (e.g. ValueError, TypeError, etc.)
+            raised_errors = []
+            # Find the next nonempty line
+            idx += 1
+            while is_empty_line(lines[idx]):
+                idx += 1
+            # Grab the indent of the list of raises, this block will stop when we unindent under it or we see the
+            # Returns block.
+            raise_indent = find_indent(lines[idx])
+            while (
+                idx < len(lines) and find_indent(lines[idx]) == raise_indent and _re_returns.search(lines[idx]) is None
+            ):
+                intro, doc = split_arg_line(lines[idx])
+                intro = re.sub(r"^\s*`?([\w\.]*)`?$", r"`\1`", intro)
+                lines[idx] = "- " + intro + " --" + doc
+                raised_errors.append(intro)
+                idx += 1
+                while idx < len(lines) and (is_empty_line(lines[idx]) or find_indent(lines[idx]) > raise_indent):
+                    idx += 1
+            lines.insert(idx, "</raises>\n")
+            idx += 1
+            lines.insert(idx, f'<raisederrors>{" or ".join(raised_errors)}</raisederrors>\n')
             idx += 1
 
         # Returns section

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -440,10 +440,9 @@ def parse_rst_docstring(docstring):
             # The line may contain the return type.
             return_type, lines[idx] = split_return_line(lines[idx])
             idx += 1
-            while idx < len(lines) and (
+            while idx < len(lines) and_re_raises.search(lines[idx]) is None and (
                 is_empty_line(lines[idx])
                 or find_indent(lines[idx]) >= return_indent
-                or _re_raises.search(lines[idx]) is not None
             ):
                 idx += 1
             lines.insert(idx, "</returns>\n")

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -66,7 +66,12 @@ List of [input IDs](../glossary.html#input-ids) with the appropriate special tok
 
 </returns>
 
-<returntype>            `List[int]`</returntype>"""
+<returntype>            `List[int]`</returntype>
+<raises>
+- `ValuError` -- this value error will be raised on wrong input type.
+</raises>
+<raisederrors>`ValuError`</raisederrors>
+"""
 
 TEST_DOCSTRING_WITH_EXAMPLE = """Constructs a BERTweet tokenizer, using Byte-Pair-Encoding.
 
@@ -195,7 +200,7 @@ class AutodocTester(unittest.TestCase):
         ]
         object_doc = TEST_DOCSTRING
         source_link = "test_link"
-        expected_signature_component = '<docstring><name>class transformers.BertweetTokenizer</name><anchor>transformers.BertweetTokenizer</anchor><source>test_link</source><parameters>[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'&amp;lt;s>\'"}]</parameters><paramsdesc>- **vocab_file** (`str`) --\n  Path to the vocabulary file.\n- **merges_file** (`str`) --\n  Path to the merges file.\n- **normalization** (`bool`, _optional_, defaults to `False`) --\n  Whether or not to apply a normalization preprocess.\n\n<Tip>\n\nWhen building a sequence using special tokens, this is not the token that is used for the beginning of\nsequence. The token used is the `cls_token`.\n\n</Tip></paramsdesc><paramgroups>0</paramgroups><rettype>`List[int]`</rettype><retdesc>List of [input IDs](../glossary.html#input-ids) with the appropriate special tokens.</retdesc></docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n\n\n\n\n'
+        expected_signature_component = '<docstring><name>class transformers.BertweetTokenizer</name><anchor>transformers.BertweetTokenizer</anchor><source>test_link</source><parameters>[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'&amp;lt;s>\'"}]</parameters><paramsdesc>- **vocab_file** (`str`) --\n  Path to the vocabulary file.\n- **merges_file** (`str`) --\n  Path to the merges file.\n- **normalization** (`bool`, _optional_, defaults to `False`) --\n  Whether or not to apply a normalization preprocess.\n\n<Tip>\n\nWhen building a sequence using special tokens, this is not the token that is used for the beginning of\nsequence. The token used is the `cls_token`.\n\n</Tip></paramsdesc><paramgroups>0</paramgroups><rettype>`List[int]`</rettype><retdesc>List of [input IDs](../glossary.html#input-ids) with the appropriate special tokens.</retdesc><raises>- `ValuError` -- this value error will be raised on wrong input type.</raises><raisederrors>`ValuError`</raisederrors></docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n\n\n\n\n\n\n\n'
         self.assertEqual(
             get_signature_component(name, anchor, signature, object_doc, source_link), expected_signature_component
         )

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -480,6 +480,12 @@ Args:
     b (:obj:`str` or :obj:`bool`):
         Another parameter with the description below
 
+Raises:
+    `pa.ArrowInvalidError`: if the arrow data casting fails
+    TypeError: if the target type is not supported according, e.g.
+        - point1
+        - point2
+
 Returns:
     :obj:`str` or :obj:`bool`: some result
 
@@ -499,6 +505,17 @@ docstring
         Another parameter with the description below
 
 </parameters>
+
+<raises>
+
+- `pa.ArrowInvalidError` -- if the arrow data casting fails
+- `TypeError` -- if the target type is not supported according, e.g.
+        - point1
+        - point2
+
+</raises>
+
+<raisederrors>`pa.ArrowInvalidError` or `TypeError`</raisederrors>
 
 <returns>
 


### PR DESCRIPTION
Unlike transformers docs, datasets docs has a lot of using `raises` section in docstring. Therefore, this PR implements catching raises sections in docstrings