### PR TITLE
Support any package name in notebooks widget

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -46,8 +46,9 @@ def resolve_open_in_colab(content, page_info):
     if "[[open-in-colab]]" not in content:
         return content
 
+    package_name = page_info["package_name"]
     page_name = Path(page_info["page"]).stem
-    nb_prefix = "/github/huggingface/notebooks/blob/master/transformers_doc/"
+    nb_prefix = f"/github/huggingface/notebooks/blob/master/{package_name}_doc/"
     nb_prefix_colab = f"https://colab.research.google.com{nb_prefix}"
     nb_prefix_awsstudio = f"https://studiolab.sagemaker.aws/import{nb_prefix}"
     links = [

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -41,7 +41,10 @@ class BuildDocTester(unittest.TestCase):
     {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/quicktour.ipynb"},
 ]} />
 """
-        self.assertEqual(resolve_open_in_colab("\n[[open-in-colab]]\n", {"page": "quicktour.html"}), expected)
+        self.assertEqual(
+            resolve_open_in_colab("\n[[open-in-colab]]\n", {"package_name": "transformers", "page": "quicktour.html"}),
+            expected,
+        )
 
     def test_generate_frontmatter_in_text(self):
         # test canonical


### PR DESCRIPTION
This removes the hard-coded "transformers" to support other libraries (like datasets)