### PR TITLE
Literalinclude start-after end-before

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ There should be json between `<literalinclude>` open & close tags.
 <literalinclude>
 {"path": "./data/convert_literalinclude_dummy.txt", # relative path
 "language": "python", # defaults to " (empty str)
-"start-after": "START python_import",
-"end-before": "END python_import",
+"start-after": "START python_import",  # defaults to start of file
+"end-before": "END python_import",  # defaults to end of file
 "dedent": 7 # defaults to 0
 }
 </literalinclude>

--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ by default) you can put the list of methods to add in a list that contains `all`
     - __call__
 ```
 
+You can create a code-block by referencing a file excerpt with `<literalinclude>` (sphinx-inspired) syntax. 
+```
+<literalinclude>
+{'path': './data/convert_literalinclude_dummy.txt', # relative path
+'language': 'python', # defaults to '' (empty str)
+'start-after': 'START python_import',
+'end-before': 'END python_import',
+'dedent': 7 # defaults to 0
+}
+</literalinclude>
+```
+
 ### Writing source documentation
 
 Arguments of a function/class/method should be defined with the `Args:` (or `Arguments:` or `Parameters:`) prefix, followed by a line return and

--- a/README.md
+++ b/README.md
@@ -203,13 +203,14 @@ by default) you can put the list of methods to add in a list that contains `all`
 ```
 
 You can create a code-block by referencing a file excerpt with `<literalinclude>` (sphinx-inspired) syntax. 
+There should be json between `<literalinclude>` open & close tags.
 ```
 <literalinclude>
-{'path': './data/convert_literalinclude_dummy.txt', # relative path
-'language': 'python', # defaults to '' (empty str)
-'start-after': 'START python_import',
-'end-before': 'END python_import',
-'dedent': 7 # defaults to 0
+{"path": "./data/convert_literalinclude_dummy.txt", # relative path
+"language": "python", # defaults to " (empty str)
+"start-after": "START python_import",
+"end-before": "END python_import",
+"dedent": 7 # defaults to 0
 }
 </literalinclude>
 ```

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -167,7 +167,7 @@ def build_mdx_files(package, doc_folder, output_dir, page_info):
     for file in tqdm(all_files, desc="Building the MDX files"):
         new_anchors = None
         errors = None
-        page_info["file"] = file
+        page_info["path"] = file
         try:
             if file.suffix in [".md", ".mdx"]:
                 dest_file = output_dir / (file.with_suffix(".mdx").relative_to(doc_folder))

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -167,6 +167,7 @@ def build_mdx_files(package, doc_folder, output_dir, page_info):
     for file in tqdm(all_files, desc="Building the MDX files"):
         new_anchors = None
         errors = None
+        page_info["file"] = file
         try:
             if file.suffix in [".md", ".mdx"]:
                 dest_file = output_dir / (file.with_suffix(".mdx").relative_to(doc_folder))

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -119,16 +119,17 @@ def convert_literalinclude_helper(match, page_info):
     if "start-after" in literalinclude_info or "end-before" in literalinclude_info:
         start_after, end_before = -1, -1
         for idx, line in enumerate(lines):
-            if literalinclude_info["start-after"] in line:
+            line = line.strip()
+            if line.endswith(literalinclude_info["start-after"]):
                 start_after = idx + 1
-            if literalinclude_info["end-before"] in line:
+            if line.endswith(literalinclude_info["end-before"]):
                 end_before = idx
         if start_after == -1 or end_before == -1:
             raise ValueError(f"The following 'literalinclude' does NOT exist:\n{match[0]}")
         literalinclude = lines[start_after:end_before]
     literalinclude = [indent + line[literalinclude_info.get("dedent", 0) :] for line in literalinclude]
     literalinclude = "".join(literalinclude)
-    return f"""{indent}```{literalinclude_info.get('language', '')}\n{literalinclude}{indent}```"""
+    return f"""{indent}```{literalinclude_info.get('language', '')}\n{literalinclude.rstrip()}\n{indent}```"""
 
 
 def convert_literalinclude(text, page_info):

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -111,7 +111,7 @@ def convert_literalinclude_helper(match, page_info):
     """
     literalinclude_info = eval(match[2].strip())
     indent = match[1]
-    file = page_info["file"].parent / literalinclude_info["path"]
+    file = page_info["path"].parent / literalinclude_info["path"]
     with open(file, "r", encoding="utf-8-sig") as reader:
         lines = reader.readlines()
     start_after, end_before = -1, -1

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -107,7 +107,8 @@ _re_literalinclude = re.compile(r"([ \t]*)<literalinclude>(((?!<literalinclude>)
 
 def convert_literalinclude_helper(match, page_info):
     """
