### PR TITLE
Clean up docstrings

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -284,9 +284,9 @@ def document_object(object_name, package, page_info, full_name=True):
     Writes the document of a function, class or method.
 
     Args:
-    - **object_name** (`str`) -- The name of the object to document.
-    - **package** (`types.ModuleType`) -- The package of the object.
-    - **full_name** (`bool`, _optional_, defaults to `True`) -- Whether to write the full name of the object or not.
+        object_name (`str`): The name of the object to document.
+        package (`types.ModuleType`): The package of the object.
+        full_name (`bool`, *optional*, defaults to `True`): Whether to write the full name of the object or not.
     """
     if page_info is None:
         page_info = {}
@@ -362,14 +362,15 @@ def autodoc(object_name, package, methods=None, return_anchors=False, page_info=
     Generates the documentation of an object, with a potential filtering on the methods for a class.
 
     Args:
-    - **object_name** (`str`) -- The name of the function or class to document.
-    - **package** (`types.ModuleType`) -- The package of the object.
-    - **methods** (`List[str]`, _optional_) -- A list of methods to document if `obj` is a class. If nothing is passed,
-      all public methods with a new docstring compared to the superclasses are documented. If a list of methods is
-      passed and ou want to add all those methods, the key "all" will add them.
-    - **return_anchors** (`bool`, _optional_, defaults to `False`) -- Whether or not to return the list of anchors
-      generated.
-    - **page_info** (`Dict[str, str]`, *optional*) -- Some information about the page.
+        object_name (`str`): The name of the function or class to document.
+        package (`types.ModuleType`): The package of the object.
+        methods (`List[str]`, *optional*):
+            A list of methods to document if `obj` is a class. If nothing is passed, all public methods with a new
+            docstring compared to the superclasses are documented. If a list of methods is passed and ou want to add
+            all those methods, the key "all" will add them.
+        return_anchors (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the list of anchors generated.
+        page_info (`Dict[str, str]`, *optional*): Some information about the page.
     """
     if page_info is None:
         page_info = {}
@@ -413,10 +414,10 @@ def resolve_links_in_text(text, package, mapping, page_info):
     Resolve links of the form [`SomeClass`] to the link in the documentation to `SomeClass`.
 
     Args:
-    - **text** (`str`) -- The text in which to convert the links.
-    - **package** (`types.ModuleType`) -- The package in which to search objects for.
-    - **mapping** (`Dict[str, str]`) -- The map from anchor names of objects to their page in the documentation.
-    - **page_info** (`Dict[str, str]`) -- Some information about the page.
+        text (`str`): The text in which to convert the links.
+        package (`types.ModuleType`): The package in which to search objects for.
+        mapping (`Dict[str, str]`): The map from anchor names of objects to their page in the documentation.
+        page_info (`Dict[str, str]`): Some information about the page.
     """
     package_name = page_info.get("package_name", package.__name__)
     version = page_info.get("version", "master")

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -76,11 +76,11 @@ def resolve_autodoc(content, package, return_anchors=False, page_info=None):
     Replaces [[autodoc]] special syntax by the corresponding generated documentation in some content.
 
     Args:
-    - **content** (`str`) -- The documentation to treat.
-    - **package** (`types.ModuleType`) -- The package where to look for objects to document.
-    - **return_anchors** (`bool`, *optional*, defaults to `False`) -- Whether or not to return the list of anchors
-      generated.
-    - **page_info** (`Dict[str, str]`, *optional*) -- Some information about the page.
+        content (`str`): The documentation to treat.
+        package (`types.ModuleType`): The package where to look for objects to document.
+        return_anchors (`bool`, *optional*, defaults to `False`):
+            Whether or not to return the list of anchors generated.
+        page_info (`Dict[str, str]`, *optional*): Some information about the page.
     """
     idx_last_heading = None
     is_inside_codeblock = False
@@ -143,10 +143,10 @@ def build_mdx_files(package, doc_folder, output_dir, page_info):
     Build the MDX files for a given package.
 
     Args:
-    - **package** (`types.ModuleType`) -- The package where to look for objects to document.
-    - **doc_folder** (`str` or `os.PathLike`) -- The folder where the doc source files are.
-    - **output_dir** (`str` or `os.PathLike`) -- The folder where to put the files built.
-    - **page_info** (`Dict[str, str]`) -- Some information about the page.
+        package (`types.ModuleType`): The package where to look for objects to document.
+        doc_folder (`str` or `os.PathLike`): The folder where the doc source files are.
+        output_dir (`str` or `os.PathLike`): The folder where to put the files built.
+        page_info (`Dict[str, str]`): Some information about the page.
     """
     doc_folder = Path(doc_folder)
     output_dir = Path(output_dir)
@@ -221,10 +221,10 @@ def resolve_links(doc_folder, package, mapping, page_info):
     folder.
 
     Args:
-    - **doc_folder** (`str` or `os.PathLike`) -- The folder in which to look for files.
-    - **package** (`types.ModuleType`) -- The package in which to search objects for.
-    - **mapping** (`Dict[str, str]`) -- The map from anchor names of objects to their page in the documentation.
-    - **page_info** (`Dict[str, str]`) -- Some information about the page.
+        doc_folder (`str` or `os.PathLike`): The folder in which to look for files.
+        package (`types.ModuleType`): The package in which to search objects for.
+        mapping (`Dict[str, str]`): The map from anchor names of objects to their page in the documentation.
+        page_info (`Dict[str, str]`): Some information about the page.
     """
     doc_folder = Path(doc_folder)
     all_files = list(doc_folder.glob("**/*.mdx"))
@@ -241,7 +241,7 @@ def generate_frontmatter_in_text(text, file_name=None):
     Adds frontmatter & turns markdown headers into markdown headers with hash links.
 
     Args:
-    - **text** (`str`) -- The text in which to convert the links.
+        text (`str`): The text in which to convert the links.
     """
     text = text.split("\n")
     root = None
@@ -288,7 +288,7 @@ def generate_frontmatter(doc_folder):
     Adds frontmatter & turns markdown headers into markdown headers with hash links for all files in a folder.
 
     Args:
-    - **doc_folder** (`str` or `os.PathLike`) -- The folder in which to look for files.
+        doc_folder (`str` or `os.PathLike`): The folder in which to look for files.
     """
     doc_folder = Path(doc_folder)
     all_files = list(doc_folder.glob("**/*.mdx"))

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -83,7 +83,7 @@ def convert_parametype_numpydoc_to_groupsdoc(paramtype):
     Converts parameter type str that is written in numpystyle to groupsstyle (e.g. transformers docs).
 
     Args:
-    paramtype (`str`): The name of the object to document.
+        paramtype (`str`): The name of the object to document.
 
     Example:
     ```py
@@ -116,7 +116,7 @@ def convert_numpydoc_to_groupsdoc(docstring):
     Converts docstring that is written in numpystyle to groupsstyle (e.g. transformers docs).
 
     Args:
-    - **docstring** (`str`) -- Docstring that is written in numpystyle.
+        docstring (`str`): Docstring that is written in numpystyle.
     """
 
     def stringify_arr(arr):


### PR DESCRIPTION
This PR cleans up all docstrings to make them consistent with the way we document things in Markdown.