### PR TITLE
Preparation for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__/
 # Build
 build
 dist
+src/hf_doc_builder.egg-info
 src/doc_builder.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include kit/*
+recursive-include kit/src *

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras["dev"] = extras["all"]
 
 
 setup(
-    name="doc-builder",
+    name="hf-doc-builder",
     version="0.1.0.dev0",
     author="Hugging Face, Inc.",
     author_email="sylvain@huggingface.co",


### PR DESCRIPTION
This PR prepares the packaging of `doc-builder` by:
- updating the MANIFEST to include the kit src subfolder but no other subfolders.
- changing the name to `hf-doc-builder` (as `doc-builder` is too close to a name chosen on Pypi)

To avoid changing the workflow of people, the CLI tool and the module are still going to be named `doc-builder`, but the package will be installable from Pypi via `pip install hf-doc-builder`.