-    Convert a docstring written in Markdown to mdx.
+    Convert a literalinclude regex match into markdown code blocks by opening a file and
+    copying specificed start-end section into markdown code block.
     """
     literalinclude_info = eval(match[2].strip())
     indent = match[1]
@@ -130,7 +131,7 @@ def convert_literalinclude_helper(match, page_info):
 
 def convert_literalinclude(text, page_info):
     """
-    Convert a docstring written in Markdown to mdx.
+    Convert a literalinclude into markdown code blocks.
     """
     text = _re_literalinclude.sub(lambda m: convert_literalinclude_helper(m, page_info), text)
     return text
@@ -148,8 +149,9 @@ def convert_md_docstring_to_mdx(docstring, page_info):
 def process_md(text, page_info):
     """
     Processes markdown by:
-        1. Converting special characters
-        2. Converting image links
+        1. Converting literalinclude
+        2. Converting special characters
+        3. Converting image links
     """
     text = convert_literalinclude(text, page_info)
     text = convert_special_chars(text)

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -115,15 +115,17 @@ def convert_literalinclude_helper(match, page_info):
     file = page_info["path"].parent / literalinclude_info["path"]
     with open(file, "r", encoding="utf-8-sig") as reader:
         lines = reader.readlines()
-    start_after, end_before = -1, -1
-    for idx, line in enumerate(lines):
-        if literalinclude_info["start-after"] in line:
-            start_after = idx + 1
-        if literalinclude_info["end-before"] in line:
-            end_before = idx
-    if start_after == -1 or end_before == -1:
-        raise ValueError(f"The following 'literalinclude' does NOT exist:\n{match[0]}")
-    literalinclude = lines[start_after:end_before]
+    literalinclude = lines  # defaults to entire file
+    if "start-after" in literalinclude_info or "end-before" in literalinclude_info:
+        start_after, end_before = -1, -1
+        for idx, line in enumerate(lines):
+            if literalinclude_info["start-after"] in line:
+                start_after = idx + 1
+            if literalinclude_info["end-before"] in line:
+                end_before = idx
+        if start_after == -1 or end_before == -1:
+            raise ValueError(f"The following 'literalinclude' does NOT exist:\n{match[0]}")
+        literalinclude = lines[start_after:end_before]
     literalinclude = [indent + line[literalinclude_info.get("dedent", 0) :] for line in literalinclude]
     literalinclude = "".join(literalinclude)
     return f"""{indent}```{literalinclude_info.get('language', '')}\n{literalinclude}{indent}```"""

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import json
 import re
 
 from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
@@ -109,7 +110,7 @@ def convert_literalinclude_helper(match, page_info):
     Convert a literalinclude regex match into markdown code blocks by opening a file and
     copying specificed start-end section into markdown code block.
     """
-    literalinclude_info = eval(match[2].strip())
+    literalinclude_info = json.loads(match[2].strip())
     indent = match[1]
     file = page_info["path"].parent / literalinclude_info["path"]
     with open(file, "r", encoding="utf-8-sig") as reader:

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -120,6 +120,7 @@ def convert_literalinclude_helper(match, page_info):
         start_after, end_before = -1, -1
         for idx, line in enumerate(lines):
             line = line.strip()
+            line = re.sub(r"\W+$", "", line)
             if line.endswith(literalinclude_info["start-after"]):
                 start_after = idx + 1
             if line.endswith(literalinclude_info["end-before"]):

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -15,7 +15,6 @@
 
 
 import re
-from pathlib import Path
 
 from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
 
@@ -125,8 +124,8 @@ def convert_literalinclude_helper(match, page_info):
         raise ValueError(f"The following 'literalinclude' does NOT exist:\n{match[0]}")
     literalinclude = lines[start_after:end_before]
     literalinclude = [indent + line[literalinclude_info.get("dedent", 0) :] for line in literalinclude]
-    literalinclude = "\n".join(literalinclude)
-    return f"""{indent}```{literalinclude_info.get('language', '')}\n{literalinclude}\n{indent}```"""
+    literalinclude = "".join(literalinclude)
+    return f"""{indent}```{literalinclude_info.get('language', '')}\n{literalinclude}{indent}```"""
 
 
 def convert_literalinclude(text, page_info):

--- a/tests/data/convert_literalinclude_dummy.py
+++ b/tests/data/convert_literalinclude_dummy.py
@@ -1,0 +1,6 @@
+# START python_import
+import numpy as np
+import pandas as pd
+
+
+# END python_import

--- a/tests/data/convert_literalinclude_dummy.txt
+++ b/tests/data/convert_literalinclude_dummy.txt
@@ -6,3 +6,7 @@ import scipy as sp
 import numpy as np
 import pandas as pd
 # END python_import
