### PR TITLE
[frontend] Highlight hashlinks

### DIFF
--- a/kit/src/app.css
+++ b/kit/src/app.css
@@ -345,14 +345,6 @@
 	@apply text-sm;
 }
 
-.prose.prose-doc .docstring {
-	@apply border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6;
-}
-
-.prose.prose-doc .docstring {
-	@apply mt-8;
-}
-
 .prose.prose-doc .docstring .course-tip {
 	@apply text-base my-6;
 }

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -28,7 +28,7 @@
 			const { name, description } = element;
 			return { ...acc, [name]: description };
 		}, {}) || {};
-	const bgHighlightClass = "bg-yellow-100 dark:bg-[#494a3d]";
+	const bgHighlightClass = "bg-yellow-50 dark:bg-[#494a3d]";
 
 	onMount(() => {
 		const { hash } = window.location;

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -18,6 +18,7 @@
 	export let returnDescription: string;
 	export let returnType: string;
 	export let source: string;
+	export let hashlink: string | undefined;
 
 	let parametersElement: HTMLElement;
 	let collapsed: boolean = false;
@@ -27,11 +28,13 @@
 			const { name, description } = element;
 			return { ...acc, [name]: description };
 		}, {}) || {};
+	const bgHighlightClass = "bg-yellow-100 dark:bg-[#494a3d]";
 
 	onMount(() => {
 		const { hash } = window.location;
+		hashlink = hash.substring(1);
 		const containsAnchor =
-			!!hash && parametersDescription?.some(({ anchor }) => anchor === hash.substring(1));
+			!!hash && parametersDescription?.some(({ anchor }) => anchor === hashlink);
 
 		collapsed = !containsAnchor && parametersElement.clientHeight > 500;
 	});
@@ -61,9 +64,19 @@
 		const REGEX_P = /\s*<p>(((?!<p>).)*)<\/p>\s*/gms;
 		return txt.replace(REGEX_P, (_, content) => `<span>${content}</span>`);
 	}
+
+	function onHashChange() {
+		const { hash } = window.location;
+		hashlink = hash.substring(1);
+	}
 </script>
 
-<div>
+<svelte:window on:hashchange={onHashChange} />
+
+<div
+	class="border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6 mt-8 {hashlink ===
+		anchor && bgHighlightClass}"
+>
 	<span
 		class="group flex space-x-1.5 items-center text-gray-800 bg-gradient-to-r rounded-tr-lg -mt-4 -ml-4 pt-3 px-2.5"
 		id={anchor}
@@ -136,7 +149,7 @@
 			</p>
 			<ul class="px-2">
 				{#each parametersDescription as { anchor, description }}
-					<li class="text-base !pl-4 my-3">
+					<li class="text-base !pl-4 my-3 rounded {hashlink === anchor && bgHighlightClass}">
 						<span class="group flex space-x-1.5 items-start">
 							<a
 								id={anchor}
@@ -163,7 +176,8 @@
 		{/if}
 		{#if !!returnType}
 			<div
-				class="flex items-center font-semibold space-x-3 text-base !mt-0 !mb-0 text-gray-800"
+				class="flex items-center font-semibold space-x-3 text-base !mt-0 !mb-0 text-gray-800 rounded {hashlink ===
+					anchor && bgHighlightClass}"
 				id={`${anchor}.returns`}
 			>
 				<p class="text-base">Returns</p>

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -75,7 +75,7 @@
 
 <div
 	class="border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6 mt-8 {hashlink ===
-		anchor && bgHighlightClass}"
+		anchor ? bgHighlightClass : ''}"
 >
 	<span
 		class="group flex space-x-1.5 items-center text-gray-800 bg-gradient-to-r rounded-tr-lg -mt-4 -ml-4 pt-3 px-2.5"
@@ -149,7 +149,7 @@
 			</p>
 			<ul class="px-2">
 				{#each parametersDescription as { anchor, description }}
-					<li class="text-base !pl-4 my-3 rounded {hashlink === anchor && bgHighlightClass}">
+					<li class="text-base !pl-4 my-3 rounded {hashlink === anchor ? bgHighlightClass : ''}">
 						<span class="group flex space-x-1.5 items-start">
 							<a
 								id={anchor}
@@ -177,7 +177,7 @@
 		{#if !!returnType}
 			<div
 				class="flex items-center font-semibold space-x-3 text-base !mt-0 !mb-0 text-gray-800 rounded {hashlink ===
-					anchor && bgHighlightClass}"
+					anchor ? bgHighlightClass : ''}"
 				id={`${anchor}.returns`}
 			>
 				<p class="text-base">Returns</p>

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -30,7 +30,7 @@ const config = {
 		vite: {
 			build: {
 				sourcemap: Boolean(process.env.DOCS_SOURCEMAP)
-			},
+			}
 		},
 
 		paths: {


### PR DESCRIPTION
One thing I really like about rust docs is that hashlinks are highlited in frontend.
For example, [this one](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelIterator.html#method.cloned)
<img width="700" alt="Screenshot 2022-04-06 at 12 17 15" src="https://user-images.githubusercontent.com/11827707/161953467-371014fb-5142-45ab-bdca-87b12bc30312.png">

This PR, implements a similar behaviour for doc-builder
| lightmode | darkmode |
|-----------|----------|
| <img width="738" alt="Screenshot 2022-04-06 at 12 05 07" src="https://user-images.githubusercontent.com/11827707/161953622-4788693e-47f0-43b2-a2cc-c83d43951e30.png">         | <img width="526" alt="Screenshot 2022-04-06 at 12 08 26" src="https://user-images.githubusercontent.com/11827707/161953630-31c10252-147e-418b-a10e-da8d026b0a68.png">       |

cc: @sgugger @LysandreJik 

TODO: add moon-landing tailwind classes