### PR TITLE
Rm unneded if condition for `version_tag`

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -79,7 +79,7 @@ def build_command(args):
     # `version` will always start with prefix `v`
     # `version_tag` does not have to start with prefix `v` (see: https://github.com/huggingface/datasets/tags)
     version_tag = version
-    if args.version is None and version != default_version:
+    if version != default_version:
         doc_config = get_doc_config()
         version_prefix = getattr(doc_config, "version_prefix", "v")
         version_ = version[1:]  # v2.1.0 -> 2.1.0


### PR DESCRIPTION
As suggested [here](https://github.com/huggingface/doc-builder/pull/203#discussion_r859752858)

apologies for causing bunch of issues because of #200 😊

Tested both on transformers & datasets, the source urls are working correctly:
https://huggingface.co/docs/transformers/main/en/model_doc/bert#transformers.BertConfig

https://huggingface.co/docs/datasets/master/en/package_reference/main_classes#datasets.DatasetInfo.from_directory