### PR TITLE
Optional `package_name` attribute for gh workflows

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -11,6 +11,7 @@ on:
         type: string
       package_name:
         type: string
+        description: "Should be used when a package name differs from its repostory name"
       path_to_docs:
         type: string
       notebook_folder:

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -9,6 +9,8 @@ on:
       package:
         required: true
         type: string
+      package_name:
+        type: string
       path_to_docs:
         type: string
       notebook_folder:
@@ -144,9 +146,16 @@ jobs:
         run: |
           cd doc-build
           git pull
-          mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ inputs.package }}/
-          rm -rf ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
-          mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
+          if [ -z "${{ inputs.package_name }}" ];
+          then
+            mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ inputs.package }}/
+            rm -rf ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
+            mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
+          else
+            mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ inputs.package_name }}/
+            rm -rf ${{ inputs.package_name }}/$(ls ../build_dir/${{ inputs.package }})
+            mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ inputs.package_name }}/$(ls ../build_dir/${{ inputs.package }})
+          fi
           git status
 
           if [[ `git status --porcelain` ]]; then 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -14,6 +14,7 @@ on:
         type: string
       package_name:
         type: string
+        description: "Should be used when a package name differs from its repostory name"
       path_to_docs:
         type: string
       # supply --not_python_module for HF Course

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -12,6 +12,8 @@ on:
       package:
         required: true
         type: string
+      package_name:
+        type: string
       path_to_docs:
         type: string
       # supply --not_python_module for HF Course
@@ -130,7 +132,12 @@ jobs:
           cd doc-build-dev
           git pull
           rm -rf ${{ inputs.package }}/pr_${{ inputs.pr_number }}
-          mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ inputs.package }}/pr_${{ inputs.pr_number }}
+          if [ -z "${{ inputs.package_name }}" ];
+          then
+            mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ inputs.package }}/pr_${{ inputs.pr_number }}
+          else
+            mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ inputs.package_name }}/pr_${{ inputs.pr_number }}
+          fi
           git status
 
           if [[ `git status --porcelain` ]]; then


### PR DESCRIPTION
Context: migrating hf.co/docs/hub to using doc-builder

The repo/package name is [hub-docs](https://github.com/huggingface/hub-docs), but we want to output in [hub](https://github.com/huggingface/doc-build-dev/tree/main/hub)