### PR TITLE
Handle data class auto generated doc

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -243,6 +243,21 @@ def is_numpy_docstring(docstring):
     return _re_numpydocstring.search(docstring)
 
 
+def is_dataclass_autodoc(obj):
+    """
+    Returns boolean whether object's doc was generated automatically by `dataclass`.
+    """
+    try:
+        signature = str(inspect.signature(obj))
+    except ValueError:
+        # object doesn't have signature
+        return False
+    doc = obj.__doc__
+    doc_generated = obj.__name__ + signature
+    is_generated = doc in doc_generated
+    return is_generated
+
+
 def get_source_link(obj, page_info):
     """
     Returns the link to the source code of an object on GitHub.
@@ -292,7 +307,9 @@ def document_object(object_name, package, page_info, full_name=True):
     check = None
     if getattr(obj, "__doc__", None) is not None and len(obj.__doc__) > 0:
         object_doc = obj.__doc__
-        if is_numpy_docstring(object_doc):
+        if is_dataclass_autodoc(obj):
+            object_doc = ""
+        elif is_numpy_docstring(object_doc):
             object_doc = convert_numpydoc_to_groupsdoc(object_doc)
         if is_rst_docstring(object_doc):
             object_doc = convert_rst_docstring_to_mdx(obj.__doc__, page_info)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -449,7 +449,7 @@ tuple before.
 
         self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))
 
-        # test class with no signaure (because of `dict` inheritance)
+        # test class with no signature (because of `dict` inheritance)
         class AutomaticSpeechRecognition(dict):
             audio_file_path_column: str = "audio_file_path"
             transcription_column: str = "transcription"

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -16,6 +16,7 @@
 
 import inspect
 import unittest
+from dataclasses import dataclass
 from typing import List, Optional, Union
 
 import transformers
@@ -29,6 +30,7 @@ from doc_builder.autodoc import (
     get_signature_component,
     get_source_link,
     get_type_name,
+    is_dataclass_autodoc,
     remove_example_tags,
     resolve_links_in_text,
 )
@@ -417,3 +419,31 @@ tuple before.
                 "[transformers.BertModel.forward()](/docs/transformers/v4.10.0/fr/model_doc/bert.html#transformers.BertModel.forward)."
             ),
         )
+
+    def test_is_dataclass_autodoc(self):
+        # test data class auto generated doc
+        @dataclass(frozen=True)
+        class AutomaticSpeechRecognition:
+            audio_file_path_column: str = "audio_file_path"
+            transcription_column: str = "transcription"
+
+        self.assertTrue(is_dataclass_autodoc(AutomaticSpeechRecognition))
+
+        # test data class auto non-generated doc
+        @dataclass(frozen=True)
+        class AutomaticSpeechRecognition:
+            """
+            Non auto generated doc
+            """
+
+            audio_file_path_column: str = "audio_file_path"
+            transcription_column: str = "transcription"
+
+        self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))
+
+        # test class with no signaure (because of `dict` inheritance)
+        class AutomaticSpeechRecognition(dict):
+            audio_file_path_column: str = "audio_file_path"
+            transcription_column: str = "transcription"
+
+        self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -421,6 +421,14 @@ tuple before.
         )
 
     def test_is_dataclass_autodoc(self):
+        # example auto generated doc from dataclass
+        @dataclass(frozen=True)
+        class MyClass:
+            attr1: str = "audio_file_path"
+            attr2: str = "transcription"
+
+        self.assertEqual(MyClass.__doc__, "MyClass(attr1: str = 'audio_file_path', attr2: str = 'transcription')")
+
         # test data class auto generated doc
         @dataclass(frozen=True)
         class AutomaticSpeechRecognition:


### PR DESCRIPTION
`dataclass` decorator auto generates docs for a class if the class doesn't have a doc. The generated doc is redundant with the class signature. Therefore, we don't want that. See [the test example](https://github.com/huggingface/doc-builder/pull/93/commits/77085f8cdff8c9daba8817d6d4d03e89e95735df) for more info