### PR TITLE
Clean up doctest artifacts

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -19,6 +19,9 @@ import re
 from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
 
 
+_re_doctest_flags = re.compile("^(>>>.*\S)(\s+)# doctest:\s+\+[A-Z_]+\s*$", flags=re.MULTILINE)
+
+
 def convert_md_to_mdx(md_text, page_info):
     """
     Convert a document written in md to mdx.
@@ -72,6 +75,15 @@ def convert_img_links(text, page_info):
     return text
 
 
+def clean_doctest_syntax(text):
+    """
+    Clean the doctest artifacts in a given content.
+    """
+    text = text.replace(">>> # ===PT-TF-SPLIT===", "===PT-TF-SPLIT===")
+    text = _re_doctest_flags.sub(r"\1", text)
+    return text
+
+
 def convert_md_docstring_to_mdx(docstring, page_info):
     """
     Convert a docstring written in Markdown to mdx.
@@ -88,5 +100,6 @@ def process_md(text, page_info):
         2. Converting image links
     """
     text = convert_special_chars(text)
+    text = clean_doctest_syntax(text)
     text = convert_img_links(text, page_info)
     return text

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import nbformat
 
 from .autodoc import resolve_links_in_text
+from .convert_md_to_mdx import clean_doctest_syntax
 from .convert_rst_to_mdx import is_empty_line
 from .utils import get_doc_config
 
@@ -85,6 +86,8 @@ def split_frameworks(content):
     """
     split_pattern = "===PT-TF-SPLIT==="
     new_lines = {"mixed": [], "pt": [], "tf": []}
+
+    content = clean_doctest_syntax(content)
     lines = content.split("\n")
     idx = 0
     while idx < len(lines):


### PR DESCRIPTION
This PR cleans up the doctest artifacts that may appear in examples:
- flags to ignore outputs or skip
- a framework split variation since we can't use the regular one and it doesn't look like #63 is going to be merged any time soon.