### PR TITLE
Skip package install if --not_python_module is provided

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -72,7 +72,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.additional_args }}" != "--not_python_module" ]
+          if [ "${{ inputs.additional_args }}" != *"--not_python_module"* ]
           then
             cd ${{ inputs.package }}
             pip install .[dev]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -72,7 +72,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.additional_args }}" != *"--not_python_module"* ]
+          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
           then
             cd ${{ inputs.package }}
             pip install .[dev]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -9,7 +9,7 @@ on:
       package:
         required: true
         type: string
-      path_to_doc:
+      path_to_docs:
         type: string
       notebook_folder:
         type: string
@@ -72,8 +72,11 @@ jobs:
           pip install .
           cd ..
 
-          cd ${{ inputs.package }}
-          pip install .[dev]
+          if [ "${{ inputs.additional_args }}" != "--not_python_module" ]
+          then
+            cd ${{ inputs.package }}
+            pip install .[dev]
+          fi
           cd ..
 
       - name: Setup git

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -63,7 +63,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.additional_args }}" != *"--not_python_module"* ]
+          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
           then
             cd ${{ inputs.package }}
             pip install .[dev]

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -63,7 +63,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.additional_args }}" != "--not_python_module" ]
+          if [ "${{ inputs.additional_args }}" != *"--not_python_module"* ]
           then
             cd ${{ inputs.package }}
             pip install .[dev]

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,7 +12,7 @@ on:
       package:
         required: true
         type: string
-      path_to_doc:
+      path_to_docs:
         type: string
       # supply --not_python_module for HF Course
       additional_args:
@@ -63,8 +63,11 @@ jobs:
           pip install .
           cd ..
 
-          cd ${{ inputs.package }}
-          pip install .[dev]
+          if [ "${{ inputs.additional_args }}" != "--not_python_module" ]
+          then
+            cd ${{ inputs.package }}
+            pip install .[dev]
+          fi
           cd ..
 
       - name: Setup git

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -62,7 +62,7 @@ def build_command(args):
                 "the doc-builder package installed, so you need to run the command from inside the doc-builder repo."
             )
 
-    if args.not_python_module:
+    if args.not_python_module and args.version is None:
         version = get_default_branch_name(args.path_to_docs)
     elif args.version is None:
         module = importlib.import_module(args.library_name)


### PR DESCRIPTION
This PR adds logic to skip the `pip install .[dev]` step in the doc building templates if the `--not_python_module` argument is provided. This should solve the failing build for the course [here](https://github.com/huggingface/course/runs/5690210360?check_suite_focus=true)