+
+# START node_import
+import fs
+# END node_import"""

--- a/tests/data/convert_literalinclude_dummy.txt
+++ b/tests/data/convert_literalinclude_dummy.txt
@@ -1,6 +1,4 @@
 # START python_import
 import numpy as np
 import pandas as pd
-
-
 # END python_import

--- a/tests/data/convert_literalinclude_dummy.txt
+++ b/tests/data/convert_literalinclude_dummy.txt
@@ -1,3 +1,7 @@
+# START python_import_answer
+import scipy as sp
+# END python_import_answer
+
 # START python_import
 import numpy as np
 import pandas as pd

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -108,6 +108,10 @@ export let fw: "pt" | "tf"
 "language": "python"}
 </literalinclude>"""
         expected_conversion = """```python
+# START python_import_answer
+import scipy as sp
+# END python_import_answer
+
 # START python_import
 import numpy as np
 import pandas as pd

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -107,7 +107,7 @@ export let fw: "pt" | "tf"
 {"path": "./data/convert_literalinclude_dummy.txt",
 "language": "python"}
 </literalinclude>"""
-        expected_conversion = """```python
+        expected_conversion = '''```python
 # START python_import_answer
 import scipy as sp
 # END python_import_answer
@@ -116,7 +116,11 @@ import scipy as sp
 import numpy as np
 import pandas as pd
 # END python_import
-```"""
+
+# START node_import
+import fs
+# END node_import"""
+```'''
         self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
         # test without language
         text = """<literalinclude>
@@ -155,4 +159,14 @@ import pandas as pd
     numpy as np
     pandas as pd
     ```"""
+        self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
+        # test tag rstrip
+        text = """<literalinclude>
+{"path": "./data/convert_literalinclude_dummy.txt",
+"start-after": "START node_import",
+"end-before": "END node_import"}
+</literalinclude>"""
+        expected_conversion = """```
+import fs
+```"""
         self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -15,8 +15,15 @@
 
 
 import unittest
+from pathlib import Path
 
-from doc_builder.convert_md_to_mdx import convert_img_links, convert_md_to_mdx, convert_special_chars, process_md
+from doc_builder.convert_md_to_mdx import (
+    convert_img_links,
+    convert_literalinclude,
+    convert_md_to_mdx,
+    convert_special_chars,
+    process_md,
+)
 
 
 class ConvertMdToMdxTester(unittest.TestCase):
@@ -84,3 +91,57 @@ export let fw: "pt" | "tf"
 &amp;lcub;}
 &amp;lt;>"""
         self.assertEqual(process_md(text, page_info), expected_conversion)
+
+    def test_convert_literalinclude(self):
+        path = Path(__file__).resolve()
+        page_info = {"file": path}
+        # test canonical
+        text = """<literalinclude>
+{'path': './data/convert_literalinclude_dummy.py',
+'language': 'python',
+'start-after': 'START python_import',
+'end-before': 'END python_import'}
+</literalinclude>"""
+        expected_conversion = """```python
+import numpy as np
+import pandas as pd
+```"""
+        self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
+        # test without language
+        text = """<literalinclude>
+{'path': './data/convert_literalinclude_dummy.py',
+'start-after': 'START python_import',
+'end-before': 'END python_import'}
+</literalinclude>"""
+        expected_conversion = """```
+import numpy as np
+import pandas as pd
+```"""
+        self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
+        # test with indent
+        text = """Some text
+    <literalinclude>
+{'path': './data/convert_literalinclude_dummy.py',
+'start-after': 'START python_import',
+'end-before': 'END python_import'}
+</literalinclude>"""
+        expected_conversion = """Some text
+    ```
+    import numpy as np
+    import pandas as pd
+    ```"""
+        self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
+        # test with dedent
+        text = """Some text
+    <literalinclude>
+{'path': './data/convert_literalinclude_dummy.py',
+'start-after': 'START python_import',
+'end-before': 'END python_import',
+'dedent': 7}
+</literalinclude>"""
+        expected_conversion = """Some text
+    ```
+    numpy as np
+    pandas as pd
+    ```"""
+        self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -97,10 +97,10 @@ export let fw: "pt" | "tf"
         page_info = {"path": path}
         # test canonical
         text = """<literalinclude>
