### PR TITLE
Generate objects.inv file

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -443,7 +443,8 @@ def convert_anchors_mapping_to_sphinx_format(anchors_mapping, package):
         elif hasattr(obj, "__name__") and hasattr(obj, "__qualname__"):
             obj_type = "py:method" if obj.__name__ != obj.__qualname__ else "py:function"
         else:
-            # Default to function
+            # Default to function (this part is never hit when building the docs for Transformers and Datasets)
+            # so it's just to be extra defensive
             obj_type = "py:function"
 
         sphinx_refs.append(f"{anchor} {obj_type} 1 {url}#$ -")

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -444,7 +444,6 @@ def convert_anchors_mapping_to_sphinx_format(anchors_mapping, package):
             obj_type = "py:method" if obj.__name__ != obj.__qualname__ else "py:function"
         else:
             # Default to function
-            print(anchor)
             obj_type = "py:function"
 
         sphinx_refs.append(f"{anchor} {obj_type} 1 {url}#$ -")


### PR DESCRIPTION
This PR adds support to automatically generate an `objects.inv` file in each doc that contains the references to all the anchors of the objects in the doc. This is then used by other projects that use Sphinx to generate their documentation to automatically link to our documentation, see [here](https://sphobjinv.readthedocs.io/en/latest/syntax.html) for more details.

Fixes #81