### PR TITLE
GH workflow changes for tokenizers

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -19,6 +19,10 @@ on:
       languages:
       # supply space-separated language codes
         type: string
+      package_path:
+        type: string
+      install_rust:
+        type: boolean
     secrets:
       token:
         required: true
@@ -67,6 +71,12 @@ jobs:
             echo "doc_folder=${{ inputs.path_to_docs }}" >> $GITHUB_ENV
           fi
 
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        if: inputs.install_rust
+        with:
+          toolchain: stable
+
       - name: Setup environment
         shell: bash
         run: |
@@ -76,7 +86,11 @@ jobs:
           pip install .
           cd ..
 
-          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          if [ "${{ inputs.package_path }}" ]
+          then
+            cd ${{ inputs.package_path }}
+            pip install .[dev]
+          elif [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
           then
             cd ${{ inputs.package }}
             pip install .[dev]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -86,7 +86,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.package_path }}" ]
+          if [[ -n "${{ inputs.package_path }}" ]]
           then
             cd ${{ inputs.package_path }}
             pip install .[dev]

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -86,7 +86,7 @@ jobs:
           pip install .
           cd ..
 
-          if [ "${{ inputs.package_path }}" ]
+          if [[ -n "${{ inputs.package_path }}" ]]
           then
             cd ${{ inputs.package_path }}
             pip install .[dev]

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -22,6 +22,10 @@ on:
         type: string
       hub_base_path:
         type: string
+      package_path:
+        type: string
+      install_rust:
+        type: boolean
 
 jobs:
   build_pr_documentation:
@@ -64,6 +68,12 @@ jobs:
             echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
           fi
 
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        if: inputs.install_rust
+        with:
+          toolchain: stable
+
       - name: Setup environment
         shell: bash
         run: |
@@ -76,7 +86,11 @@ jobs:
           pip install .
           cd ..
 
-          if [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
+          if [ "${{ inputs.package_path }}" ]
+          then
+            cd ${{ inputs.package_path }}
+            pip install .[dev]
+          elif [[ "${{ inputs.additional_args }}" != *"--not_python_module"* ]];
           then
             cd ${{ inputs.package }}
             pip install .[dev]


### PR DESCRIPTION
Needed for https://github.com/huggingface/tokenizers/pull/980

See [here](https://github.com/huggingface/tokenizers/blob/95b5d066d5b90582ceccb76b84b7d41351532e82/.github/workflows/build_pr_documentation.yml#L18-L19)

Adding 2 new [inputs](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow) to doc build gh workflows:
1. `package_path`: because tokenizers python package is not in its git root folder, but in `tokenizers/bindings/python`
2. `install_rust`: installing rust is needed to install tokenizers from source

For install `install_rust`, I wanted to re-use [additional_args](https://github.com/huggingface/doc-builder/blob/main/.github/workflows/build_pr_documentation.yml#L18) but `additional_args` gets passed to `doc-builder`, which errors:
```bash
Make documentation step
args="--build_dir ../build_dir --clean --version pr_980 --html --rust-toolchain"
Doc Builder CLI tool: error: unrecognized arguments: --rust-toolchain
```