### PR TITLE
Add multilingual support for CI templates

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -16,6 +16,10 @@ on:
       # supply --not_python_module for HF Course
       additional_args:
         type: string
+      languages:
+      # supply space-separated language codes
+        type: string
+        default: 'en'
     secrets:
       token:
         required: true
@@ -95,6 +99,7 @@ jobs:
           cp doc-build/${{ inputs.package }}/_versions.yml build_dir/${{ inputs.package }}
 
       - name: Make documentation
+        shell: bash
         env:
           NODE_OPTIONS: --max-old-space-size=6656
         run: |
@@ -102,8 +107,14 @@ jobs:
 
           if [ -z "${{ inputs.notebook_folder }}" ]
           then
-            cd doc-builder &&
-            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }} &&
+            IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
+
+            cd doc-builder
+            for lang in "${langs[@]}"
+            do
+                echo "Generating docs for language $lang"
+                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --language $lang
+            done
             cd ..
           else
             cd doc-builder &&

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -104,30 +104,28 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6656
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
+          cd doc-builder
+          args="--build_dir ../build_dir --clean --html ${{ inputs.additional_args }}"
 
-          if [ -z "${{ inputs.notebook_folder }}" ];
+          if [ ! -z "${{ inputs.notebook_folder }}" ];
           then
-            IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
-
-            cd doc-builder
-            if [ -z "${{ inputs.languages }}" ];
-            then
-              echo "languages not provided, defaulting to English"
-              doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}
-            else
-              IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
-              for lang in "${langs[@]}"
-              do
-                  echo "Generating docs for language $lang"
-                  doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --language $lang
-              done
-            fi
-            cd ..
-          else
-            cd doc-builder &&
-            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --notebook_dir ../notebook_dir --clean --html ${{ inputs.additional_args }} &&
-            cd ..
+            args="$args --notebook_dir ../notebook_dir"
           fi
+
+          if [ -z "${{ inputs.languages }}" ];
+          then
+            echo "languages not provided, defaulting to English"
+            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} $args
+          else
+            IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
+            for lang in "${langs[@]}"
+            do
+                echo "Generating docs for language $lang"
+                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang $args --language $lang
+            done
+          fi
+
+          cd ..
 
       - name: Push to repositories
         run: |

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -110,11 +110,18 @@ jobs:
             IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
 
             cd doc-builder
-            for lang in "${langs[@]}"
-            do
-                echo "Generating docs for language $lang"
-                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --language $lang
-            done
+            if [ -z "${{ inputs.languages }}" ];
+            then
+              echo "languages not provided, defaulting to English"
+              doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}
+            else
+              IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
+              for lang in "${langs[@]}"
+              do
+                  echo "Generating docs for language $lang"
+                  doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --language $lang
+              done
+            fi
             cd ..
           else
             cd doc-builder &&

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -19,7 +19,7 @@ on:
       languages:
       # supply space-separated language codes
         type: string
-        default: 'en'
+        default: ''
     secrets:
       token:
         required: true
@@ -105,7 +105,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
 
-          if [ -z "${{ inputs.notebook_folder }}" ]
+          if [ -z "${{ inputs.notebook_folder }}" ];
           then
             IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
-          IFS=', ' read -r -a langs <<< "${{ inputs.languages }}""
+          IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
 
           cd doc-builder
           for lang in "${langs[@]}"

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -86,18 +86,19 @@ jobs:
         shell: bash
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
-
           cd doc-builder
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }}"
+
           if [ -z "${{ inputs.languages }}" ];
           then
             echo "languages not provided, defaulting to English"
-            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }}
+            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} $args
           else
             IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
             for lang in "${langs[@]}"
             do
                 echo "Generating docs for language $lang"
-                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --language $lang
+                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang $args --language $lang
             done
           fi
           cd ..

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -21,7 +21,7 @@ on:
       languages:
       # supply space-separated language codes
         type: string
-        default: 'en'
+        default: ''
 
 jobs:
   build_pr_documentation:
@@ -86,14 +86,18 @@ jobs:
         shell: bash
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
-          IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
 
           cd doc-builder
-          for lang in "${langs[@]}"
-          do
-              echo "Generating docs for language $lang"
-              doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --language $lang
-          done
+          if [ -z "${{ inputs.languages }}" ]
+            echo "languages not provided, defaulting to English"
+            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}
+          else
+            IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
+            for lang in "${langs[@]}"
+            do
+                echo "Generating docs for language $lang"
+                doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --language $lang
+            done
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -99,6 +99,7 @@ jobs:
                 echo "Generating docs for language $lang"
                 doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --language $lang
             done
+          fi
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -89,6 +89,7 @@ jobs:
 
           cd doc-builder
           if [ -z "${{ inputs.languages }}" ]
+          then
             echo "languages not provided, defaulting to English"
             doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}
           else

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -88,7 +88,7 @@ jobs:
           echo "doc_folder has been set to ${{ env.doc_folder }}"
 
           cd doc-builder
-          if [ -z "${{ inputs.languages }}" ]
+          if [ -z "${{ inputs.languages }}" ];
           then
             echo "languages not provided, defaulting to English"
             doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,6 +18,9 @@ on:
       additional_args:
         type: string
         default: ''
+      languages:
+        type: string
+        default: 'en'
 
 jobs:
   build_pr_documentation:
@@ -79,11 +82,17 @@ jobs:
       - name: Make documentation
         env:
           NODE_OPTIONS: --max-old-space-size=6656
+        shell: bash
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
+          IFS=', ' read -r -a langs <<< "${{ inputs.languages }}""
 
-          cd doc-builder &&
-          doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} &&
+          cd doc-builder
+          for lang in "${langs[@]}"
+          do
+              echo "Generating docs for language $lang"
+              doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }}/$lang --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --language $lang
+          done
           cd ..
 
       - name: Push to repositories

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -91,7 +91,7 @@ jobs:
           if [ -z "${{ inputs.languages }}" ];
           then
             echo "languages not provided, defaulting to English"
-            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --html ${{ inputs.additional_args }}
+            doc-builder build ${{ inputs.package }} ../${{ env.doc_folder }} --build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }}
           else
             IFS=', ' read -r -a langs <<< "${{ inputs.languages }}"
             for lang in "${langs[@]}"

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -19,6 +19,7 @@ on:
         type: string
         default: ''
       languages:
+      # supply space-separated language codes
         type: string
         default: 'en'
 


### PR DESCRIPTION
This PR adds multilingual support for the CI templates via a new `languages` argument. Thanks to a tip from @sgugger, the current logic is _opt-in_ which means that multilingual docs are only created if the `languages` argument is provided and the source docs are structured as follows:

```
doc_folder
├── en
│   ├── _toctree.yml
    ...
└── es
    ├── _toctree.yml
    ...
```

An [example](https://github.com/huggingface/doc-build-dev/tree/main/course/pr_39) showing a successful build for the course can be found in this PR: https://github.com/huggingface/course/pull/39

Similarly, an example showing that the current implementation works for monolingual docs can be found here: https://github.com/huggingface/datasets/pull/4055
