### PR TITLE
Changes for datasets new frontend

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -264,16 +264,16 @@ const _mdsvexPreprocess = mdsvex({
 				}
 				return `
 	<CodeBlockFw
-		group1={
+		group1={{
 			id: '${isPtTf ? "pt" : "stringapi"}',
 			code: \`${escape(codeGroup1)}\`,
 			highlighted: \`${escape(highlightedPt)}\`
-		}
-		group2={
+		}}
+		group2={{
 			id: '${isPtTf ? "tf" : "readinstruction"}',
 			code: \`${escape(codeGroup2)}\`,
 			highlighted: \`${escape(highlightedTf)}\`
-		}
+		}}
 	/>`;
 			} else {
 				const highlighted = _highlight(code);

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { group } from "./stores";
-	import CopyButton from "../CopyButton/CopyButton.svelte";
+	import CopyButton from "./CopyButton.svelte";
 	import FrameworkSwitch from "./FrameworkSwitch.svelte";
 
 	export let group1: { id: string; code: string; highlighted: string };

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { group } from "./stores";
+	import { getGroupStore } from "./stores";
 	import CopyButton from "./CopyButton.svelte";
 	import FrameworkSwitch from "./FrameworkSwitch.svelte";
 
@@ -7,6 +7,9 @@
 	export let group2: { id: string; code: string; highlighted: string };
 
 	const ids = [group1.id, group2.id];
+	const storeKey = ids.join("-");
+	const group = getGroupStore(storeKey);
+
 
 	let hideCopyButton = true;
 

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import { fw } from "./stores";
-	import CopyButton from "./CopyButton.svelte";
+	import { group } from "./stores";
+	import CopyButton from "../CopyButton/CopyButton.svelte";
 	import FrameworkSwitch from "./FrameworkSwitch.svelte";
 
-	export let pt: { code: string; highlighted: string };
-	export let tf: { code: string; highlighted: string };
+	export let group1: { id: string; code: string; highlighted: string };
+	export let group2: { id: string; code: string; highlighted: string };
+
+	const ids = [group1.id, group2.id];
 
 	let hideCopyButton = true;
 
@@ -21,25 +23,25 @@
 	on:mouseover={handleMouseOver}
 	on:focus={handleMouseOver}
 	on:mouseout={handleMouseOut}
-	on:blur={handleMouseOut}
+	on:focus={handleMouseOut}
 >
-	{#if $fw === "pt"}
+	{#if $group === "group1"}
 		<div class="absolute top-2.5 right-4">
 			<CopyButton
 				classNames="transition duration-200 ease-in-out {hideCopyButton && 'opacity-0'}"
 				title="Copy code excerpt to clipboard"
-				value={pt.code}
+				value={group1.code}
 			/>
 		</div>
-		<pre><FrameworkSwitch />{@html pt.highlighted}</pre>
+		<pre><FrameworkSwitch {ids}/>{@html group1.highlighted}</pre>
 	{:else}
 		<div class="absolute top-2.5 right-4">
 			<CopyButton
 				classNames="transition duration-200 ease-in-out {hideCopyButton && 'opacity-0'}"
 				title="Copy code excerpt to clipboard"
-				value={tf.code}
+				value={group2.code}
 			/>
 		</div>
-		<pre><FrameworkSwitch />{@html tf.highlighted}</pre>
+		<pre><FrameworkSwitch {ids}/>{@html group2.highlighted}</pre>
 	{/if}
 </div>

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -161,7 +161,7 @@
 				<p>{@html parametersDescription}</p>
 			{/each}
 		{/if}
-		{#if !!returnDescription}
+		{#if !!returnType}
 			<div
 				class="flex items-center font-semibold space-x-3 text-base !mt-0 !mb-0 text-gray-800"
 				id={`${anchor}.returns`}
@@ -172,7 +172,7 @@
 				{/if}
 				<span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700" />
 			</div>
-			<p class="text-base">{@html returnDescription}</p>
+			<p class="text-base">{@html returnDescription || ""}</p>
 		{/if}
 	</div>
 </div>

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -9,25 +9,27 @@
 	const GROUPS = [
 		{
 			id: "pt",
-			classNames: "bg-red-50 text-red-600",
+			classNames: "",
 			icon: IconPytorch,
 			name: "Pytorch",
 			group: "group1",
 		},
 		{
 			id: "tf",
-			classNames: "bg-orange-50 text-yellow-600",
+			classNames: "",
 			icon: IconTensorflow,
 			name: "TensorFlow",
 			group: "group2",
 		},
 		{
 			id: "stringapi",
+			classNames: "text-blue-600",
 			name: "String API",
 			group: "group1",
 		},
 		{
 			id: "readinstruction",
+			classNames: "text-blue-600",
 			name: "ReadInstruction",
 			group: "group2",
 		},
@@ -52,7 +54,7 @@
 				{#if g.icon}
 					<svelte:component this={g.icon} classNames="mr-1.5" />
 				{/if}
-				<p style="margin: 0px;">
+				<p class="m-0 {g.classNames}">
 					{g.name}
 				</p>
 			</button>

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -56,7 +56,7 @@
 				{#if g.icon}
 					<svelte:component this={g.icon} classNames="mr-1.5" />
 				{/if}
-				<p class="m-0 {g.classNames}">
+				<p class="!m-0 {g.classNames}">
 					{g.name}
 				</p>
 			</button>

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -1,43 +1,61 @@
 <script lang="ts">
-	import type { Framework } from "./types";
-	import { fw } from "./stores";
-	import IconPytorch from "./IconPytorch.svelte";
-	import IconTensorflow from "./IconTensorflow.svelte";
+	import type { Group } from "./types";
+	import { group } from "./stores";
+	import IconPytorch from "../Icons/IconPytorch.svelte";
+	import IconTensorflow from "../Icons/IconTensorflow.svelte";
 
-	const FRAMEWORKS = [
+	export let ids: string[];
+
+	const GROUPS = [
 		{
 			id: "pt",
 			classNames: "bg-red-50 text-red-600",
 			icon: IconPytorch,
-			name: "Pytorch"
+			name: "Pytorch",
+			group: "group1",
 		},
 		{
 			id: "tf",
 			classNames: "bg-orange-50 text-yellow-600",
 			icon: IconTensorflow,
-			name: "TensorFlow"
-		}
-	] as const;
+			name: "TensorFlow",
+			group: "group2",
+		},
+		{
+			id: "stringapi",
+			name: "String API",
+			group: "group1",
+		},
+		{
+			id: "readinstruction",
+			name: "ReadInstruction",
+			group: "group2",
+		},
+	];
 
-	function changeFw(_fw: Framework) {
-		$fw = _fw;
+	function changeGroup(_group: string) {
+		$group = _group as Group;
 	}
 </script>
 
-<div
-	class="bg-white leading-none border border-gray-100 rounded-lg flex p-0.5 w-56 text-sm mb-4 select-none"
->
-	{#each FRAMEWORKS as { icon, id, name }, i}
-		<button
-			class="flex justify-center flex-1 py-1.5 px-2.5 focus:outline-none
+<div>
+	<div
+		class="bg-white leading-none border border-gray-100 rounded-lg inline-flex p-0.5 text-sm mb-4 select-none"
+	>
+		{#each GROUPS.filter((g) => ids.includes(g.id)) as g, i}
+			<button
+				class="flex justify-center py-1.5 px-2.5 focus:outline-none
 			rounded-{i ? 'r' : 'l'}
-			{id !== $fw && 'text-gray-500 filter grayscale'}"
-			on:click={() => changeFw(id)}
-		>
-			<svelte:component this={icon} classNames="mr-1.5" />
-			<p style="margin: 0px;">
-				{name}
-			</p>
-		</button>
-	{/each}
+			{g.group !== $group && 'text-gray-500 filter grayscale'}"
+				on:click={() => changeGroup(g.group)}
+			>
+				{#if g.icon}
+					<svelte:component this={g.icon} classNames="mr-1.5" />
+				{/if}
+				<p style="margin: 0px;">
+					{g.name}
+				</p>
+			</button>
+		{/each}
+	</div>
 </div>

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import type { Group } from "./types";
 	import { group } from "./stores";
-	import IconPytorch from "../Icons/IconPytorch.svelte";
-	import IconTensorflow from "../Icons/IconTensorflow.svelte";
+	import IconPytorch from "./IconPytorch.svelte";
+	import IconTensorflow from "./IconTensorflow.svelte";
 
 	export let ids: string[];
 

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import type { Group } from "./types";
-	import { group } from "./stores";
+	import { getGroupStore } from "./stores";
 	import IconPytorch from "./IconPytorch.svelte";
 	import IconTensorflow from "./IconTensorflow.svelte";
 
 	export let ids: string[];
+	const storeKey = ids.join("-");
+	const group = getGroupStore(storeKey);
 
 	const GROUPS = [
 		{

--- a/kit/src/lib/stores.ts
+++ b/kit/src/lib/stores.ts
@@ -1,4 +1,12 @@
+import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
 import type { Group } from "./types";
 
-export const group = writable<Group>("group1");
+const groups: Record<string, Writable<Group>> = {};
+
+export function getGroupStore(key: string): Writable<Group>{
+    if(!groups[key]){
+        groups[key] = writable<Group>("group1");
+    }
+    return groups[key];
+}

--- a/kit/src/lib/stores.ts
+++ b/kit/src/lib/stores.ts
@@ -1,4 +1,4 @@
 import { writable } from "svelte/store";
-import type { Framework } from "./types";
+import type { Group } from "./types";
 
-export const fw = writable<Framework>("pt");
+export const group = writable<Group>("group1");

--- a/kit/src/lib/types.ts
+++ b/kit/src/lib/types.ts
@@ -1,1 +1,1 @@
-export type Framework = "pt" | "tf";
+export type Group = "group1" | "group2";


### PR DESCRIPTION
Generalizing CodeBlockFw.svelte components.

Before, CodeBlockFw.svelte only supported `Pytorch/Tensorflow` tabs. Example [url](https://moon-preprod.huggingface.co/docs/datasets/quickstart)
<img width="500" alt="Screenshot 2022-03-02 at 15 51 30" src="https://user-images.githubusercontent.com/11827707/156385913-d7cd9eb3-0748-422d-a0c0-751f208e24e0.png">

With this PR, it will also support `String API/ReadInstruction` tabs. Example [url](https://moon-preprod.huggingface.co/docs/datasets/master/en/loading#slice-splits)
<img width="500" alt="Screenshot 2022-03-02 at 15 50 34" src="https://user-images.githubusercontent.com/11827707/156386017-292cf5f2-90ef-4ab5-924e-1a4aee9cb9be.png">

