### PR TITLE
Convert numpy doc style to groups doc style

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-install_requires = ["tqdm", "pyyaml", "packaging", "nbformat"]
+install_requires = ["tqdm", "pyyaml", "packaging", "nbformat", "numpydoc"]
 
 extras = {}
 

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -20,6 +20,7 @@ import re
 
 from .convert_md_to_mdx import convert_md_docstring_to_mdx
 from .convert_rst_to_mdx import convert_rst_docstring_to_mdx, find_indent, is_empty_line
+from .utils import convert_numpydoc_to_groupsdoc
 
 
 def find_object_in_package(object_name, package):
@@ -221,6 +222,17 @@ def is_rst_docstring(docstring):
     return False
 
 
+# Re pattern to numpystyle docstring (e.g Parameter -------).
+_re_numpydocstring = re.compile(r"(Parameter|Raise|Return)s?\n\s*----+\n")
+
+
+def is_numpy_docstring(docstring):
+    """
+    Returns `True` if `docstring` is written in numpystyle.
+    """
+    return _re_numpydocstring.search(docstring)
+
+
 def get_source_link(obj, page_info):
     """
     Returns the link to the source code of an object on GitHub.
@@ -270,6 +282,8 @@ def document_object(object_name, package, page_info, full_name=True):
     check = None
     if getattr(obj, "__doc__", None) is not None and len(obj.__doc__) > 0:
         object_doc = obj.__doc__
+        if is_numpy_docstring(object_doc):
+            object_doc = convert_numpydoc_to_groupsdoc(object_doc)
         if is_rst_docstring(object_doc):
             object_doc = convert_rst_docstring_to_mdx(obj.__doc__, page_info)
         else:

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -16,8 +16,10 @@
 import importlib.machinery
 import importlib.util
 import os
+import re
 
 import yaml
+from numpydoc.docscrape import NumpyDocString
 from packaging import version as package_version
 
 
@@ -74,3 +76,76 @@ def get_doc_config():
     Returns the `doc_config` if it has been loaded.
     """
     return doc_config
+
+
+def convert_parametype_numpydoc_to_groupsdoc(paramtype):
+    """
+    Converts parameter type str that is written in numpystyle to groupsstyle (e.g. transformers docs).
+
+    Args:
+    - **paramtype** (`str`) -- The name of the object to document.
+
+    Example::
+
+        >>> s = "bool, optional, default True"
+        >>> convert_numpydoc_to_rstdoc(s)
+        '`bool`, `optional`, defults to `True`'
+    """
+    paramtype = re.sub(r"\s*\(.*\)$", "", paramtype).replace("default", "defults to")
+    arr = paramtype.split(", ")
+    for i, s in enumerate(arr):
+        s = s.split(" ")
+        s[-1] = f"`{s[-1]}`"
+        arr[i] = " ".join(s)
+    return ", ".join(arr)
+
+
+def convert_numpydoc_to_groupsdoc(docstring):
+    """
+    Converts docstring that is written in numpystyle to groupsstyle (e.g. transformers docs).
+
+    Args:
+    - **docstring** (`str`) -- Docstring that is written in numpystyle.
+    """
+    numydoc = NumpyDocString(docstring)
+
+    def helper(arr):
+        """
+        Helper function that joins array into space-separated string.
+        """
+        arr = [a.strip() for a in arr if a.strip()]
+        if arr:
+            return " ".join(arr) + "\n"
+        return ""
+
+    indent = "    "
+    result = ""
+    result += helper(numydoc["Summary"])
+    if numydoc["Parameters"]:
+        result += "\nArgs:\n"
+        for parameter in numydoc["Parameters"]:
+            result += indent + parameter[0]
+            if parameter[1]:
+                result += f" ({convert_parametype_numpydoc_to_groupsdoc(parameter[1])})"
+            result += ":\n"
+            if parameter[2]:
+                result += indent * 2 + helper(parameter[2])
+    if numydoc["Returns"]:
+        result += "\nReturns:\n"
+        for parameter in numydoc["Returns"]:
+            returnttype = f":obj:'{parameter[1]}'" if parameter[1] else ""
+            result += indent + ": ".join(s for s in [returnttype, helper(parameter[2])] if s)
+    if numydoc["Raises"]:
+        result += "\nRaises:\n"
+        for parameter in numydoc["Raises"]:
+            raiseerror = f"{parameter[1]}" if parameter[1] else ""
+            result += indent + ": ".join(s for s in [raiseerror, helper(parameter[2])] if s)
+    if numydoc["Examples"]:
+        result += "\nExample::\n"
+        first_line = numydoc["Examples"][0]
+        indent_n = len(first_line) - len(first_line.lstrip())
+        examples = [indent + line[indent_n:] for line in numydoc["Examples"]]
+        examples_str = "\n".join(examples)
+        result += examples_str
+
+    return result

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -102,7 +102,7 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
         elif "defaults" in s:
             # parameter default value
             valtype = type(eval(s[-1]))
