### PR TITLE
Fix `postbuild.sh`

### DIFF
--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -9,4 +9,4 @@ cp src/routes/_toctree.yml build/_toctree.yml
 # 2. making `rel="stylesheet"` -> `rel="modulepreload"`
 > $(find . -regex '.*build.*.css')
 cd build
-find . -name '*.html' -exec sed -i '' 's/rel="stylesheet"/rel="modulepreload"/g' {} \;
+find . -name '*.html' -exec perl -pi -e 's/rel="stylesheet"/rel="modulepreload"/g' {} +


### PR DESCRIPTION
Closes #198

Previously, `sed` was failing with like [here](https://github.com/huggingface/doc-builder/runs/6158261692?check_suite_focus=true#step:7:28):
```
sed: can't read s/rel="stylesheet"/rel="modulepreload"/g: No such file or directory
```