### PR TITLE
Switch default branch to main and fix tests

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -136,9 +136,9 @@ jobs:
             if [[ `git status --porcelain` ]]; then
               git add ${{ inputs.notebook_folder }}
               git commit -m "Updated ${{ inputs.package }} doc notebooks with commit ${{ inputs.commit_sha }} \n\nSee: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
-              git push origin master ||
-              (echo "Failed on the first try, rebasing and pushing again" && git pull --rebase && git push origin master) ||
-              (echo "Failed on the second try, rebasing and pushing again" && git pull --rebase && git push origin master)
+              git push origin main ||
+              (echo "Failed on the first try, rebasing and pushing again" && git pull --rebase && git push origin main) ||
+              (echo "Failed on the second try, rebasing and pushing again" && git pull --rebase && git push origin main)
             else
               echo "No diff in the notebooks."
             fi

--- a/kit/README.md
+++ b/kit/README.md
@@ -5,7 +5,7 @@
 - Install `nodejs` / `npm`
 - Run `npm install`
 - Copy the mdx docs into the routes folder
-- set `DOCS_VERSION` in the env to the correct prefix (eg `master`)
+- set `DOCS_VERSION` in the env to the correct prefix (eg `main`)
 - set `DOCS_LANGUAGE` in the env to the correct language (eg `en`)
 - Run `npm run run build`
 
@@ -13,4 +13,4 @@ The generated html files and assets are in the `build` folder.
 
 ## Previewing the docs
 
-Instead of `npm run build`, do `npm run dev`. Then go to http://localhost:3000 (or replace `master` with the correct prefix).
+Instead of `npm run build`, do `npm run dev`. Then go to http://localhost:3000 (or replace `main` with the correct prefix).

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -39,7 +39,7 @@ const config = {
 				: "/docs/" +
 				  (process.env.DOCS_LIBRARY || "transformers") +
 				  "/" +
-				  (process.env.DOCS_VERSION || "master") +
+				  (process.env.DOCS_VERSION || "main") +
 				  "/" +
 				  (process.env.DOCS_LANGUAGE || "en")
 		}

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -280,7 +280,7 @@ def get_source_link(obj, page_info):
     Returns the link to the source code of an object on GitHub.
     """
     package_name = page_info["package_name"]
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     base_link = f"https://github.com/huggingface/{package_name}/blob/{version}/src/"
     module = obj.__module__.replace(".", "/")
     line_number = inspect.getsourcelines(obj)[1]
@@ -438,7 +438,7 @@ def resolve_links_in_text(text, package, mapping, page_info):
         page_info (`Dict[str, str]`): Some information about the page.
     """
     package_name = page_info.get("package_name", package.__name__)
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     language = page_info.get("language", "en")
 
     prefix = f"/docs/{package_name}/{version}/{language}/"

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -49,7 +49,7 @@ def resolve_open_in_colab(content, page_info):
 
     package_name = page_info["package_name"]
     page_name = Path(page_info["page"]).stem
