### PR TITLE
Add integration test for doc building

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -1,0 +1,53 @@
+name: Accelerate doc build
+
+on: [pull_request]
+
+jobs:
+  integration_doc_build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-builder'
+          path: doc-builder
+      
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/accelerate'
+          path: accelerate
+
+      - name: Loading cache.
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: ~/.cache/pip
+          key: v1-test_build_doc
+          restore-keys: |
+            v1-test_build_doc-${{ hashFiles('setup.py') }}
+            v1-test_build_doc
+
+      - name: Setup environment
+        run: |
+          cd doc-builder
+          pip install .
+          cd ..
+
+          cd accelerate
+          pip install .[quality]
+          cd ..
+          
+      - name: Make documentation
+        run: |
+          cd doc-builder &&
+          doc-builder build accelerate ../accelerate/docs/source --build_dir ../build_dir --clean --html &&
+          cd ..
+        env:
+          NODE_OPTIONS: --max-old-space-size=6656


### PR DESCRIPTION
This PR adds a new GitHub action that builds the doc of Accelerate on each PR. This makes a nice integration test that stays short.