### PR TITLE
Return type without return description

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -339,7 +339,7 @@ def split_return_line(line):
     while idx < len(splits_on_colon) and splits_on_colon[idx] in ["obj", "class"]:
         idx += 2
     if idx >= len(splits_on_colon):
-        if len(splits_on_colon) in [1, 3]:
+        if len(splits_on_colon) % 2 == 1 and re.search(r"`\w+`$", line.rstrip()):
             return line, ""
         return None, line
     return ":".join(splits_on_colon[:idx]), ":".join(splits_on_colon[idx:])

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -339,6 +339,8 @@ def split_return_line(line):
     while idx < len(splits_on_colon) and splits_on_colon[idx] in ["obj", "class"]:
         idx += 2
     if idx >= len(splits_on_colon):
+        if len(splits_on_colon) in [1, 3]:
+            return line, ""
         return None, line
     return ":".join(splits_on_colon[:idx]), ":".join(splits_on_colon[idx:])
 

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -466,6 +466,8 @@ $$formula$$
             split_return_line("    :obj:`str` or :obj:`bool`: some result:"),
             ("    :obj:`str` or :obj:`bool`", " some result:"),
         )
+        self.assertEqual(split_return_line(":class:`IterableDataset`"), (":class:`IterableDataset`", ""))
+        self.assertEqual(split_return_line("`int`"), ("`int`", ""))
 
     def test_split_arg_line(self):
         self.assertEqual(split_arg_line("   x (:obj:`int`): an int"), ("   x (:obj:`int`)", " an int"))


### PR DESCRIPTION
In datastes docs, there are docstrings with return type but without return descriptions.
```
def cast_column(self, column: str, feature: FeatureType) -> "IterableDataset":
    """Cast column to feature for decoding.

    Args:
        column (:obj:`str`): Column name.
        feature (:class:`Feature`): Target feature 2.

    Returns:
        :class:`IterableDataset`
    """
```

`split_return_line` function was not handling this case properly.

