### PR TITLE
Don't error in style_doc for empty docstrings

### DIFF
--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -235,6 +235,9 @@ def style_docstring(docstring, max_len):
     Returns:
         `str`: The styled docstring
     """
+    if is_empty_line(docstring):
+        return docstring
+
     lines = docstring.split("\n")
     new_lines = []
 


### PR DESCRIPTION
Currently `doc-builder style` will return an error if a file has an empty docstring. This PR fixes that.