-            non_obj_types = [str, int, float]
+            non_obj_types = [int, float]
             s[-1] = s[-1] if valtype in non_obj_types else f":obj:`{s[-1]}`"
         else:
             # parameter type

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -96,7 +96,17 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     arr = paramtype.split(", ")
     for i, s in enumerate(arr):
         s = s.split(" ")
-        s[-1] = f"`{s[-1]}`"
+        if "optional" in s[-1]:
+            # parameter is optional or not
+            s[-1] = f"`{s[-1]}`"
+        elif "defaults" in s:
+            # parameter default value
+            valtype = type(eval(s[-1]))
+            non_obj_types = [str, int, float]
+            s[-1] = s[-1] if valtype in non_obj_types else f":obj:`{s[-1]}`"
+        else:
+            # parameter type
+            s[-1] = f":obj:`{s[-1]}`"
         arr[i] = " ".join(s)
     return ", ".join(arr)
 

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -85,11 +85,12 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     Args:
     - **paramtype** (`str`) -- The name of the object to document.
 
-    Example::
-
-        >>> s = "bool, optional, default True"
-        >>> convert_numpydoc_to_rstdoc(s)
-        '`bool`, `optional`, defults to `True`'
+    Example:
+    ```py
+    >>> s = "bool, optional, default True"
+    >>> convert_numpydoc_to_rstdoc(s)
+    '`bool`, `optional`, defaults to `True`'
+    ```
     """
     paramtype = re.sub(r"\s*\(.*\)$", "", paramtype).replace("default", "defults to")
     arr = paramtype.split(", ")

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -92,7 +92,7 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     '`bool`, `optional`, defaults to `True`'
     ```
     """
