### PR TITLE
Update numpydocs summary conversion

### DIFF
--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -119,13 +119,13 @@ def convert_numpydoc_to_groupsdoc(docstring):
     - **docstring** (`str`) -- Docstring that is written in numpystyle.
     """
 
-    def stringify_arr(arr):
+    def stringify_arr(arr, sep=" "):
         """
         Helper function that joins array into space-separated string.
         """
         arr = [a.strip() for a in arr if a.strip()]
         if arr:
-            return " ".join(arr) + "\n"
+            return sep.join(arr) + "\n"
         return ""
 
     def start_section(docstring, section):
@@ -137,7 +137,8 @@ def convert_numpydoc_to_groupsdoc(docstring):
     numydoc = NumpyDocString(docstring)
     indent = "    "
     result = ""
-    summary_str = f'{stringify_arr(numydoc["Summary"])}\n{stringify_arr(numydoc["Extended Summary"])}'
+    summary_extended_str = stringify_arr(numydoc["Extended Summary"], "\n")
+    summary_str = f'{stringify_arr(numydoc["Summary"])}\n{summary_extended_str}'
     result += summary_str
     if numydoc["Parameters"]:
         result = start_section(result, "Args")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,17 @@ class UtilsTester(unittest.TestCase):
 
         expected_conversion = """Convert pandas.DataFrame to an Arrow Table.
 
-The column types in the resulting Arrow Table are inferred from the dtypes of the pandas.Series in the DataFrame. In the case of non-object Series, the NumPy dtype is translated to its Arrow equivalent. In the case of `object`, we need to guess the datatype by looking at the Python objects in this Series. Be aware that Series of the `object` dtype don't carry enough information to always lead to a meaningful Arrow type. In the case that we cannot infer a type, e.g. because the DataFrame is of length 0 or the Series only contains None/nan objects, the type is set to null. This behavior can be avoided by constructing an explicit schema and passing it to this function.
+The column types in the resulting Arrow Table are inferred from the
+dtypes of the pandas.Series in the DataFrame. In the case of non-object
+Series, the NumPy dtype is translated to its Arrow equivalent. In the
+case of `object`, we need to guess the datatype by looking at the
+Python objects in this Series.
+Be aware that Series of the `object` dtype don't carry enough
+information to always lead to a meaningful Arrow type. In the case that
+we cannot infer a type, e.g. because the DataFrame is of length 0 or
+the Series only contains None/nan objects, the type is set to
+null. This behavior can be avoided by constructing an explicit schema
+and passing it to this function.
 
 Args:
     df (:obj:`pandas.DataFrame`):


### PR DESCRIPTION
In `extended summary` section of docstrings, newline information matters to render distinct blocks like:

```
First paragraph

Second paragraph
```

Before this PR, this information was getting lost. They were being rendered as:
```
First paragraph Second paragraph
```