### PR TITLE
Revert "Skip package install if --not_python_module is provided"

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -9,7 +9,7 @@ on:
       package:
         required: true
         type: string
-      path_to_docs:
+      path_to_doc:
         type: string
       notebook_folder:
         type: string
@@ -72,11 +72,8 @@ jobs:
           pip install .
           cd ..
 
-          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
-          then
-            cd ${{ inputs.package }}
-            pip install .[dev]
-          fi
+          cd ${{ inputs.package }}
+          pip install .[dev]
           cd ..
 
       - name: Setup git

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,7 +12,7 @@ on:
       package:
         required: true
         type: string
-      path_to_docs:
+      path_to_doc:
         type: string
       # supply --not_python_module for HF Course
       additional_args:
@@ -63,11 +63,8 @@ jobs:
           pip install .
           cd ..
 
-          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
-          then
-            cd ${{ inputs.package }}
-            pip install .[dev]
-          fi
+          cd ${{ inputs.package }}
+          pip install .[dev]
           cd ..
 
       - name: Setup git


### PR DESCRIPTION
Reverts huggingface/doc-builder#154

The use of a bash builtin for string comparison is causing the doc builds to fails for libs like `datasets` : https://stackoverflow.com/questions/12230690/string-comparison-in-bash-not-found