### PR TITLE
Rm `name.replace("_", "\_")`

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -297,8 +297,6 @@ def document_object(object_name, package, page_info, full_name=True):
         name = anchor_name
     else:
         name = obj.__name__
-    # Escape underscores in magic method names
-    name = name.replace("_", "\_")
 
     prefix = "class " if isinstance(obj, type) else ""
     documentation = ""

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -455,7 +455,3 @@ tuple before.
             transcription_column: str = "transcription"
 
         self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))
-
-    def test_thisslash(self):
-        txt, anchors, _ = autodoc("Trainer.create_optimizer_and_scheduler", transformers, return_anchors=True)
-        print(txt)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -248,7 +248,7 @@ Users should refer to this superclass for more information regarding those metho
         page_info = {"package_name": "transformers"}
 
         model_output_doc = """
-<docstring><name>class transformers.file\_utils.ModelOutput</name><anchor>transformers.file_utils.ModelOutput</anchor><source>"""
+<docstring><name>class transformers.file_utils.ModelOutput</name><anchor>transformers.file_utils.ModelOutput</anchor><source>"""
         model_output_doc += f"{self.test_source_link}"
         model_output_doc += """</source><parameters>""</parameters></docstring>
 
@@ -455,3 +455,7 @@ tuple before.
             transcription_column: str = "transcription"
 
         self.assertFalse(is_dataclass_autodoc(AutomaticSpeechRecognition))
+
+    def test_thisslash(self):
+        txt, anchors, _ = autodoc("Trainer.create_optimizer_and_scheduler", transformers, return_anchors=True)
+        print(txt)


### PR DESCRIPTION
Fixes https://github.com/huggingface/doc-builder/pull/94#issuecomment-1042383743

@sgugger please let me know if there was a specific reason why this espacing was here initially

cc: @Pierrci 