### PR TITLE
Changes needed for tokenizers

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -25,13 +25,10 @@ export const docstringPreprocess = {
 			const name = docstringBody.match(REGEX_NAME)[1];
 			const anchor = docstringBody.match(REGEX_ANCHOR)[1];
 			const signature = docstringBody.match(REGEX_SIGNATURE)[1];
-			const source = docstringBody.match(REGEX_SOURCE)[1];
 
 			let svelteComponent = `<Docstring name={${JSON.stringify(
 				unescapeUnderscores(name)
-			)}} anchor={${JSON.stringify(anchor)}} parameters={${signature}} source={${JSON.stringify(
-				source
-			)}} `;
+			)}} anchor={${JSON.stringify(anchor)}} parameters={${signature}} `;
 
 			if (docstringBody.match(REGEX_PARAMSDESC)) {
 				let content = docstringBody.match(REGEX_PARAMSDESC)[1];
@@ -73,6 +70,11 @@ export const docstringPreprocess = {
 					}
 					svelteComponent += ` parametersDescription={${JSON.stringify(result)}} `;
 				}
+			}
+
+			if (docstringBody.match(REGEX_SOURCE)) {
+				const source = docstringBody.match(REGEX_SOURCE)[1];
+				svelteComponent += ` source={${JSON.stringify(source)}} `;
 			}
 
 			if (docstringBody.match(REGEX_RETDESC)) {

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -17,7 +17,7 @@
 	}[];
 	export let returnDescription: string;
 	export let returnType: string;
-	export let source: string;
+	export let source: string | undefined = undefined;
 	export let hashlink: string | undefined;
 
 	let parametersElement: HTMLElement;
@@ -75,7 +75,9 @@
 
 <div
 	class="border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6 mt-8 {hashlink ===
-		anchor ? bgHighlightClass : ''}"
+	anchor
+		? bgHighlightClass
+		: ''}"
 >
 	<span
 		class="group flex space-x-1.5 items-center text-gray-800 bg-gradient-to-r rounded-tr-lg -mt-4 -ml-4 pt-3 px-2.5"
@@ -89,15 +91,17 @@
 		>
 			<IconCopyLink />
 		</a>
-		<a
-			class="!ml-auto !text-gray-400 !no-underline text-sm flex items-center"
-			href={source}
-			target="_blank"
-		>
-			<span>&lt;</span>
-			<span class="hidden md:block mx-0.5 hover:!underline">source</span>
-			<span>&gt;</span>
-		</a>
+		{#if source}
+			<a
+				class="!ml-auto !text-gray-400 !no-underline text-sm flex items-center"
+				href={source}
+				target="_blank"
+			>
+				<span>&lt;</span>
+				<span class="hidden md:block mx-0.5 hover:!underline">source</span>
+				<span>&gt;</span>
+			</a>
+		{/if}
 	</span>
 	<p class="font-mono text-xs md:text-sm !leading-relaxed !my-6">
 		<span>(</span>
@@ -177,7 +181,9 @@
 		{#if !!returnType}
 			<div
 				class="flex items-center font-semibold space-x-3 text-base !mt-0 !mb-0 text-gray-800 rounded {hashlink ===
-					anchor ? bgHighlightClass : ''}"
+				anchor
+					? bgHighlightClass
+					: ''}"
 				id={`${anchor}.returns`}
 			>
 				<p class="text-base">Returns</p>

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -348,7 +348,7 @@ def document_object(object_name, package, page_info, full_name=True, anchor_name
 
     try:
         source_link = get_source_link(obj, page_info)
-    except (AttributeError, OSError):
+    except (AttributeError, OSError, TypeError):
         # tokenizers obj do NOT have `__module__` attribute & can NOT be used with inspect.getsourcelines
         source_link = None
     component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -66,7 +66,7 @@ def get_shortest_path(obj, package):
         # Propreties have no __module__ or __name__ attributes, but their getter function does.
         obj = obj.fget
 
-    if not hasattr(obj, "__module__"):
+    if not hasattr(obj, "__module__") or obj.__module__ is None:
         return None
     long_path = obj.__module__
     # Sometimes methods are defined in another module from the class (flax.struct.dataclass)
@@ -139,7 +139,7 @@ _re_raises = re.compile(r"<raises>(.*)</raises>", re.DOTALL)
 _re_raisederrors = re.compile(r"<raisederrors>(.*)</raisederrors>", re.DOTALL)
 
 
-def get_signature_component(name, anchor, signature, object_doc, source_link):
+def get_signature_component(name, anchor, signature, object_doc, source_link=None):
     """
     Returns the svelte `Docstring` component string.
 
@@ -148,7 +148,7 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
     - **anchor** (`str`) -- The anchor name of the function or class that will be used for hash links.
     - **signature** (`List(Dict(str,str))`) -- The signature of the object.
     - **object_doc** (`str`) -- The docstring of the the object.
-    - **source_link** (`str`) -- The github source link of the the object.
+    - **source_link** (Union[`str`, `None`], *optional*, defaults to `None`) -- The github source link of the the object.
     """
 
     def inside_example_finder_closure(match, tag):
@@ -190,7 +190,8 @@ def get_signature_component(name, anchor, signature, object_doc, source_link):
     svelte_str = "<docstring>"
     svelte_str += f"<name>{name}</name>"
     svelte_str += f"<anchor>{anchor}</anchor>"
-    svelte_str += f"<source>{source_link}</source>"
+    if source_link:
+        svelte_str += f"<source>{source_link}</source>"
     svelte_str += f"<parameters>{json.dumps(signature)}</parameters>"
 
     if parameters is not None:
@@ -345,7 +346,11 @@ def document_object(object_name, package, page_info, full_name=True, anchor_name
             check = quality_check_docstring(object_doc, object_name=object_name)
             object_doc = convert_md_docstring_to_mdx(obj.__doc__, page_info)
 
-    source_link = get_source_link(obj, page_info)
+    try:
+        source_link = get_source_link(obj, page_info)
+    except (AttributeError, OSError):
+        # tokenizers obj do NOT have `__module__` attribute & can NOT be used with inspect.getsourcelines
+        source_link = None
     component = get_signature_component(signature_name, anchor_name, signature, object_doc, source_link)
     documentation = "\n" + component + "\n"
     return documentation, check

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -130,7 +130,7 @@ def resolve_autodoc(content, package, return_anchors=False, page_info=None):
 
             try:
                 source_files = source_files = get_source_path(object_name, package)
-            except (AttributeError, OSError):
+            except (AttributeError, OSError, TypeError):
                 # tokenizers obj do NOT have `__module__` attribute & can NOT be used with inspect.getfile
                 source_files = None
         else:

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -128,7 +128,11 @@ def resolve_autodoc(content, package, return_anchors=False, page_info=None):
                 doc = doc[0]
             new_lines.append(doc)
 
-            source_files = get_source_path(object_name, package)
+            try:
+                source_files = source_files = get_source_path(object_name, package)
+            except (AttributeError, OSError):
+                # tokenizers obj do NOT have `__module__` attribute & can NOT be used with inspect.getfile
+                source_files = None
         else:
             new_lines.append(lines[idx])
             if lines[idx].startswith("```"):


### PR DESCRIPTION
2 features are turned off for tokenizers doc builds:
1. Tokenizers python docs will NOT have `source` btn 
   <img width="500" alt="Screenshot 2022-04-13 at 12 37 29" src="https://user-images.githubusercontent.com/11827707/163161755-4f2f543d-80d3-431a-b42b-b9e4d6cbe300.png">
2.`doc-builder preview` cmd hot reloading will NOT track docstring changes in tokenizers python bindings files.


The reason why these 2 features are turned off are: tokenizers python bindings objs:
1.  do not work with `inspect.getsourcelines` & `inspect.getfile`
2. do not have `__module__` attribute 

an error gets thrown:
```
<function descriptor> does not have XYZ
```

taking the easier/simpler route of excluding those 2 features (imo, since they are not essential, especiialy the second one) rather than trying to find a solution [because](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1649327824975459?thread_ts=1649326613.932349&cid=C02GLJ5S0E9)
>  The tokenizers doc is (sadly) not super used, so let's not make too many customizations to doc-builder for it

cc: @Narsil @julien-c 