### PR TITLE
Autodocument @property

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -270,6 +270,17 @@ def get_source_link(obj, page_info):
     return f"{base_link}{module}.py#L{line_number}"
 
 
+def document_property(obj):
+    """
+    Documents property.
+    """
+    src_str = inspect.getsource(obj).strip()
+    match = re.search(r"return (.*)$", src_str)
+    returns = match.group(1)
+    obj.__doc__ = f"`@property` that returns `{returns}`"
+    return obj
+
+
 def document_object(object_name, package, page_info, full_name=True):
     """
     Writes the document of a function, class or method.
@@ -291,6 +302,8 @@ def document_object(object_name, package, page_info, full_name=True):
     if isinstance(obj, property):
         # Propreties have no __module__ or __name__ attributes, but their getter function does.
         obj = obj.fget
+        if getattr(obj, "__doc__", None) is None:
+            obj = document_property(obj)
 
     anchor_name = get_shortest_path(obj, package)
     if full_name and anchor_name is not None:

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -23,6 +23,7 @@ import transformers
 from doc_builder.autodoc import (
     autodoc,
     document_object,
+    document_property,
     find_documented_methods,
     find_object_in_package,
     format_signature,
@@ -455,3 +456,14 @@ tuple before.
             transcription_column: str = "transcription"
 
         self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))
+
+    def test_document_property(self):
+        class MyClass:
+            def __init__(self):
+                self.attr = 5
+
+            @property
+            def property1(self):
+                return self.attr
+
+        self.assertEqual(document_property(MyClass.property1.fget).__doc__, "`@property` that returns `self.attr`")


### PR DESCRIPTION
Most methods with @property decorator don't have any __doc__ (see [here](https://github.com/huggingface/datasets/blob/b45dd77d01486e08731a0383aaf2c6140f85576c/src/datasets/table.py#L245-L263) for an example).
And because of [this line](https://github.com/huggingface/doc-builder/blob/da20949cf0168447ba08a9940e337644fa4afc18/src/doc_builder/autodoc.py#L321), an empty doc string and doc component was being returned.

As a solution, this PR auto generates docstring for  methods with @property.

Example:

Before:
```python
@property
def num_columns(self):
    return self.table.num_columns
```

After:
```python
@property
def num_columns(self):
    """
    `@property` that returns `self.table.num_columns`
    """
    return self.table.num_columns
```