### PR TITLE
Fix documentation of --version in doc-builder build

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -176,8 +176,8 @@ def build_command_parser(subparsers=None):
     parser.add_argument(
         "--version",
         type=str,
-        help="Version under which to push the files. Will not affect the actual files generated, as these are"
-        " generated according to the `path_to_docs` argument.",
+        help="Version of the documentation to generate. Will default to the version of the package module (using "
+        "`master` for a version containing dev.",
     )
     parser.add_argument("--notebook_dir", type=str, help="Where to save the generated notebooks.", default=None)
     parser.add_argument("--html", action="store_true", help="Whether or not to build HTML files instead of MDX files.")

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -177,7 +177,7 @@ def build_command_parser(subparsers=None):
         "--version",
         type=str,
         help="Version of the documentation to generate. Will default to the version of the package module (using "
-        "`master` for a version containing dev.",
+        "`master` for a version containing dev).",
     )
     parser.add_argument("--notebook_dir", type=str, help="Where to save the generated notebooks.", default=None)
     parser.add_argument("--html", action="store_true", help="Whether or not to build HTML files instead of MDX files.")


### PR DESCRIPTION
This fixes the --help of the command `doc-builder build` for the `--version` argument.

Fixes #105