### PR TITLE
Git clone for kit

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include kit *

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# Doc-builder package setup.
+# The line above is checked by some of the utilities in this repo, do not change it.
+
 from setuptools import find_packages, setup
 
 install_requires = ["tqdm", "pyyaml", "packaging", "nbformat"]

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -158,7 +158,6 @@ def get_cached_repo():
         _ = subprocess.run(
             "git clone https://github.com/huggingface/doc-builder.git".split(),
             stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
             check=True,
             encoding="utf-8",
             cwd=DOC_BUILDER_CACHE,

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -16,10 +16,19 @@
 import importlib.machinery
 import importlib.util
 import os
+import shutil
 import subprocess
+from pathlib import Path
 
 import yaml
 from packaging import version as package_version
+
+
+hf_cache_home = os.path.expanduser(
+    os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
+)
+default_cache_path = os.path.join(hf_cache_home, "doc_builder")
+DOC_BUILDER_CACHE = os.getenv("DOC_BUILDER_CACHE", default_cache_path)
 
 
 def get_default_branch_name(repo_folder):
@@ -97,3 +106,71 @@ def get_doc_config():
     Returns the `doc_config` if it has been loaded.
     """
     return doc_config
+
+
+def is_doc_builder_repo(path):
+    """
+    Detects whether a folder is the `doc_builder` or not.
+    """
+    setup_file = Path(path) / "setup.py"
+    if not setup_file.exists():
+        return False
+    with open(os.path.join(path, "setup.py")) as f:
+        first_line = f.readline()
+    return first_line == "# Doc-builder package setup.\n"
+
+
+def locate_kit_folder():
+    """
+    Returns the location of the `kit` folder of `doc-builder`.
+
+    Will clone the doc-builder repo and cache it, if it's not found.
+    """
+    # First try: let's search where the module is.
+    repo_root = Path(__file__).parent.parent.parent
+    kit_folder = repo_root / "kit"
+    if kit_folder.is_dir():
+        return kit_folder
+
+    # Second try, maybe we are inside the doc-builder repo
+    current_dir = Path.cwd()
+    while current_dir.parent != current_dir and not (current_dir / ".git").is_dir():
+        current_dir = current_dir.parent
+    kit_folder = current_dir / "kit"
+    if kit_folder.is_dir() and is_doc_builder_repo(current_dir):
+        return kit_folder
+
+    # Otherwise, let's clone the repo and cache it.
+    return Path(get_cached_repo()) / "kit"
+
+
+def get_cached_repo():
+    """
+    Clone and cache the `doc-builder` repo.
+    """
+    os.makedirs(DOC_BUILDER_CACHE, exist_ok=True)
+    cache_repo_path = Path(DOC_BUILDER_CACHE) / "doc-builder-repo"
+    if not cache_repo_path.is_dir():
+        print(
+            "To build the HTML doc, we need the kit subfolder of the `doc-builder` repo. Cloning it and caching at "
+            f"{cache_repo_path}."
+        )
+        _ = subprocess.run(
+            "git clone https://github.com/huggingface/doc-builder.git".split(),
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            encoding="utf-8",
+            cwd=DOC_BUILDER_CACHE,
+        )
+        shutil.move(Path(DOC_BUILDER_CACHE) / "doc-builder", cache_repo_path)
+    else:
+        _ = subprocess.run(
+            ["git", "pull"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            check=True,
+            encoding="utf-8",
+            cwd=cache_repo_path,
+        )
+    return cache_repo_path


### PR DESCRIPTION
The kit subfolder can't be packaged with `doc-builder` as it makes a tar file that is too heavy (105MB) and PyPi refuses it. This PR removes it from the package (deletion of the manifest file) and introduces a mechanism for cloning and caching the repo to access the kit subfolder.