### PR TITLE
Skip package installation if `--not_python_module` provided

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -65,6 +65,7 @@ jobs:
           fi
 
       - name: Setup environment
+        shell: bash
         run: |
           pip uninstall -y doc-builder
           cd doc-builder

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -9,7 +9,7 @@ on:
       package:
         required: true
         type: string
-      path_to_doc:
+      path_to_docs:
         type: string
       notebook_folder:
         type: string
@@ -72,8 +72,11 @@ jobs:
           pip install .
           cd ..
 
-          cd ${{ inputs.package }}
-          pip install .[dev]
+          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          then
+            cd ${{ inputs.package }}
+            pip install .[dev]
+          fi
           cd ..
 
       - name: Setup git

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -53,6 +53,7 @@ jobs:
           fi
 
       - name: Setup environment
+        shell: bash
         run: |
           rm -rf doc-build-dev
           git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.write_token }}@github.com/huggingface/doc-build-dev
@@ -63,18 +64,11 @@ jobs:
           pip install .
           cd ..
 
-          case "${{ inputs.additional_args }}" in
-
-              *"--not_python_module"*)
-                  echo "--not_python_module provided, skipping installation ..."
-                  ;;
-              *)
-                  echo "Installing package depdendencies ..."
-                  cd ${{ inputs.package }}
-                  pip install .[dev]
-                  ;;
-          esac
-
+          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          then
+            cd ${{ inputs.package }}
+            pip install .[dev]
+          fi
           cd ..
 
       - name: Setup git

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -63,8 +63,9 @@ jobs:
           pip install .
           cd ..
 
-          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          if ! grep -q "\--not_python_module" <<< "${{ inputs.additional_args }}";
           then
+            echo "Installing package dependencies ..."
             cd ${{ inputs.package }}
             pip install .[dev]
           fi

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,7 +12,7 @@ on:
       package:
         required: true
         type: string
-      path_to_doc:
+      path_to_docs:
         type: string
       # supply --not_python_module for HF Course
       additional_args:
@@ -63,8 +63,11 @@ jobs:
           pip install .
           cd ..
 
-          cd ${{ inputs.package }}
-          pip install .[dev]
+          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          then
+            cd ${{ inputs.package }}
+            pip install .[dev]
+          fi
           cd ..
 
       - name: Setup git

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -63,12 +63,18 @@ jobs:
           pip install .
           cd ..
 
-          if ! grep -q "\--not_python_module" <<< "${{ inputs.additional_args }}";
-          then
-            echo "Installing package dependencies ..."
-            cd ${{ inputs.package }}
-            pip install .[dev]
-          fi
+          case "${{ inputs.additional_args }}" in
+
+              *"--not_python_module"*)
+                  echo "--not_python_module provided, skipping installation ..."
+                  ;;
+              *)
+                  echo "Installing package depdendencies ..."
+                  cd ${{ inputs.package }}
+                  pip install .[dev]
+                  ;;
+          esac
+
           cd ..
 
       - name: Setup git


### PR DESCRIPTION
This PR reverts the revert in #161 to properly set the shell to `bash` when we run the `Setup environment` step. As far as I can tell, `ubuntu-latest` actually runs `dash` by default, so it couldn't parse the double `[[` brackets that we use for substring matching, e.g. in https://github.com/huggingface/doc-builder/issues/160 we encounter the following error in the CI:

```
/__w/_temp/75bf1d4b-4452-4c1d-8927-838e5094620a.sh: 7: [[: not found
```

Setting `shell: bash` in the CI step resolves the issue and here are two successful builds of the docs on `datasets` and `course` based on this branch:

* https://github.com/huggingface/datasets/runs/5718880095?check_suite_focus=true
* https://github.com/huggingface/course/runs/5719043810?check_suite_focus=true (the add doc comment step fails, but that's because we need to deploy `moon-landing` with some updates)