-    paramtype = re.sub(r"\s*\(.*\)$", "", paramtype).replace("default", "defults to")
+    paramtype = re.sub(r"\s*\(.*\)$", "", paramtype).replace("default", "defaults to")
     arr = paramtype.split(", ")
     for i, s in enumerate(arr):
         s = s.split(" ")

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -107,9 +107,8 @@ def convert_numpydoc_to_groupsdoc(docstring):
     Args:
     - **docstring** (`str`) -- Docstring that is written in numpystyle.
     """
-    numydoc = NumpyDocString(docstring)
 
-    def helper(arr):
+    def stringify_arr(arr):
         """
         Helper function that joins array into space-separated string.
         """
@@ -118,31 +117,39 @@ def convert_numpydoc_to_groupsdoc(docstring):
             return " ".join(arr) + "\n"
         return ""
 
+    def start_section(docstring, section):
+        """
+        Helper function that joins array into space-separated string.
+        """
+        return docstring.rstrip() + f"\n\n{section}:\n"
+
+    numydoc = NumpyDocString(docstring)
     indent = "    "
     result = ""
-    summary_str = f'{helper(numydoc["Summary"])}\n{helper(numydoc["Extended Summary"])}'
+    summary_str = f'{stringify_arr(numydoc["Summary"])}\n{stringify_arr(numydoc["Extended Summary"])}'
     result += summary_str
     if numydoc["Parameters"]:
-        result += "\nArgs:\n"
+        result = start_section(result, "Args")
         for parameter in numydoc["Parameters"]:
+            result = result.rstrip() + "\n"
             result += indent + parameter[0]
             if parameter[1]:
-                result += f" ({convert_parametype_numpydoc_to_groupsdoc(parameter[1])})"
-            result += ":\n"
+                result += f" ({convert_parametype_numpydoc_to_groupsdoc(parameter[1])}):"
             if parameter[2]:
-                result += indent * 2 + helper(parameter[2])
+                result += " " + stringify_arr(parameter[2])
     if numydoc["Returns"]:
-        result += "\nReturns:\n"
+        result = start_section(result, "Returns")
         for parameter in numydoc["Returns"]:
             returnttype = f":obj:'{parameter[1]}'" if parameter[1] else ""
-            result += indent + ": ".join(s for s in [returnttype, helper(parameter[2])] if s)
+            result += indent + ": ".join(s for s in [returnttype, stringify_arr(parameter[2])] if s)
     if numydoc["Raises"]:
-        result += "\nRaises:\n"
+        result = start_section(result, "Raises")
         for parameter in numydoc["Raises"]:
+            result = result.rstrip() + "\n"
             raiseerror = f"{parameter[1]}" if parameter[1] else ""
-            result += indent + ": ".join(s for s in [raiseerror, helper(parameter[2])] if s)
+            result += indent + ": ".join(s for s in [raiseerror, stringify_arr(parameter[2])] if s)
     if numydoc["Examples"]:
-        result += "\nExample::\n"
+        result = start_section(result, "Example:")
         first_line = numydoc["Examples"][0]
         indent_n = len(first_line) - len(first_line.lstrip())
         examples = [indent + line[indent_n:] for line in numydoc["Examples"]]

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -120,7 +120,8 @@ def convert_numpydoc_to_groupsdoc(docstring):
 
     indent = "    "
     result = ""
-    result += helper(numydoc["Summary"])
+    summary_str = f'{helper(numydoc["Summary"])}\n{helper(numydoc["Extended Summary"])}'
+    result += summary_str
     if numydoc["Parameters"]:
         result += "\nArgs:\n"
         for parameter in numydoc["Parameters"]:

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -89,7 +89,7 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     ```py
     >>> s = "bool, optional, default True"
     >>> convert_numpydoc_to_rstdoc(s)
-    '`bool`, `optional`, defaults to `True`'
+    ':obj:`bool`, `optional`, defaults to :obj:`True`'
     ```
     """
     paramtype = re.sub(r"\s*\(.*\)$", "", paramtype).replace("default", "defaults to")

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -141,7 +141,7 @@ def convert_numpydoc_to_groupsdoc(docstring):
     if numydoc["Returns"]:
         result = start_section(result, "Returns")
         for parameter in numydoc["Returns"]:
-            returnttype = f":obj:'{parameter[1]}'" if parameter[1] else ""
+            returnttype = f":obj:`{parameter[1]}`" if parameter[1] else ""
             result += indent + ": ".join(s for s in [returnttype, stringify_arr(parameter[2])] if s)
     if numydoc["Raises"]:
         result = start_section(result, "Raises")

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -83,7 +83,7 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     Converts parameter type str that is written in numpystyle to groupsstyle (e.g. transformers docs).
 
     Args:
