### PR TITLE
Fix example formatting

### DIFF
--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -161,7 +161,7 @@ def format_code_example(code: str, max_len: int, in_docstring: bool = False):
             if has_doctest and not is_empty_line(line):
                 prefix = (
                     "... "
-                    if line.startswith(" ") or line in [")", "]", "}"] or in_triple_quotes or in_decorator
+                    if line.startswith(" ") or line[0] in [")", "]", "}"] or in_triple_quotes or in_decorator
                     else ">>> "
                 )
             else:


### PR DESCRIPTION
For example formatting, we need to use `...` for any line that starts with a closing parenthesis/bracket. This PR fixes this (before it was required the whole line be just a closing parenthesis/bracket).

Fixes #206

You can see the changes it makes in Transformers in [this PR](https://github.com/huggingface/transformers/pull/17015)