### PR TITLE
Respect repo default branch

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -66,6 +66,22 @@ def locate_kit_folder():
     # TODO for the future if asked for, if we can't locate the kit folder git clone doc-builder and cache it somewhere.
 
 
+def get_default_branch_name(repo_folder):
+    try:
+        p = subprocess.run(
+            ["git", "branch"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            encoding="utf-8",
+            cwd=repo_folder,
+        )
+        branches = p.stdout.strip()
+        return "master" if "master" in branches else "main"
+    except Exception:
+        return "main"
+
+
 def build_command(args):
     if args.html:
         # Error at the beginning if node is not properly installed.
@@ -83,7 +99,7 @@ def build_command(args):
         version = module.__version__
 
         if "dev" in version:
-            version = "master"
+            version = get_default_branch_name(args.path_to_docs)
         else:
             version = f"v{version}"
     else:

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -26,13 +26,13 @@ def update_versions_file(build_path, version):
     Insert new version into _versions.yml file of the library
     Assumes that _versions.yml exists and has its first entry as master version
     """
-    if version == "master":
+    if version in ["main", "master"]:
         return
     with open(os.path.join(build_path, "_versions.yml"), "r") as versions_file:
         versions = yaml.load(versions_file, yaml.FullLoader)
 
-        if versions[0]["version"] != "master":
-            raise ValueError(f"{build_path}/_versions.yml does not contain master version")
+        if versions[0]["version"] not in ["main", "master"]:
+            raise ValueError(f"{build_path}/_versions.yml does not contain a dev version")
 
         master_version, sem_versions = versions[0], versions[1:]
         new_version = {"version": version}


### PR DESCRIPTION
We hardcode `"master"` for the version in development but we should use the repo default branch (for instance `"main"`). This PR addresses that.