-    - **paramtype** (`str`) -- The name of the object to document.
+    paramtype (`str`): The name of the object to document.
 
     Example:
     ```py

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,6 +119,7 @@ Example::
         ... })
     >>> pa.Table.from_pandas(df)
     <pyarrow.lib.Table object at 0x7f05d1fb1b40>"""
+
         self.assertEqual(convert_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
     def test_convert_parametype_numpydoc_to_groupsdoc(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,7 +73,7 @@ class UtilsTester(unittest.TestCase):
         KeyError
             If any of the passed columns name are not existing.
         ValueError
-            
+
         Returns
         -------
         Table

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,6 +93,8 @@ class UtilsTester(unittest.TestCase):
 
         expected_conversion = """Convert pandas.DataFrame to an Arrow Table.
 
+The column types in the resulting Arrow Table are inferred from the dtypes of the pandas.Series in the DataFrame. In the case of non-object Series, the NumPy dtype is translated to its Arrow equivalent. In the case of `object`, we need to guess the datatype by looking at the Python objects in this Series. Be aware that Series of the `object` dtype don't carry enough information to always lead to a meaningful Arrow type. In the case that we cannot infer a type, e.g. because the DataFrame is of length 0 or the Series only contains None/nan objects, the type is set to null. This behavior can be avoided by constructing an explicit schema and passing it to this function.
+
 Args:
     df (`pandas.DataFrame`):
     schema (`pyarrow.Schema`, `optional`):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,16 +97,11 @@ The column types in the resulting Arrow Table are inferred from the dtypes of th
 
 Args:
     df (`pandas.DataFrame`):
-    schema (`pyarrow.Schema`, `optional`):
-        The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
-    preserve_index (`bool`, `optional`, defults to `True`):
-        Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
-    nthreads (`int`, defults to `None`):
-        If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
-    columns (`list`, `optional`):
-        List of column to be converted. If None, use all columns.
-    safe (`bool`, defults to `True`):
-        Check for overflows or other unsafe conversions.
+    schema (`pyarrow.Schema`, `optional`): The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
+    preserve_index (`bool`, `optional`, defults to `True`): Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
+    nthreads (`int`, defults to `None`): If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
+    columns (`list`, `optional`): List of column to be converted. If None, use all columns.
+    safe (`bool`, defults to `True`): Check for overflows or other unsafe conversions.
 
 Returns:
     :obj:'Table': New table without the columns.
@@ -114,6 +109,7 @@ Returns:
 Raises:
     KeyError: If any of the passed columns name are not existing.
     ValueError
+
 Example::
     >>> import pandas as pd
     >>> import pyarrow as pa
@@ -123,7 +119,6 @@ Example::
         ... })
     >>> pa.Table.from_pandas(df)
     <pyarrow.lib.Table object at 0x7f05d1fb1b40>"""
-
         self.assertEqual(convert_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
     def test_convert_parametype_numpydoc_to_groupsdoc(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,10 +18,128 @@ import tempfile
 import unittest
 
 import yaml
-from doc_builder.utils import update_versions_file
+from doc_builder.utils import (
+    convert_numpydoc_to_groupsdoc,
+    convert_parametype_numpydoc_to_groupsdoc,
+    update_versions_file,
+)
 
 
 class UtilsTester(unittest.TestCase):
+    def test_convert_numpydoc_to_groupsdoc(self):
+        original_numpydocstring = """Table.from_pandas(type cls, df, Schema schema=None, preserve_index=None, nthreads=None, columns=None, bool safe=True)
+
+        Convert pandas.DataFrame to an Arrow Table.
+
+        The column types in the resulting Arrow Table are inferred from the
+        dtypes of the pandas.Series in the DataFrame. In the case of non-object
+        Series, the NumPy dtype is translated to its Arrow equivalent. In the
+        case of `object`, we need to guess the datatype by looking at the
+        Python objects in this Series.
+
+        Be aware that Series of the `object` dtype don't carry enough
+        information to always lead to a meaningful Arrow type. In the case that
+        we cannot infer a type, e.g. because the DataFrame is of length 0 or
+        the Series only contains None/nan objects, the type is set to
+        null. This behavior can be avoided by constructing an explicit schema
+        and passing it to this function.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+        schema : pyarrow.Schema, optional
+            The expected schema of the Arrow Table. This can be used to
+            indicate the type of columns if we cannot infer it automatically.
+            If passed, the output will have exactly this schema. Columns
+            specified in the schema that are not found in the DataFrame columns
+            or its index will raise an error. Additional columns or index
+            levels in the DataFrame which are not specified in the schema will
+            be ignored.
+        preserve_index : bool, optional, default True
+            Whether to store the index as an additional column in the resulting
+            ``Table``. The default of None will store the index as a column,
+            except for RangeIndex which is stored as metadata only. Use
+            ``preserve_index=True`` to force it to be stored as a column.
+        nthreads : int, default None (may use up to system CPU count threads)
+            If greater than 1, convert columns to Arrow in parallel using
+            indicated number of threads.
+        columns : list, optional
+           List of column to be converted. If None, use all columns.
+        safe : bool, default True
+           Check for overflows or other unsafe conversions.
+
+        Raises
+        ------
+        KeyError
+            If any of the passed columns name are not existing.
+        ValueError
+            
+        Returns
+        -------
+        Table
+            New table without the columns.
+
+        Examples
+        --------
+
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> df = pd.DataFrame({
+            ...     'int': [1, 2],
+            ...     'str': ['a', 'b']
+            ... })
+        >>> pa.Table.from_pandas(df)
+        <pyarrow.lib.Table object at 0x7f05d1fb1b40>"""
+
+        expected_conversion = """Convert pandas.DataFrame to an Arrow Table.
+
+Args:
+    df (`pandas.DataFrame`):
+    schema (`pyarrow.Schema`, `optional`):
+        The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
+    preserve_index (`bool`, `optional`, defults to `True`):
+        Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
+    nthreads (`int`, defults to `None`):
+        If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
+    columns (`list`, `optional`):
+        List of column to be converted. If None, use all columns.
+    safe (`bool`, defults to `True`):
+        Check for overflows or other unsafe conversions.
+
+Returns:
+    :obj:'Table': New table without the columns.
+
+Raises:
+    KeyError: If any of the passed columns name are not existing.
+    ValueError
+Example::
+    >>> import pandas as pd
+    >>> import pyarrow as pa
+    >>> df = pd.DataFrame({
+        ...     'int': [1, 2],
+        ...     'str': ['a', 'b']
+        ... })
+    >>> pa.Table.from_pandas(df)
+    <pyarrow.lib.Table object at 0x7f05d1fb1b40>"""
+
+        self.assertEqual(convert_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
+    def test_convert_parametype_numpydoc_to_groupsdoc(self):
+        # test canonical
+        original_numpydocstring = "bool, optional, default True"
+        expected_conversion = "`bool`, `optional`, defults to `True`"
+        self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
+        # test without `optional`
+        original_numpydocstring = "bool, default True"
+        expected_conversion = "`bool`, defults to `True`"
+        self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
+        # test with extra info
+        original_numpydocstring = "bool, optional, default True (some extra info)"
+        expected_conversion = "`bool`, `optional`, defults to `True`"
+        self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
     def test_update_versions_file(self):
         # test canonical
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,7 +145,7 @@ Example::
 
         # test str
         original_numpydocstring = "str, optional, default 'some_str'"
-        expected_conversion = ":obj:`str`, `optional`, defaults to 'some_str'"
+        expected_conversion = ":obj:`str`, `optional`, defaults to :obj:`'some_str'`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
     def test_update_versions_file(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,17 +125,27 @@ Example::
     def test_convert_parametype_numpydoc_to_groupsdoc(self):
         # test canonical
         original_numpydocstring = "bool, optional, default True"
-        expected_conversion = "`bool`, `optional`, defaults to `True`"
+        expected_conversion = ":obj:`bool`, `optional`, defaults to :obj:`True`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
         # test without `optional`
         original_numpydocstring = "bool, default True"
-        expected_conversion = "`bool`, defaults to `True`"
+        expected_conversion = ":obj:`bool`, defaults to :obj:`True`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
         # test with extra info
         original_numpydocstring = "bool, optional, default True (some extra info)"
-        expected_conversion = "`bool`, `optional`, defaults to `True`"
+        expected_conversion = ":obj:`bool`, `optional`, defaults to :obj:`True`"
+        self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
+        # test int
+        original_numpydocstring = "int, optional, default 1"
+        expected_conversion = ":obj:`int`, `optional`, defaults to 1"
+        self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
+
+        # test str
+        original_numpydocstring = "str, optional, default 'some_str'"
+        expected_conversion = ":obj:`str`, `optional`, defaults to 'some_str'"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
     def test_update_versions_file(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,10 +98,10 @@ The column types in the resulting Arrow Table are inferred from the dtypes of th
 Args:
     df (`pandas.DataFrame`):
     schema (`pyarrow.Schema`, `optional`): The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
-    preserve_index (`bool`, `optional`, defults to `True`): Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
-    nthreads (`int`, defults to `None`): If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
+    preserve_index (`bool`, `optional`, defaults to `True`): Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
+    nthreads (`int`, defaults to `None`): If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
     columns (`list`, `optional`): List of column to be converted. If None, use all columns.
-    safe (`bool`, defults to `True`): Check for overflows or other unsafe conversions.
+    safe (`bool`, defaults to `True`): Check for overflows or other unsafe conversions.
 
 Returns:
     :obj:'Table': New table without the columns.
@@ -125,17 +125,17 @@ Example::
     def test_convert_parametype_numpydoc_to_groupsdoc(self):
         # test canonical
         original_numpydocstring = "bool, optional, default True"
-        expected_conversion = "`bool`, `optional`, defults to `True`"
+        expected_conversion = "`bool`, `optional`, defaults to `True`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
         # test without `optional`
         original_numpydocstring = "bool, default True"
-        expected_conversion = "`bool`, defults to `True`"
+        expected_conversion = "`bool`, defaults to `True`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
         # test with extra info
         original_numpydocstring = "bool, optional, default True (some extra info)"
-        expected_conversion = "`bool`, `optional`, defults to `True`"
+        expected_conversion = "`bool`, `optional`, defaults to `True`"
         self.assertEqual(convert_parametype_numpydoc_to_groupsdoc(original_numpydocstring), expected_conversion)
 
     def test_update_versions_file(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,15 +96,15 @@ class UtilsTester(unittest.TestCase):
 The column types in the resulting Arrow Table are inferred from the dtypes of the pandas.Series in the DataFrame. In the case of non-object Series, the NumPy dtype is translated to its Arrow equivalent. In the case of `object`, we need to guess the datatype by looking at the Python objects in this Series. Be aware that Series of the `object` dtype don't carry enough information to always lead to a meaningful Arrow type. In the case that we cannot infer a type, e.g. because the DataFrame is of length 0 or the Series only contains None/nan objects, the type is set to null. This behavior can be avoided by constructing an explicit schema and passing it to this function.
 
 Args:
-    df (`pandas.DataFrame`):
-    schema (`pyarrow.Schema`, `optional`): The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
-    preserve_index (`bool`, `optional`, defaults to `True`): Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
-    nthreads (`int`, defaults to `None`): If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
-    columns (`list`, `optional`): List of column to be converted. If None, use all columns.
-    safe (`bool`, defaults to `True`): Check for overflows or other unsafe conversions.
+    df (:obj:`pandas.DataFrame`):
+    schema (:obj:`pyarrow.Schema`, `optional`): The expected schema of the Arrow Table. This can be used to indicate the type of columns if we cannot infer it automatically. If passed, the output will have exactly this schema. Columns specified in the schema that are not found in the DataFrame columns or its index will raise an error. Additional columns or index levels in the DataFrame which are not specified in the schema will be ignored.
+    preserve_index (:obj:`bool`, `optional`, defaults to :obj:`True`): Whether to store the index as an additional column in the resulting ``Table``. The default of None will store the index as a column, except for RangeIndex which is stored as metadata only. Use ``preserve_index=True`` to force it to be stored as a column.
+    nthreads (:obj:`int`, defaults to :obj:`None`): If greater than 1, convert columns to Arrow in parallel using indicated number of threads.
+    columns (:obj:`list`, `optional`): List of column to be converted. If None, use all columns.
+    safe (:obj:`bool`, defaults to :obj:`True`): Check for overflows or other unsafe conversions.
 
 Returns:
-    :obj:'Table': New table without the columns.
+    :obj:`Table`: New table without the columns.
 
 Raises:
     KeyError: If any of the passed columns name are not existing.


### PR DESCRIPTION
### TLDR: convert docstring that is written in numpy doc style to groups doc style (e.g. the style that is used in transformers, datasets, etc.)

Example Input:
```
Description

