### PR TITLE
Fix document_object when objdoc is empty

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -301,7 +301,6 @@ def document_object(object_name, package, page_info, full_name=True):
     name = name.replace("_", "\_")
 
     prefix = "class " if isinstance(obj, type) else ""
-    documentation = ""
     object_doc = ""
     signature_name = prefix + name
     signature = format_signature(obj)
@@ -320,7 +319,7 @@ def document_object(object_name, package, page_info, full_name=True):
 
     source_link = get_source_link(obj, page_info)
     component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
-    documentation += "\n" + component + "\n"
+    documentation = "\n" + component + "\n"
     return documentation, check
 
 

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -302,6 +302,7 @@ def document_object(object_name, package, page_info, full_name=True):
 
     prefix = "class " if isinstance(obj, type) else ""
     documentation = ""
+    object_doc = ""
     signature_name = prefix + name
     signature = format_signature(obj)
     check = None
@@ -317,9 +318,9 @@ def document_object(object_name, package, page_info, full_name=True):
             check = quality_check_docstring(object_doc, object_name=object_name)
             object_doc = convert_md_docstring_to_mdx(obj.__doc__, page_info)
 
-        source_link = get_source_link(obj, page_info)
-        component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
-        documentation += "\n" + component + "\n"
+    source_link = get_source_link(obj, page_info)
+    component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
+    documentation += "\n" + component + "\n"
     return documentation, check
 
 


### PR DESCRIPTION
# Problem description:
When `obj.__doc__` is empty, no mdx section for that doc gets generated.

# Solution
https://github.com/huggingface/doc-builder/pull/96 fixes the problem by generating the signature str/svelte for that doc even if `obj.__doc__` is empty.

I realize that #95 was overcomplicating things. Please let me know if the problem is clear 🙂 