### PR TITLE
Fix indentation in some nested list cases

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -519,11 +519,14 @@ def remove_indent(text):
             elif len(current_indents) > 0:
                 # Let's find the proper level of indentation
                 level = len(current_indents) - 1
-                while level >= 0 and current_indents[level] != indent:
+                while level >= 0 and current_indents[level] > indent:
                     level -= 1
                 current_indents = current_indents[: level + 1]
                 if level >= 0:
-                    new_indents = new_indents[:level]
+                    if current_indents[level] < indent:
+                        new_indents = new_indents[: level + 1]
+                    else:
+                        new_indents = new_indents[:level]
                     new_indent = 0 if len(new_indents) == 0 else new_indents[-1]
                     lines[idx] = " " * new_indent + line[indent:]
                     new_indents.append(new_indent)

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -630,6 +630,37 @@ Loulou
 Now we are out of the list.
 """
 
+        example1b = """
+    Lala
+    Loulou
+
+    - This is a list.
+      This item is long.
+    - This is the second item.
+          - This list is nested
+          - With two items.
+        Now we are at the nested level
+
+    - We return to the previous level.
+
+    Now we are out of the list.
+"""
+        expected1b = """
+Lala
+Loulou
+
+- This is a list.
+  This item is long.
+- This is the second item.
+  - This list is nested
+  - With two items.
+  Now we are at the nested level
+
+- We return to the previous level.
+
+Now we are out of the list.
+"""
+
         example2 = """
 [[autodoc]] transformers.BertModel
     - forward
@@ -672,6 +703,7 @@ def function(x):
 Loulou
 """
         self.assertEqual(remove_indent(example1), expected1)
+        self.assertEqual(remove_indent(example1b), expected1b)
         self.assertEqual(remove_indent(example2), expected2)
         self.assertEqual(remove_indent(example3), expected3)
 


### PR DESCRIPTION
This PR fixes a wrong indent done in `remove_indent` which I believe is the cause for the documentaiton of [`from_pretrained`](https://huggingface.co/docs/transformers/master/en/main_classes/model#transformers.PreTrainedModel.from_pretrained) in Transformers to be truncated.

The crux of the issue is that a docstring like this:
```
    Lala
    Loulou

    - This is a list.
      This item is long.
    - This is the second item.
          - This list is nested
          - With two items.
        Now we are at the nested level
```

is currently reindented like this:

```
Lala
Loulou

- This is a list.
  This item is long.
- This is the second item.
  - This list is nested
  - With two items.
Now we are at the nested level
```
and so the list of parameters is interrupted before its end. This PR fixes it and adds a new test.