More description

Parameters
----------
columns : list, optional
    List of column to be converted. If None, use all columns.
safe : bool, default True
    Check for overflows or other unsafe conversions.

Raises
------
KeyError
    If any of the passed columns name are not existing.
ValueError

Returns
-------
Table
    New table without the columns.

Examples
--------

>>> import pandas as pd
>>> import pyarrow as pa
>>> df = pd.DataFrame({
    ...     'int': [1, 2],
    ...     'str': ['a', 'b']
    ... })
>>> pa.Table.from_pandas(df)
<pyarrow.lib.Table object at 0x7f05d1fb1b40>
```

Example Output:
```
Description

More description

Args:
    columns (`list`, `optional`): List of column to be converted. If None, use all columns.
    safe (`bool`, defults to `True`): Check for overflows or other unsafe conversions.

Returns:
    :obj:'Table': New table without the columns.

Raises:
    KeyError: If any of the passed columns name are not existing.
    ValueError

Example::
    >>> import pandas as pd
    >>> import pyarrow as pa
    >>> df = pd.DataFrame({
        ...     'int': [1, 2],
        ...     'str': ['a', 'b']
        ... })
    >>> pa.Table.from_pandas(df)
    <pyarrow.lib.Table object at 0x7f05d1fb1b40>
```

Why:
Because `datasets` inherits [some docs from pyarrow](https://github.com/huggingface/datasets/blob/b45dd77d01486e08731a0383aaf2c6140f85576c/src/datasets/table.py#L26-L36) that are written in numpy doc style.