### PR TITLE
Enable Hub docs directory to be configurable

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -19,7 +19,6 @@ on:
       languages:
       # supply space-separated language codes
         type: string
-        default: ''
     secrets:
       token:
         required: true

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -20,7 +20,7 @@ on:
       languages:
       # supply space-separated language codes
         type: string
-      hub_docs_url:
+      hub_base_path:
         type: string
 
 jobs:
@@ -56,12 +56,12 @@ jobs:
             echo "doc_folder=${{ inputs.path_to_docs }}" >> $GITHUB_ENV
           fi
 
-          if [ -z "${{ inputs.hub_docs_url }}" ]
+          if [ -z "${{ inputs.hub_base_path }}" ]
           then
-            echo "hub_endpoint=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
-            echo "hub_docs_url not provided, defaulting to https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}"
+            echo "hub_docs_url=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
+            echo "hub_base_path not provided, defaulting to https://moon-ci-docs.huggingface.co/docs"
           else
-            echo "hub_endpoint=${{ inputs.hub_docs_url }}" >> $GITHUB_ENV
+            echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
           fi
 
       - name: Setup environment
@@ -142,7 +142,7 @@ jobs:
         if: steps.find_comment.outputs.comment-id == ''
 
         with:
-          message: 'The docs for this PR live [here](${{ env.hub_endpoint }}). All of your documentation changes will be reflected on that endpoint.'
+          message: 'The docs for this PR live [here](${{ env.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.'
           GITHUB_TOKEN: ${{ env.write_token }}
 
       - name: Update doc comment if necessary
@@ -153,4 +153,4 @@ jobs:
           token: ${{ env.write_token }}
           edit-mode: replace
           body: |
-            The docs for this PR live [here](${{ env.hub_endpoint }}). All of your documentation changes will be reflected on that endpoint.
+            The docs for this PR live [here](${{ env.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -22,6 +22,9 @@ on:
       # supply space-separated language codes
         type: string
         default: ''
+      hub_docs_dir:
+        type: string
+        default: "docs"
 
 jobs:
   build_pr_documentation:
@@ -34,7 +37,7 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
-        
+
       - uses: actions/checkout@v2
         with:
           repository: 'huggingface/${{ inputs.package }}'
@@ -47,7 +50,7 @@ jobs:
       - name: Set env variables
         run: |
           echo "write_token=$(echo 'ghp_'$(wget -qO- lysand.re/doc-build-dev)'bm')" >> $GITHUB_ENV
-          
+
           if [ -z "${{ inputs.path_to_docs }}" ]
           then
             echo "doc_folder=${{ inputs.package }}/docs/source" >> $GITHUB_ENV
@@ -61,7 +64,7 @@ jobs:
         run: |
           rm -rf doc-build-dev
           git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.write_token }}@github.com/huggingface/doc-build-dev
-          
+
           pip uninstall -y doc-builder
           cd doc-builder
           git pull origin main
@@ -121,20 +124,20 @@ jobs:
             echo "No diff in the documentation."
           fi
         shell: bash
-      
+
       - name: Find doc comment
         uses: peter-evans/find-comment@v1
         id: find_comment
         with:
           issue-number: ${{ inputs.pr_number }}
           comment-author: HuggingFaceDocBuilderDev
-      
+
       - name: Add doc comment if not present
         uses: thollander/actions-comment-pull-request@v1
         if: steps.find_comment.outputs.comment-id == ''
 
         with:
-          message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.'
+          message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/${{ inputs.hub_docs_dir }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.'
           GITHUB_TOKEN: ${{ env.write_token }}
 
       - name: Update doc comment if necessary
@@ -145,4 +148,4 @@ jobs:
           token: ${{ env.write_token }}
           edit-mode: replace
           body: |
-            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.
+            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/${{ inputs.hub_docs_dir }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -17,14 +17,11 @@ on:
       # supply --not_python_module for HF Course
       additional_args:
         type: string
-        default: ''
       languages:
       # supply space-separated language codes
         type: string
-        default: ''
-      hub_docs_dir:
+      hub_docs_url:
         type: string
-        default: "docs"
 
 jobs:
   build_pr_documentation:
@@ -57,6 +54,14 @@ jobs:
             echo "path_to_docs not provided, defaulting to ${{ inputs.package }}/docs/source"
           else
             echo "doc_folder=${{ inputs.path_to_docs }}" >> $GITHUB_ENV
+          fi
+
+          if [ -z "${{ inputs.hub_docs_url }}" ]
+          then
+            echo "hub_endpoint=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
+            echo "hub_docs_url not provided, defaulting to https://moon-ci-docs.huggingface.co/docs/${{ inputs.package }}/pr_${{ inputs.pr_number }}"
+          else
+            echo "hub_endpoint=${{ inputs.hub_docs_url }}" >> $GITHUB_ENV
           fi
 
       - name: Setup environment
@@ -137,7 +142,7 @@ jobs:
         if: steps.find_comment.outputs.comment-id == ''
 
         with:
-          message: 'The docs for this PR live [here](https://moon-ci-docs.huggingface.co/${{ inputs.hub_docs_dir }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.'
+          message: 'The docs for this PR live [here](${{ env.hub_endpoint }}). All of your documentation changes will be reflected on that endpoint.'
           GITHUB_TOKEN: ${{ env.write_token }}
 
       - name: Update doc comment if necessary
@@ -148,4 +153,4 @@ jobs:
           token: ${{ env.write_token }}
           edit-mode: replace
           body: |
-            The docs for this PR live [here](https://moon-ci-docs.huggingface.co/${{ inputs.hub_docs_dir }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}). All of your documentation changes will be reflected on that endpoint.
+            The docs for this PR live [here](${{ env.hub_endpoint }}). All of your documentation changes will be reflected on that endpoint.


### PR DESCRIPTION
As discussed in https://github.com/huggingface/moon-landing/pull/2499 this PR enables the docs directory on hf.co to be configurable via a `hub_docs_dir` argument. By default, the docs URL will be 

```
# Compatible with existing URL
https://moon-ci-docs.huggingface.co/docs/{package_name}/pr_{pr_number}
```

but for the course we can configure this to be 

```
# New support for the course
https://moon-ci-docs.huggingface.co/course/{package_name}/pr_{pr_number}
```

A test run with the course CI can be found here: https://github.com/huggingface/course/pull/68