-{'path': './data/convert_literalinclude_dummy.txt',
-'language': 'python',
-'start-after': 'START python_import',
-'end-before': 'END python_import'}
+{"path": "./data/convert_literalinclude_dummy.txt",
+"language": "python",
+"start-after": "START python_import",
+"end-before": "END python_import"}
 </literalinclude>"""
         expected_conversion = """```python
 import numpy as np
@@ -109,9 +109,9 @@ import pandas as pd
         self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
         # test without language
         text = """<literalinclude>
-{'path': './data/convert_literalinclude_dummy.txt',
-'start-after': 'START python_import',
-'end-before': 'END python_import'}
+{"path": "./data/convert_literalinclude_dummy.txt",
+"start-after": "START python_import",
+"end-before": "END python_import"}
 </literalinclude>"""
         expected_conversion = """```
 import numpy as np
@@ -121,9 +121,9 @@ import pandas as pd
         # test with indent
         text = """Some text
     <literalinclude>
-{'path': './data/convert_literalinclude_dummy.txt',
-'start-after': 'START python_import',
-'end-before': 'END python_import'}
+{"path": "./data/convert_literalinclude_dummy.txt",
+"start-after": "START python_import",
+"end-before": "END python_import"}
 </literalinclude>"""
         expected_conversion = """Some text
     ```
@@ -134,10 +134,10 @@ import pandas as pd
         # test with dedent
         text = """Some text
     <literalinclude>
-{'path': './data/convert_literalinclude_dummy.txt',
-'start-after': 'START python_import',
-'end-before': 'END python_import',
-'dedent': 7}
+{"path": "./data/convert_literalinclude_dummy.txt",
+"start-after": "START python_import",
+"end-before": "END python_import",
+"dedent": 7}
 </literalinclude>"""
         expected_conversion = """Some text
     ```

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -97,7 +97,7 @@ export let fw: "pt" | "tf"
         page_info = {"file": path}
         # test canonical
         text = """<literalinclude>
-{'path': './data/convert_literalinclude_dummy.py',
+{'path': './data/convert_literalinclude_dummy.txt',
 'language': 'python',
 'start-after': 'START python_import',
 'end-before': 'END python_import'}
@@ -109,7 +109,7 @@ import pandas as pd
         self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
         # test without language
         text = """<literalinclude>
-{'path': './data/convert_literalinclude_dummy.py',
+{'path': './data/convert_literalinclude_dummy.txt',
 'start-after': 'START python_import',
 'end-before': 'END python_import'}
 </literalinclude>"""
@@ -121,7 +121,7 @@ import pandas as pd
         # test with indent
         text = """Some text
     <literalinclude>
-{'path': './data/convert_literalinclude_dummy.py',
+{'path': './data/convert_literalinclude_dummy.txt',
 'start-after': 'START python_import',
 'end-before': 'END python_import'}
 </literalinclude>"""
@@ -134,7 +134,7 @@ import pandas as pd
         # test with dedent
         text = """Some text
     <literalinclude>
-{'path': './data/convert_literalinclude_dummy.py',
+{'path': './data/convert_literalinclude_dummy.txt',
 'start-after': 'START python_import',
 'end-before': 'END python_import',
 'dedent': 7}

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -102,9 +102,16 @@ export let fw: "pt" | "tf"
 "start-after": "START python_import",
 "end-before": "END python_import"}
 </literalinclude>"""
+        # test entire file
+        text = """<literalinclude>
+{"path": "./data/convert_literalinclude_dummy.txt",
+"language": "python"}
+</literalinclude>"""
         expected_conversion = """```python
+# START python_import
 import numpy as np
 import pandas as pd
+# END python_import
 ```"""
         self.assertEqual(convert_literalinclude(text, page_info), expected_conversion)
         # test without language

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -94,7 +94,7 @@ export let fw: "pt" | "tf"
 
     def test_convert_literalinclude(self):
         path = Path(__file__).resolve()
-        page_info = {"file": path}
+        page_info = {"path": path}
         # test canonical
         text = """<literalinclude>
 {'path': './data/convert_literalinclude_dummy.txt',


### PR DESCRIPTION
I'm in the process of migrating [tokenizers](https://github.com/huggingface/tokenizers) & [inference-api ](https://api-inference.huggingface.co/docs/python/html/index.html) repos to new frontend.

One of the missing capabilities needed is `literalinclude start-after end-before` (example [here](https://github.com/huggingface/tokenizers/blob/main/docs/source/pipeline.rst#id24)), as mentioned in #173

The syntax I'm proposing is html-like tags `<literalinclude>...</literalinclude>`, which will hold python dict str between them specifying options. Wdyt?

Example:
```
<literalinclude>
{'path': './data/convert_literalinclude_dummy.txt', # relative path
'language': 'python', # defaults to '' (empty str)
'start-after': 'START python_import',
'end-before': 'END python_import',
'dedent': 7 # defaults to 0
}
</literalinclude>
```

cc: @adrinjalali @Narsil 