### PR TITLE
Make generated CSS empty

### DIFF
--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -3,3 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 cp src/routes/_toctree.yml build/_toctree.yml
+
+# To void conflict with Hub Tailwind CSS build, 
+# making doc-builder's PostCSS geenrated file an empty one
+> $(find . -regex '.*build.*.css')

--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -5,5 +5,8 @@ IFS=$'\n\t'
 cp src/routes/_toctree.yml build/_toctree.yml
 
 # To avoid conflict with Hub Tailwind CSS build, 
-# making doc-builder's PostCSS geenrated file an empty one
+# 1. making doc-builder's PostCSS geenrated file an empty one
+# 2. making `rel="stylesheet"` -> `rel="modulepreload"`
 > $(find . -regex '.*build.*.css')
+cd build
+find . -name '*.html' -exec sed -i '' 's/rel="stylesheet"/rel="modulepreload"/g' {} \;

--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -4,6 +4,6 @@ IFS=$'\n\t'
 
 cp src/routes/_toctree.yml build/_toctree.yml
 
-# To void conflict with Hub Tailwind CSS build, 
+# To avoid conflict with Hub Tailwind CSS build, 
 # making doc-builder's PostCSS geenrated file an empty one
 > $(find . -regex '.*build.*.css')


### PR DESCRIPTION
Do not output CSS file in sveltekit build to avoid problem mentioned [here](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1646069793888439?thread_ts=1646055958.293249&cid=C02GLJ5S0E9).

There is still main body shifting to the left glitch, which is caused by [SubSideMenu and its breakpoints loading](https://github.com/huggingface/moon-landing/blob/4a16818bf77260ad9f3d23d530c990b859fac464/server/views/pages/DocPage/DocBuilderPage.svelte#L69). Will handle that problem in a separate moon-landing PR.

Rather than reverting the entire CSS addition as in [here](https://github.com/huggingface/doc-builder/pull/113), I'd like to keep it for dev purposes.

In the video below, I load the bert page 3 times for demo:

https://user-images.githubusercontent.com/11827707/156076438-d61b3aa3-becb-4580-b0d5-184878f56c7a.mov

