### PR TITLE
Revert "Raise exception when non-unique headings"

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -19,7 +19,6 @@ import os
 import re
 import shutil
 import zlib
-from collections import Counter
 from pathlib import Path
 
 import yaml
@@ -263,7 +262,6 @@ def generate_frontmatter_in_text(text, file_name=None):
     text = text.split("\n")
     root = None
     is_inside_codeblock = False
-    locals_encountered = Counter()
     for idx, line in enumerate(text):
         if line.startswith("```"):
             is_inside_codeblock = not is_inside_codeblock
@@ -284,7 +282,6 @@ def generate_frontmatter_in_text(text, file_name=None):
             local = re.sub(r"[^a-z0-9\s]+", "", title.lower())
             local = re.sub(r"\s{2,}", " ", local.strip()).replace(" ", "-")
         text[idx] = f'<h{header_level} id="{local}">{title}</h{header_level}>'
-        locals_encountered[local] += 1
         node = FrontmatterNode(title, local)
         if header_level == 1:
             root = node
@@ -299,11 +296,6 @@ def generate_frontmatter_in_text(text, file_name=None):
                     " second (or more) level header. Make sure to include one!"
                 )
             root.add_child(node, header_level)
-
-    duplicate_locals = [key for key, count in locals_encountered.items() if count > 1]
-    if duplicate_locals:
-        duplicate_locals_str = ", ".join(duplicate_locals)
-        raise ValueError(f"{file_name} contains non-unique (duplicate) headings: '{duplicate_locals_str}'")
 
     frontmatter = root.get_frontmatter()
     text = "\n".join(text)

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -88,11 +88,3 @@ class BuildDocTester(unittest.TestCase):
             generate_frontmatter_in_text("# Bert 1\n## BertTokenizer 2 3\n### BertTokenizer 4 5 6 Method"),
             '---\nlocal: bert-1\nsections:\n- local: berttokenizer-2-3\n  sections:\n  - local: berttokenizer-4-5-6-method\n    title: BertTokenizer 4 5 6 Method\n  title: BertTokenizer 2 3\ntitle: Bert 1\n---\n<h1 id="bert-1">Bert 1</h1>\n<h2 id="berttokenizer-2-3">BertTokenizer 2 3</h2>\n<h3 id="berttokenizer-4-5-6-method">BertTokenizer 4 5 6 Method</h3>',
         )
-
-        # test missing header h1
-        with self.assertRaises(ValueError):
-            generate_frontmatter_in_text("## Bert")
-
-        # test non-unique (duplicate) headers
-        with self.assertRaises(ValueError):
-            generate_frontmatter_in_text("# Bert \n## Bert")


### PR DESCRIPTION
Reverts huggingface/doc-builder#184

Reverting the PR as it breaks a lot of things across repos with no easy fix (the failures are reported at the first file, not all together). This needs to be more carefully integrated.