### PR TITLE
Fix notebook push in template

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -147,7 +147,7 @@ jobs:
 
           cd ..
 
-          if [ -z "${{ inputs.notebook_folder }}" ]
+          if [ -d "notebook_dir" ]
           then
             echo "Notebooks creation was not enabled."
           else


### PR DESCRIPTION
This PR fixes the template job that builds the documentation, to make sure we only try to push notebooks when they have been created: a doc job for a specific version does not create them, which results in an error.