### PR TITLE
Enable support for notebooks in multiple languages

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -48,8 +48,9 @@ def resolve_open_in_colab(content, page_info):
         return content
 
     package_name = page_info["package_name"]
+    language = page_info.get("language", "en")
     page_name = Path(page_info["page"]).stem
-    nb_prefix = f"/github/huggingface/notebooks/blob/main/{package_name}_doc/"
+    nb_prefix = f"/github/huggingface/notebooks/blob/main/{package_name}_doc/{language}/"
     nb_prefix_colab = f"https://colab.research.google.com{nb_prefix}"
     nb_prefix_awsstudio = f"https://studiolab.sagemaker.aws/import{nb_prefix}"
     links = [

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -82,6 +82,11 @@ def build_command(args):
     if version != default_version:
         args.notebook_dir = None
 
+    if args.language is None:
+        args.langauge = "en"
+    elif args.notebook_dir is not None:
+        args.notebook_dir = Path(args.notebook_dir) / args.language
+
     output_path = Path(args.build_dir) / args.library_name / version / args.language
 
     print("Building docs for", args.library_name, args.path_to_docs, output_path)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -82,11 +82,7 @@ def build_command(args):
     if version != default_version:
         args.notebook_dir = None
 
-    if args.language is None:
-        args.langauge = "en"
-    elif args.notebook_dir is not None:
-        args.notebook_dir = Path(args.notebook_dir) / args.language
-
+    notebook_dir = Path(args.notebook_dir) / args.language if args.notebook_dir is not None else None
     output_path = Path(args.build_dir) / args.library_name / version / args.language
 
     print("Building docs for", args.library_name, args.path_to_docs, output_path)
@@ -97,7 +93,7 @@ def build_command(args):
         clean=args.clean,
         version=version,
         language=args.language,
-        notebook_dir=args.notebook_dir,
+        notebook_dir=notebook_dir,
         is_python_module=not args.not_python_module,
     )
 
@@ -176,7 +172,7 @@ def build_command_parser(subparsers=None):
     )
     parser.add_argument("--build_dir", type=str, help="Where the built documentation will be.", default="./build/")
     parser.add_argument("--clean", action="store_true", help="Whether or not to clean the output dir before building.")
-    parser.add_argument("--language", type=str, help="Language of the documentation to generate")
+    parser.add_argument("--language", type=str, help="Language of the documentation to generate", default="en")
     parser.add_argument(
         "--version",
         type=str,

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -176,7 +176,7 @@ def build_command_parser(subparsers=None):
     )
     parser.add_argument("--build_dir", type=str, help="Where the built documentation will be.", default="./build/")
     parser.add_argument("--clean", action="store_true", help="Whether or not to clean the output dir before building.")
-    parser.add_argument("--language", type=str, help="Language of the documentation to generate", default="en")
+    parser.add_argument("--language", type=str, help="Language of the documentation to generate")
     parser.add_argument(
         "--version",
         type=str,

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -33,12 +33,12 @@ class BuildDocTester(unittest.TestCase):
 <DocNotebookDropdown
   classNames="absolute z-10 right-0 top-0"
   options={[
-    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/quicktour.ipynb"},
-    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/pytorch/quicktour.ipynb"},
-    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/tensorflow/quicktour.ipynb"},
-    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/quicktour.ipynb"},
-    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/pytorch/quicktour.ipynb"},
-    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/tensorflow/quicktour.ipynb"},
+    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/tensorflow/quicktour.ipynb"},
+    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/tensorflow/quicktour.ipynb"},
 ]} />
 """
         self.assertEqual(


### PR DESCRIPTION
This PR makes sure that when we set a language argument, we build the notebook in subfolders of notebook_dir (one per language). This will change the current structure (e.g. notebooks will now be pushed to transformers_doc/en instead of just transformers_doc) but makes things support multilingual doc, so I think it's okay.
