### PR TITLE
Fix space eaten by links not in anchors mapping

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -474,7 +474,7 @@ def resolve_links_in_text(text, package, mapping, page_info):
         # Link to the anchor
         anchor = get_shortest_path(obj, package)
         if anchor not in mapping:
-            return f"`{object_name}`"
+            return f"`{object_name}`{last_char}"
         page = f"{prefix}{mapping[anchor]}"
         if "#" in page:
             return f"[{object_name}]({page}){last_char}"


### PR DESCRIPTION
When there is a link to an object that exists but is not in the anchor mapping (as seen a lot in the Spanish doc), a space is eaten. This PR fixes that.