### PR TITLE
Support anchor names for inherited methods

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -15,7 +15,6 @@
 
 
 import importlib
-import json
 import os
 import re
 import shutil

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -394,8 +394,6 @@ def build_doc(
 
     package = importlib.import_module(package_name) if is_python_module else None
     anchors_mapping, source_files_mapping = build_mdx_files(package, doc_folder, output_dir, page_info)
-    with open(os.path.join(output_dir, "anchors.json"), "w") as f:
-        f.write(json.dumps(anchors_mapping))
     if not watch_mode:
         sphinx_refs = check_toc_integrity(doc_folder, output_dir)
         sphinx_refs.extend(convert_anchors_mapping_to_sphinx_format(anchors_mapping, package))

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -301,7 +301,7 @@ before.
             anchors,
             [
                 "transformers.BertTokenizer",
-                "transformers.BertTokenizer.__call__",
+                ("transformers.BertTokenizer.__call__", "transformers.PreTrainedTokenizerBase.__call__"),
                 "transformers.BertTokenizer.build_inputs_with_special_tokens",
                 "transformers.BertTokenizer.convert_tokens_to_string",
                 "transformers.BertTokenizer.create_token_type_ids_from_sequences",
@@ -310,7 +310,13 @@ before.
         )
 
         _, anchors, _ = autodoc("BertTokenizer", transformers, methods=["__call__"], return_anchors=True)
-        self.assertListEqual(anchors, ["transformers.BertTokenizer", "transformers.BertTokenizer.__call__"])
+        self.assertListEqual(
+            anchors,
+            [
+                "transformers.BertTokenizer",
+                ("transformers.BertTokenizer.__call__", "transformers.PreTrainedTokenizerBase.__call__"),
+            ],
+        )
 
     def test_resolve_links_in_text(self):
         page_info = {"package_name": "transformers"}


### PR DESCRIPTION
There is a problem in the way anchors are generated for methods of classes that are inherited from a superclass. The problem was first reported in [this PR](https://github.com/huggingface/datasets/pull/3999) but it happens more broadly when you have an object (let's say `BertTokenizer`) and a method (let's say the `__call__` magic method) that you are asking in the documentation, but that method's documentation is actually written in the superclass (in our example `PreTrainedTokenizerBase`).

Currently, doc-builder will create the documentation of this method under the anchor `PreTrainedTokenizerBase.__call__` which has two problems:
- if we were in a page with two different tokenizers documenting that method, we would get the same anchor twice
- more annoying is that this method can never be linked to via inter-links. When asking for a link to this method via ``[`BertTokenizer.__call__`]``, we get a link to the `BertTokenizer.__call__` anchor

And even more insidious, the object found by `doc-builder` when looking at `BertTokenizer.__call__` is `PreTrainedTokenizerBase.__call__` (that's why this is the generated anchor name), so when resolving ``[`BertTokenizer.__call__`]``, it tries to find in the anchors mapping `PreTrainedTokenizerBase.__call__`, but in that mapping, the method is under the child's name `BertTokenizer.__call__`, so the reference is not resovled.

This PR solves those issues the following way:
- it adds an `anchor_name` to the `document_object` method, to force the anchor name to be `{documented_class_anchor}.{method}` in those situations
- if the `anchor_name` is different from the object name (as above) it saves both names in the anchor mapping
- when it's time to build links from those mappings, it creates, for the object name a link to the proper anchor name.