### PR TITLE
Move objects.inv out of the way during npm build

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -125,6 +125,9 @@ def build_command(args):
                 else:
                     shutil.copy(f, dest)
 
+            # Move the objects.inv file at the root
+            shutil.move(tmp_dir / "kit" / "src" / "routes" / "objects.inv", tmp_dir / "objects.inv")
+
             # Build doc with node
             working_dir = str(tmp_dir / "kit")
             print("Installing node dependencies")
@@ -153,6 +156,8 @@ def build_command(args):
             # Copy result back in the build_dir.
             shutil.rmtree(output_path)
             shutil.copytree(tmp_dir / "kit" / "build", output_path)
+            # Move the objects.inv file back
+            shutil.move(tmp_dir / "objects.inv", output_path / "objects.inv")
 
 
 def build_command_parser(subparsers=None):


### PR DESCRIPTION
This PR removes the `objects.inv` out of the build dir before running `npm build`.