-    nb_prefix = f"/github/huggingface/notebooks/blob/master/{package_name}_doc/"
+    nb_prefix = f"/github/huggingface/notebooks/blob/main/{package_name}_doc/"
     nb_prefix_colab = f"https://colab.research.google.com{nb_prefix}"
     nb_prefix_awsstudio = f"https://studiolab.sagemaker.aws/import{nb_prefix}"
     links = [
@@ -355,7 +355,7 @@ def build_doc(
     doc_folder,
     output_dir,
     clean=True,
-    version="master",
+    version="main",
     language="en",
     notebook_dir=None,
     is_python_module=False,
@@ -371,7 +371,7 @@ def build_doc(
             The folder in which to put the built documentation. Will be created if it does not exist.
         clean (`bool`, *optional*, defaults to `True`):
             Whether or not to delete the content of the `output_dir` if that directory exists.
-        version (`str`, *optional*, defaults to `"master"`): The name of the version of the doc.
+        version (`str`, *optional*, defaults to `"main"`): The name of the version of the doc.
         language (`str`, *optional*, defaults to `"en"`): The language of the doc.
         notebook_dir (`str` or `os.PathLike`, *optional*):
             If provided, where to save the notebooks generated from the doc file with an [[open-in-colab]] marker.

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -171,7 +171,7 @@ def build_command_parser(subparsers=None):
         "--version",
         type=str,
         help="Version of the documentation to generate. Will default to the version of the package module (using "
-        "`master` for a version containing dev).",
+        "`main` for a version containing dev).",
     )
     parser.add_argument("--notebook_dir", type=str, help="Where to save the generated notebooks.", default=None)
     parser.add_argument("--html", action="store_true", help="Whether or not to build HTML files instead of MDX files.")

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -225,7 +225,7 @@ def preview_command_parser(subparsers=None):
         "documentation files should be indicated here.",
     )
     parser.add_argument("--language", type=str, help="Language of the documentation to generate", default="en")
-    parser.add_argument("--version", type=str, help="Version of the documentation to generate", default="master")
+    parser.add_argument("--version", type=str, help="Version of the documentation to generate", default="main")
     parser.add_argument(
         "--not_python_module",
         action="store_true",

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -83,7 +83,7 @@ def convert_img_links(text, page_info):
     if "package_name" not in page_info:
         raise ValueError("`page_info` must contain at least the package_name.")
     package_name = page_info["package_name"]
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     language = page_info.get("language", "en")
 
     _re_img_link = re.compile(r"(src=\"|\()/imgs/")

--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -92,7 +92,7 @@ def convert_rst_links(text, page_info):
     if "package_name" not in page_info:
         raise ValueError("`page_info` must contain at least the package_name.")
     package_name = page_info["package_name"]
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     language = page_info.get("language", "en")
     no_prefix = page_info.get("no_prefix", False)
 
@@ -116,7 +116,7 @@ def convert_rst_links(text, page_info):
 
     # Links with a prefix
     # TODO: when it exists, use the API to deal with prefix links properly.
-    prefix = f"https://github.com/huggingface/{package_name}/tree/master/"
+    prefix = f"https://github.com/huggingface/{package_name}/tree/main/"
     text = _re_prefix_links.sub(rf"[\1]({prefix}\2)", text)
     # Other links
     text = _re_links.sub(r"[\1](\2)", text)
@@ -220,7 +220,7 @@ def convert_rst_blocks(text, page_info):
     if "package_name" not in page_info:
         raise ValueError("`page_info` must contain at least the package_name.")
     package_name = page_info["package_name"]
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     language = page_info.get("language", "en")
 
     lines = text.split("\n")

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -46,7 +46,7 @@ def expand_links(content, page_info):
     Expand links relative to the documentation to full links to the hf.co website.
     """
     package_name = page_info["package_name"]
-    version = page_info.get("version", "master")
+    version = page_info.get("version", "main")
     language = page_info.get("language", "en")
     page = str(page_info["page"])
 

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -55,7 +55,7 @@ def get_default_branch_name(repo_folder):
 def update_versions_file(build_path, version, doc_folder):
     """
     Insert new version into _versions.yml file of the library
-    Assumes that _versions.yml exists and has its first entry as master version
+    Assumes that _versions.yml exists and has its first entry as main version
     """
     main_branch = get_default_branch_name(doc_folder)
     if version == main_branch:
@@ -66,7 +66,7 @@ def update_versions_file(build_path, version, doc_folder):
         if versions[0]["version"] != main_branch:
             raise ValueError(f"{build_path}/_versions.yml does not contain a {main_branch} version")
 
-        master_version, sem_versions = versions[0], versions[1:]
+        main_version, sem_versions = versions[0], versions[1:]
         new_version = {"version": version}
         did_insert = False
         for i, value in enumerate(sem_versions):
@@ -81,7 +81,7 @@ def update_versions_file(build_path, version, doc_folder):
             sem_versions.append(new_version)
 
     with open(os.path.join(build_path, "_versions.yml"), "w") as versions_file:
-        versions_updated = [master_version] + sem_versions
+        versions_updated = [main_version] + sem_versions
         yaml.dump(versions_updated, versions_file)
 
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -35,11 +35,11 @@ from doc_builder.autodoc import (
     resolve_links_in_text,
 )
 from transformers import BertModel, BertTokenizer, BertTokenizerFast
-from transformers.file_utils import PushToHubMixin
+from transformers.utils import PushToHubMixin
 
 
 # This is dynamic since the Transformers library is not frozen.
-TEST_LINE_NUMBER = inspect.getsourcelines(transformers.file_utils.ModelOutput)[1]
+TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 
 TEST_DOCSTRING = """Constructs a BERTweet tokenizer, using Byte-Pair-Encoding.
 
@@ -135,7 +135,7 @@ Builds something very cool!
 
 class AutodocTester(unittest.TestCase):
     test_source_link = (
-        f"https://github.com/huggingface/transformers/blob/master/src/transformers/file_utils.py#L{TEST_LINE_NUMBER}"
+        f"https://github.com/huggingface/transformers/blob/main/src/transformers/utils/generic.py#L{TEST_LINE_NUMBER}"
     )
 
     def test_find_object_in_package(self):
@@ -161,7 +161,7 @@ class AutodocTester(unittest.TestCase):
     def test_get_shortest_path(self):
         self.assertEqual(get_shortest_path(BertModel, transformers), "transformers.BertModel")
         self.assertEqual(get_shortest_path(BertModel.forward, transformers), "transformers.BertModel.forward")
-        self.assertEqual(get_shortest_path(PushToHubMixin, transformers), "transformers.file_utils.PushToHubMixin")
+        self.assertEqual(get_shortest_path(PushToHubMixin, transformers), "transformers.utils.PushToHubMixin")
 
     def test_get_type_name(self):
         self.assertEqual(get_type_name(str), "str")
@@ -242,13 +242,13 @@ Users should refer to this superclass for more information regarding those metho
 
     def test_get_source_link(self):
         page_info = {"package_name": "transformers"}
-        self.assertEqual(get_source_link(transformers.file_utils.ModelOutput, page_info), self.test_source_link)
+        self.assertEqual(get_source_link(transformers.utils.ModelOutput, page_info), self.test_source_link)
 
     def test_document_object(self):
         page_info = {"package_name": "transformers"}
 
         model_output_doc = """
-<docstring><name>class transformers.file_utils.ModelOutput</name><anchor>transformers.file_utils.ModelOutput</anchor><source>"""
+<docstring><name>class transformers.utils.ModelOutput</name><anchor>transformers.utils.ModelOutput</anchor><source>"""
         model_output_doc += f"{self.test_source_link}"
         model_output_doc += """</source><parameters>""</parameters></docstring>
 
@@ -265,7 +265,7 @@ tuple before.
 
 
 """
-        self.assertEqual(document_object("file_utils.ModelOutput", transformers, page_info)[0], model_output_doc)
+        self.assertEqual(document_object("utils.ModelOutput", transformers, page_info)[0], model_output_doc)
 
     def test_find_document_methods(self):
         self.assertListEqual(find_documented_methods(BertModel), ["forward"])
@@ -329,9 +329,9 @@ tuple before.
                 page_info,
             ),
             (
-                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward) "
-                "and [BertTokenizer](/docs/transformers/master/en/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
+                "Link to [BertModel](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel), "
+                "[BertModel.forward()](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel.forward) "
+                "and [BertTokenizer](/docs/transformers/main/en/bert.html#transformers.BertTokenizer) as well as `SomeClass`."
             ),
         )
 
@@ -343,8 +343,8 @@ tuple before.
                 page_info,
             ),
             (
-                "Link to [BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
+                "Link to [BertModel](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel), "
+                "[forward()](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel.forward)."
             ),
         )
 
@@ -356,8 +356,8 @@ tuple before.
                 page_info,
             ),
             (
-                "Link to [transformers.BertModel](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel), "
-                "[transformers.BertModel.forward()](/docs/transformers/master/en/model_doc/bert.html#transformers.BertModel.forward)."
+                "Link to [transformers.BertModel](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel), "
+                "[transformers.BertModel.forward()](/docs/transformers/main/en/model_doc/bert.html#transformers.BertModel.forward)."
             ),
         )
 

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -33,12 +33,12 @@ class BuildDocTester(unittest.TestCase):
 <DocNotebookDropdown
   classNames="absolute z-10 right-0 top-0"
   options={[
-    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/quicktour.ipynb"},
-    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/quicktour.ipynb"},
-    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/quicktour.ipynb"},
-    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/quicktour.ipynb"},
-    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/pytorch/quicktour.ipynb"},
-    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/transformers_doc/tensorflow/quicktour.ipynb"},
+    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/tensorflow/quicktour.ipynb"},
+    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/tensorflow/quicktour.ipynb"},
 ]} />
 """
         self.assertEqual(

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -220,20 +220,20 @@ third line``.
 
         self.assertEqual(
             convert_rst_links("This is a prefixed :prefix_link:`link <url>`", page_info),
-            "This is a prefixed [link](https://github.com/huggingface/transformers/tree/master/url)",
+            "This is a prefixed [link](https://github.com/huggingface/transformers/tree/main/url)",
         )
         self.assertEqual(
             convert_rst_links("This is a prefixed :prefix_link:`link <url>`", page_info),
-            "This is a prefixed [link](https://github.com/huggingface/transformers/tree/master/url)",
+            "This is a prefixed [link](https://github.com/huggingface/transformers/tree/main/url)",
         )
 
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page`.", page_info),
-            "This is a link to an inner page [page](/docs/transformers/master/en/page).",
+            "This is a link to an inner page [page](/docs/transformers/main/en/page).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner page :doc:`page name <page ref>`.", page_info),
-            "This is a link to an inner page [page name](/docs/transformers/master/en/page ref).",
+            "This is a link to an inner page [page name](/docs/transformers/main/en/page ref).",
         )
 
         self.assertEqual(
@@ -248,11 +248,11 @@ third line``.
         page_info["page"] = "model_doc/bert.html"
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section`.", page_info),
-            "This is a link to an inner section [section](/docs/transformers/master/en/model_doc/bert#section).",
+            "This is a link to an inner section [section](/docs/transformers/main/en/model_doc/bert#section).",
         )
         self.assertEqual(
             convert_rst_links("This is a link to an inner section :ref:`section name <section ref>`.", page_info),
-            "This is a link to an inner section [section name](/docs/transformers/master/en/model_doc/bert#section ref).",
+            "This is a link to an inner section [section name](/docs/transformers/main/en/model_doc/bert#section ref).",
         )
 
     def test_convert_rst_links_with_version_and_lang(self):

--- a/tests/test_convert_to_notebook.py
+++ b/tests/test_convert_to_notebook.py
@@ -156,11 +156,11 @@ End
         page_info = {"package_name": "transformers", "page": "quicktour.html"}
         self.assertEqual(
             expand_links("Checkout the [task summary](task-summary)", page_info),
-            "Checkout the [task summary](https://huggingface.co/docs/transformers/master/en/task-summary)",
+            "Checkout the [task summary](https://huggingface.co/docs/transformers/main/en/task-summary)",
         )
         self.assertEqual(
-            expand_links("Checkout the [`Trainer`](/docs/transformers/master/en/trainer#Trainer)", page_info),
-            "Checkout the [`Trainer`](https://huggingface.co/docs/transformers/master/en/trainer#Trainer)",
+            expand_links("Checkout the [`Trainer`](/docs/transformers/main/en/trainer#Trainer)", page_info),
+            "Checkout the [`Trainer`](https://huggingface.co/docs/transformers/main/en/trainer#Trainer)",
         )
 
         page_info = {"package_name": "datasets", "page": "quicktour.html", "version": "stable", "language": "fr"}
@@ -172,5 +172,5 @@ End
         page_info = {"package_name": "transformers", "page": "data/quicktour.html"}
         self.assertEqual(
             expand_links("Checkout the [task summary](task-summary)", page_info),
-            "Checkout the [task summary](https://huggingface.co/docs/transformers/master/en/data/task-summary)",
+            "Checkout the [task summary](https://huggingface.co/docs/transformers/main/en/data/task-summary)",
         )


### PR DESCRIPTION
This PR changes the default branch to "main" everywhere master is used, in particular for the notebook building job (for the rest it's the default in internal functions, which is trumped by the version set when building the doc anyway).

It also fixes a few tests due to the recent reorganization in Transformers splitting `file_utils` in several submodules.