### PR TITLE
Fixes for the doc-builder style command

### DIFF
--- a/src/doc_builder/commands/style.py
+++ b/src/doc_builder/commands/style.py
@@ -17,9 +17,12 @@
 import argparse
 
 from doc_builder import style_doc_files
+from doc_builder.utils import read_doc_config
 
 
 def style_command(args):
+    if args.path_to_docs is not None:
+        read_doc_config(args.path_to_docs)
     changed = style_doc_files(*args.files, max_len=args.max_len, check_only=args.check_only)
     if args.check_only and len(changed) > 0:
         raise ValueError(f"{len(changed)} files should be restyled!")
@@ -34,6 +37,7 @@ def style_command_parser(subparsers=None):
         parser = argparse.ArgumentParser("Doc Builder style command")
 
     parser.add_argument("files", nargs="+", help="The file(s) or folder(s) to restyle.")
+    parser.add_argument("--path_to_docs", type=str, help="The path to the doc source folder if using the config.")
     parser.add_argument("--max_len", type=int, default=119, help="The maximum length of lines.")
     parser.add_argument("--check_only", action="store_true", help="Whether to only check and not fix styling issues.")
 

--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -518,9 +518,6 @@ def style_doc_files(*files, max_len=119, check_only=False):
         else:
             warnings.warn(f"Ignoring {file} because it's not a py or an mdx file or a folder.")
     if len(black_errors) > 0:
-        raise ValueError(
-            "Some code examples can't be interpreted by black, which means they aren't regular python:\n\n"
-        )
         black_message = "\n\n".join(black_errors)
         raise ValueError(
             "Some code examples can't be interpreted by black, which means they aren't regular python:\n\n"

--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -39,7 +39,7 @@ DOCTEST_PROMPTS = [">>>", "..."]
 
 def get_black_avoid_patterns():
     patterns = {"===PT-TF-SPLIT===": "### PT-TF-SPLIT"}
-    doc_config = get_doc_config
+    doc_config = get_doc_config()
     if doc_config is not None and hasattr(doc_config, "black_avoid_patterns"):
         patterns.update(doc_config.black_avoid_patterns)
     return patterns
@@ -518,6 +518,9 @@ def style_doc_files(*files, max_len=119, check_only=False):
         else:
             warnings.warn(f"Ignoring {file} because it's not a py or an mdx file or a folder.")
     if len(black_errors) > 0:
+        raise ValueError(
+            "Some code examples can't be interpreted by black, which means they aren't regular python:\n\n"
+        )
         black_message = "\n\n".join(black_errors)
         raise ValueError(
             "Some code examples can't be interpreted by black, which means they aren't regular python:\n\n"


### PR DESCRIPTION
This PR introduces two small fixes to make the doc-builder style command work on Transformers (it needs to access the doc-builder config as we have some specific patterns to deal with in the generic docstrings)