### PR TITLE
Replace inequality with non-identity for inspect._empty

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -119,10 +119,10 @@ def format_signature(obj):
         elif param.kind == inspect._ParameterKind.VAR_KEYWORD:
             param_name = f"**{param_name}"
         param_type_val = ""
-        if param.annotation != inspect._empty:
+        if param.annotation is not inspect._empty:
             annotation = get_type_name(param.annotation)
             param_type_val += f": {annotation}"
-        if param.default != inspect._empty:
+        if param.default is not inspect._empty:
             default = param.default
             default = repr(default)
             param_type_val += f" = {default}"


### PR DESCRIPTION
The `inspect` package uses `is`/`is not` (instead of `==`/`!=`) with `inspect._empty`:
- This is useful because the user might override `__eq__`/`__ne__` (with unexpected behavior).
- For singletons, `is`/`is not` guarantees comparison based on object identity.

See examples in `inspect`:
- https://github.com/python/cpython/blob/3.10/Lib/inspect.py#L2635
- https://github.com/python/cpython/blob/3.10/Lib/inspect.py#L2643

Note I discovered this issue because of `datasets.Version`. I am also proposing an improvement in its implementation, but I think this PR makes sense anyway. 