### PR TITLE
Add library_name to env args

### DIFF
--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -25,7 +25,7 @@ const config = {
 		paths: {
 			base:
 				"/docs/" +
-				process.env.DOCS_LIBRARY +
+				(process.env.DOCS_LIBRARY || "transformers") +
 				"/" +
 				(process.env.DOCS_VERSION || "master") +
 				"/" +

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -24,7 +24,9 @@ const config = {
 
 		paths: {
 			base:
-				"/docs/transformers/" +
+				"/docs/" +
+				process.env.DOCS_LIBRARY +
+				"/" +
 				(process.env.DOCS_VERSION || "master") +
 				"/" +
 				(process.env.DOCS_LANGUAGE || "en")

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -138,6 +138,7 @@ def build_command(args):
             )
 
             env = os.environ.copy()
+            env["DOCS_LIBRARY"] = args.library_name
             env["DOCS_VERSION"] = version
             env["DOCS_LANGUAGE"] = args.language
             print("Building HTML files. This will take a while :-)")


### PR DESCRIPTION
Add `library_name` to env args so that other libraries can be used as well such as `datasets`