### PR TITLE
Commit files to `doc-build(-dev)?` using Github GraphQL

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -141,12 +141,12 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
 
           if [ -d "notebook_dir" ]
           then
             mkdir ${{ inputs.notebook_folder }}
             cp -r ./notebook_dir/. ${{ inputs.notebook_folder }}
-            doc-builder push ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg 
+            doc-builder push ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated ${{ inputs.package }} doc notebooks with commit ${{ inputs.commit_sha }} \n\nSee: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
           fi
         shell: bash

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -74,6 +74,13 @@ jobs:
             echo "doc_folder=${{ inputs.path_to_docs }}" >> $GITHUB_ENV
           fi
 
+          if [ -z "${{ inputs.package_name }}" ];
+          then
+            echo "package_name=${{ inputs.package }}" >> $GITHUB_ENV
+          else
+            echo "package_name=${{ inputs.package_name }}" >> $GITHUB_ENV
+          fi
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         if: inputs.install_rust
@@ -147,16 +154,9 @@ jobs:
         run: |
           cd doc-build
           git pull
-          if [ -z "${{ inputs.package_name }}" ];
-          then
-            mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ inputs.package }}/
-            rm -rf ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
-            mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }})
-          else
-            mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ inputs.package_name }}/
-            rm -rf ${{ inputs.package_name }}/$(ls ../build_dir/${{ inputs.package }})
-            mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ inputs.package_name }}/$(ls ../build_dir/${{ inputs.package }})
-          fi
+          mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ env.package_name }}/
+          rm -rf ${{ env.package_name }}/$(ls ../build_dir/${{ inputs.package }})
+          mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ env.package_name }}/$(ls ../build_dir/${{ inputs.package }})
           git status
 
           if [[ `git status --porcelain` ]]; then 

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -46,19 +46,6 @@ jobs:
         with:
           repository: 'huggingface/${{ inputs.package }}'
           path: ${{ inputs.package }}
-      
-      - uses: actions/checkout@v2
-        with:
-          repository: 'huggingface/doc-build'
-          path: doc-build
-          token: ${{ secrets.token }}
-      
-      - uses: actions/checkout@v2
-        if: inputs.notebook_folder != ''
-        with:
-          repository: 'huggingface/notebooks'
-          path: notebooks
-          token: ${{ secrets.token }}
 
       - uses: actions/setup-node@v2
         with:
@@ -114,12 +101,10 @@ jobs:
 
       - name: Create build directory
         run: |
-          cd doc-build
-          git pull
-          cd ..
           mkdir build_dir
           mkdir build_dir/${{ inputs.package }}
-          cp doc-build/${{ inputs.package }}/_versions.yml build_dir/${{ inputs.package }}
+          wget https://raw.githubusercontent.com/huggingface/doc-build/main/${{ inputs.package }}/_versions.yml
+          mv _versions.yml ./build_dir
 
       - name: Make documentation
         shell: bash
@@ -152,42 +137,17 @@ jobs:
 
       - name: Push to repositories
         run: |
-          cd doc-build
-          git pull
-          mv ../build_dir/${{ inputs.package }}/_versions.yml ${{ env.package_name }}/
-          rm -rf ${{ env.package_name }}/$(ls ../build_dir/${{ inputs.package }})
-          mv ../build_dir/${{ inputs.package }}/$(ls ../build_dir/${{ inputs.package }}) ${{ env.package_name }}/$(ls ../build_dir/${{ inputs.package }})
+          mv ./build_dir/${{ inputs.package }}/_versions.yml ${{ env.package_name }}/
+          rm -rf ${{ env.package_name }}/$(ls ./build_dir/${{ inputs.package }})
+          mv ./build_dir/${{ inputs.package }}/$(ls ./build_dir/${{ inputs.package }}) ${{ env.package_name }}/$(ls ./build_dir/${{ inputs.package }})
           git status
 
-          if [[ `git status --porcelain` ]]; then 
-            git add .
-            git commit -m "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
-            git push origin main ||
-            (echo "Failed on the first try, rebasing and pushing again" && git pull --rebase && git push origin main) ||
-            (echo "Failed on the second try, rebasing and pushing again" && git pull --rebase && git push origin main)
-          else
-            echo "No diff in the documentation."
-          fi
-
-          cd ..
+          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
           if [ -d "notebook_dir" ]
           then
-            cd notebooks
-            git pull
-            cp -r ../notebook_dir/. ${{ inputs.notebook_folder }}
-            git status
-            if [[ `git status --porcelain` ]]; then
-              git add ${{ inputs.notebook_folder }}
-              git commit -m "Updated ${{ inputs.package }} doc notebooks with commit ${{ inputs.commit_sha }} \n\nSee: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
-              git push origin main ||
-              (echo "Failed on the first try, rebasing and pushing again" && git pull --rebase && git push origin main) ||
-              (echo "Failed on the second try, rebasing and pushing again" && git pull --rebase && git push origin main)
-            else
-              echo "No diff in the notebooks."
-            fi
-            cd ..
-          else
-            echo "Notebooks creation was not enabled."
+            mkdir ${{ inputs.notebook_folder }}
+            cp -r ./notebook_dir/. ${{ inputs.notebook_folder }}
+            doc-builder commit ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg 
           fi
         shell: bash

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -103,8 +103,8 @@ jobs:
         run: |
           mkdir build_dir
           mkdir build_dir/${{ inputs.package }}
+          cd build_dir/${{ inputs.package }}
           wget https://raw.githubusercontent.com/huggingface/doc-build/main/${{ inputs.package }}/_versions.yml
-          mv _versions.yml ./build_dir
 
       - name: Make documentation
         shell: bash
@@ -137,11 +137,10 @@ jobs:
 
       - name: Push to repositories
         run: |
-          mv ./build_dir/${{ inputs.package }}/_versions.yml ${{ env.package_name }}/
-          rm -rf ${{ env.package_name }}/$(ls ./build_dir/${{ inputs.package }})
-          mv ./build_dir/${{ inputs.package }}/$(ls ./build_dir/${{ inputs.package }}) ${{ env.package_name }}/$(ls ./build_dir/${{ inputs.package }})
-          git status
-
+          cd build_dir
+          if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
+            mv ${{ inputs.package }} ${{ env.package_name }}
+          fi
           doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
           if [ -d "notebook_dir" ]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -137,7 +137,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --clean
 
           if [ -d "notebook_dir" ]
           then

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -143,6 +143,6 @@ jobs:
           then
             mkdir ${{ inputs.notebook_folder }}
             cp -r ./notebook_dir/. ${{ inputs.notebook_folder }}
-            doc-builder push ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated ${{ inputs.package }} doc notebooks with commit ${{ inputs.commit_sha }} \n\nSee: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
+            doc-builder push ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/notebooks" --token ${{ secrets.token }} --commit_msg "Updated ${{ inputs.package }} doc notebooks with commit ${{ inputs.commit_sha }} \n\nSee: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
           fi
         shell: bash

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -137,7 +137,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --clean
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
 
           if [ -d "notebook_dir" ]
           then

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
-          ref: use_gh_graphql
         
       - uses: actions/checkout@v2
         with:
@@ -80,7 +79,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin use_gh_graphql
+          git pull origin main
           pip install .
           cd ..
 

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
+          ref: use_gh_graphql
         
       - uses: actions/checkout@v2
         with:
@@ -79,7 +80,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin main
+          git pull origin use_gh_graphql
           pip install .
           cd ..
 

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -95,11 +95,6 @@ jobs:
           fi
           cd ..
 
-      - name: Setup git
-        run: |
-          git config --global user.name "Hugging Face Doc Builder"
-          git config --global user.email docs@huggingface.co
-
       - name: Create build directory
         run: |
           mkdir build_dir

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -141,12 +141,12 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
           if [ -d "notebook_dir" ]
           then
             mkdir ${{ inputs.notebook_folder }}
             cp -r ./notebook_dir/. ${{ inputs.notebook_folder }}
-            doc-builder commit ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg 
+            doc-builder push ${{ inputs.notebook_folder }} --doc_build_repo_id "huggingface/doc-build" --token ${{ secrets.token }} --commit_msg 
           fi
         shell: bash

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -71,6 +71,13 @@ jobs:
             echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package }}/pr_${{ inputs.pr_number }}" >> $GITHUB_ENV
           fi
 
+          if [ -z "${{ inputs.package_name }}" ];
+          then
+            echo "package_name=${{ inputs.package }}" >> $GITHUB_ENV
+          else
+            echo "package_name=${{ inputs.package_name }}" >> $GITHUB_ENV
+          fi
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         if: inputs.install_rust
@@ -133,12 +140,7 @@ jobs:
           cd doc-build-dev
           git pull
           rm -rf ${{ inputs.package }}/pr_${{ inputs.pr_number }}
-          if [ -z "${{ inputs.package_name }}" ];
-          then
-            mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ inputs.package }}/pr_${{ inputs.pr_number }}
-          else
-            mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ inputs.package_name }}/pr_${{ inputs.pr_number }}
-          fi
+          mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ env.package_name }}/pr_${{ inputs.pr_number }}
           git status
 
           if [[ `git status --porcelain` ]]; then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -29,9 +29,6 @@ on:
         type: string
       install_rust:
         type: boolean
-    secrets:
-      token:
-        required: true
 
 jobs:
   build_pr_documentation:
@@ -143,7 +140,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
+          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
+          ref: use_gh_graphql
 
       - uses: actions/checkout@v2
         with:
@@ -92,7 +93,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin main
+          git pull origin use_gh_graphql
           pip install .
           cd ..
 
@@ -136,11 +137,13 @@ jobs:
           cd ..
 
       - name: Push to repositories
-        run: |
-          mv ./build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ env.package_name }}/pr_${{ inputs.pr_number }}
-          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
-
         shell: bash
+        run: |
+          cd build_dir
+          if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
+            mv ${{ inputs.package }} ${{ env.package_name }}
+          fi
+          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Test commit GraphQL"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -143,7 +143,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Test commit GraphQL"
+          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -105,11 +105,6 @@ jobs:
           fi
           cd ..
 
-      - name: Setup git
-        run: |
-          git config --global user.name "Hugging Face Doc Builder"
-          git config --global user.email docs@huggingface.co
-
       - name: Make documentation
         env:
           NODE_OPTIONS: --max-old-space-size=6656

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -135,7 +135,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --clean
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -140,7 +140,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -140,7 +140,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
-          ref: use_gh_graphql
 
       - uses: actions/checkout@v2
         with:
@@ -90,7 +89,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin use_gh_graphql
+          git pull origin main
           pip install .
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -29,6 +29,9 @@ on:
         type: string
       install_rust:
         type: boolean
+    secrets:
+      token:
+        required: true
 
 jobs:
   build_pr_documentation:
@@ -87,9 +90,6 @@ jobs:
       - name: Setup environment
         shell: bash
         run: |
-          rm -rf doc-build-dev
-          git clone --depth 1 https://HuggingFaceDocBuilderDev:${{ env.write_token }}@github.com/huggingface/doc-build-dev
-
           pip uninstall -y doc-builder
           cd doc-builder
           git pull origin main
@@ -137,21 +137,9 @@ jobs:
 
       - name: Push to repositories
         run: |
-          cd doc-build-dev
-          git pull
-          rm -rf ${{ inputs.package }}/pr_${{ inputs.pr_number }}
-          mv ../build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ env.package_name }}/pr_${{ inputs.pr_number }}
-          git status
+          mv ./build_dir/${{ inputs.package }}/pr_${{ inputs.pr_number }} ${{ env.package_name }}/pr_${{ inputs.pr_number }}
+          doc-builder commit ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ secrets.token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
 
-          if [[ `git status --porcelain` ]]; then
-            git add .
-            git commit -m "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}"
-            git push origin main ||
-            (echo "Failed on the first try, rebasing and pushing again" && git pull --rebase && git push origin main) ||
-            (echo "Failed on the second try, rebasing and pushing again" && git pull --rebase && git push origin main)
-          else
-            echo "No diff in the documentation."
-          fi
         shell: bash
 
       - name: Find doc comment

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -135,7 +135,7 @@ jobs:
           if [ "${{ inputs.package }}" != "${{ env.package_name }}" ]; then
             mv ${{ inputs.package }} ${{ env.package_name }}
           fi
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "huggingface/doc-build-dev" --token ${{ env.write_token }} --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/huggingface/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --clean
 
       - name: Find doc comment
         uses: peter-evans/find-comment@v1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-install_requires = ["tqdm", "pyyaml", "packaging", "nbformat"]
+install_requires = ["tqdm", "pyyaml", "packaging", "nbformat", "gql[aiohttp]", "requests"]
 
 extras = {}
 

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -15,16 +15,12 @@
 
 import argparse
 import base64
-import re
 from pathlib import Path
 
 import requests
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
 from gql.transport.exceptions import TransportQueryError
-
-
-_re_head_oid = re.compile(r"\"sha\":\"([0-9a-z]+)\"")
 
 
 def get_head_oid(repo_id, token, branch="main"):
@@ -36,7 +32,8 @@ def get_head_oid(repo_id, token, branch="main"):
         headers={"Authorization": f"bearer {token}"},
     )
     if res.status_code == 200:
-        head_oid = _re_head_oid.search(res.text)[1]
+        res_json = res.json()
+        head_oid = res_json["object"]["sha"]
         return head_oid
     else:
         raise Exception(f"get_head_oid failed: {res.message}")

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -125,15 +125,18 @@ def commit_command_parser(subparsers=None):
     parser.add_argument(
         "path_to_built_docs",
         type=str,
-        help="Local path to library documentation. The library should be cloned, and the folder containing the "
-        "documentation files should be indicated here.",
+        help="Path/dir where built doc artifacts reside in",
     )
-    parser.add_argument("--doc_build_repo_id", type=str, help="Language of the documentation to generate")
-    parser.add_argument("--token", type=str, help="Language of the documentation to generate")
+    parser.add_argument(
+        "--doc_build_repo_id",
+        type=str,
+        help="Repo to which doc artifcats will be committed (e.g. `huggingface/doc-build-dev`)",
+    )
+    parser.add_argument("--token", type=str, help="Github token that has write/push premission to `doc_build_repo_id`")
     parser.add_argument(
         "--commit_msg",
         type=str,
-        help="Version of the documentation to generate",
+        help="Git commit message",
         default="Github GraphQL createcommitonbranch commit",
     )
 

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -32,14 +32,14 @@ def get_head_oid(repo_id, token, branch="main"):
     Returns last commit sha from repostory `repo_id` & branch `branch`
     """
     res = requests.get(
-        f"https://api.github.com/repos/{repo_id}/git/refs/heads/${branch}",
+        f"https://api.github.com/repos/{repo_id}/git/refs/heads/{branch}",
         headers={"Authorization": f"bearer {token}"},
     )
     if res.status_code == 200:
         head_oid = _re_head_oid.search(res.text)[1]
         return head_oid
     else:
-        raise Exception("get_head_oid failed: {{status: {res.status}, msg:{res.text}}}")
+        raise Exception(f"get_head_oid failed: {res.message}")
 
 
 def create_additions_str(path_to_built_docs):

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -39,7 +39,7 @@ def get_head_oid(repo_id, token, branch="main"):
         raise Exception(f"get_head_oid failed: {res.message}")
 
 
-def create_additions_str(path_to_built_docs):
+def create_additions(path_to_built_docs):
     """
     Given `path_to_built_docs` dir, returns [FileAddition!]!: [{path: "some_path", contents: "base64_repr_contents"}, ...]
     see more here: https://docs.github.com/en/graphql/reference/input-objects#filechanges
@@ -103,7 +103,7 @@ def commit_command(args):
     Usage: doc-builder commit $args
     """
     number_of_retries = 5
-    additions_str = create_additions_str(args.path_to_built_docs)
+    additions_str = create_additions(args.path_to_built_docs)
     while number_of_retries:
         try:
             head_oid = get_head_oid(args.doc_build_repo_id, args.token)

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -125,7 +125,7 @@ def commit_command_parser(subparsers=None):
     parser.add_argument(
         "path_to_built_docs",
         type=str,
-        help="Path/dir where built doc artifacts reside in",
+        help="The path where built doc artifacts reside in",
     )
     parser.add_argument(
         "--doc_build_repo_id",

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -1,0 +1,144 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import base64
+import re
+from pathlib import Path
+
+import requests
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.exceptions import TransportQueryError
+
+
+_re_head_oid = re.compile(r"\"sha\":\"([0-9a-z]+)\"")
+
+
+def get_head_oid(repo_id, token, branch="main"):
+    """
+    Returns last commit sha from repostory `repo_id` & branch `branch`
+    """
+    res = requests.get(
+        f"https://api.github.com/repos/{repo_id}/git/refs/heads/${branch}",
+        headers={"Authorization": f"bearer {token}"},
+    )
+    if res.status_code == 200:
+        head_oid = _re_head_oid.search(res.text)[1]
+        return head_oid
+    else:
+        raise Exception("get_head_oid failed: {{status: {res.status}, msg:{res.text}}}")
+
+
+def create_additions_str(path_to_built_docs):
+    """
+    Given `path_to_built_docs` dir, returns a str that is in format: `{path: "some_path", contents: "base64_repr_contents"}, ...`
+    see more here: https://docs.github.com/en/graphql/reference/input-objects#filechanges
+    """
+    p = Path(path_to_built_docs)
+    files = [x for x in p.glob("**/*") if x.is_file()]
+    additions = []
+
+    for fpath in files:
+        with open(fpath, "rb") as reader:
+            content = reader.read()
+            content_base64 = base64.b64encode(content)
+            content_base64 = str(content_base64, "utf-8")
+            additions.append(f'{{path: "{fpath}", contents: "{content_base64}"}}')
+
+    additions_str = ", ".join(additions)
+    return additions_str
+
+
+def commit_additions(additions_str, repo_id, head_oid, token, commit_msg):
+    """
+    Commits additions to a repository using Github GraphQL mutation `createCommitOnBranch`
+    see more here: https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch
+    """
+    # Select your transport with a defined url endpoint
+    transport = AIOHTTPTransport(url="https://api.github.com/graphql", headers={"Authorization": f"bearer {token}"})
+    # Create a GraphQL client using the defined transport
+    client = Client(transport=transport, fetch_schema_from_transport=True)
+    # Provide a GraphQL query
+    query = gql(
+        f"""
+  mutation{{
+    createCommitOnBranch(
+      input: {{
+        branch:{{
+          repositoryNameWithOwner: "{repo_id}",
+          branchName: "main"
+        }},
+        message: {{
+          headline: "{commit_msg}"
+        }},
+        fileChanges: {{
+          additions: [{additions_str}]
+        }},
+        expectedHeadOid: "{head_oid}"
+      }}
+    ) {{
+      clientMutationId
+    }}
+  }}
+  """
+    )
+    # Execute the query on the transport
+    result = client.execute(query)
+    return result
+
+
+def commit_command(args):
+    """
+    Commit file additions using Github GraphQL rather than `git`.
+    Usage: doc-builder commit $args
+    """
+    number_of_retries = 5
+    additions_str = create_additions_str(args.path_to_built_docs)
+    while number_of_retries:
+        try:
+            head_oid = get_head_oid(args.doc_build_repo_id, args.token)
+            commit_additions(additions_str, args.doc_build_repo_id, head_oid, args.token, args.commit_msg)
+        except TransportQueryError as e:
+            error_msg = str(e)
+            if "Expected branch to point to" in error_msg:
+                number_of_retries -= 1
+                print(f"Failed on try #{6-number_of_retries}, pushing again")
+
+
+def commit_command_parser(subparsers=None):
+    if subparsers is not None:
+        parser = subparsers.add_parser("commit")
+    else:
+        parser = argparse.ArgumentParser("Doc Builder commit command")
+
+    parser.add_argument(
+        "path_to_built_docs",
+        type=str,
+        help="Local path to library documentation. The library should be cloned, and the folder containing the "
+        "documentation files should be indicated here.",
+    )
+    parser.add_argument("--doc_build_repo_id", type=str, help="Language of the documentation to generate")
+    parser.add_argument("--token", type=str, help="Language of the documentation to generate")
+    parser.add_argument(
+        "--commit_msg",
+        type=str,
+        help="Version of the documentation to generate",
+        default="Github GraphQL createcommitonbranch commit",
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(func=commit_command)
+    return parser

--- a/src/doc_builder/commands/commit.py
+++ b/src/doc_builder/commands/commit.py
@@ -111,6 +111,7 @@ def commit_command(args):
         try:
             head_oid = get_head_oid(args.doc_build_repo_id, args.token)
             commit_additions(additions_str, args.doc_build_repo_id, head_oid, args.token, args.commit_msg)
+            break
         except TransportQueryError as e:
             error_msg = str(e)
             if "Expected branch to point to" in error_msg:

--- a/src/doc_builder/commands/doc_builder_cli.py
+++ b/src/doc_builder/commands/doc_builder_cli.py
@@ -17,9 +17,9 @@
 from argparse import ArgumentParser
 
 from doc_builder.commands.build import build_command_parser
-from doc_builder.commands.commit import commit_command_parser
 from doc_builder.commands.convert_doc_file import convert_command_parser
 from doc_builder.commands.preview import preview_command_parser
+from doc_builder.commands.push import push_command_parser
 from doc_builder.commands.style import style_command_parser
 
 
@@ -32,7 +32,7 @@ def main():
     build_command_parser(subparsers=subparsers)
     style_command_parser(subparsers=subparsers)
     preview_command_parser(subparsers=subparsers)
-    commit_command_parser(subparsers=subparsers)
+    push_command_parser(subparsers=subparsers)
 
     # Let's go
     args = parser.parse_args()

--- a/src/doc_builder/commands/doc_builder_cli.py
+++ b/src/doc_builder/commands/doc_builder_cli.py
@@ -17,6 +17,7 @@
 from argparse import ArgumentParser
 
 from doc_builder.commands.build import build_command_parser
+from doc_builder.commands.commit import commit_command_parser
 from doc_builder.commands.convert_doc_file import convert_command_parser
 from doc_builder.commands.preview import preview_command_parser
 from doc_builder.commands.style import style_command_parser
@@ -31,6 +32,7 @@ def main():
     build_command_parser(subparsers=subparsers)
     style_command_parser(subparsers=subparsers)
     preview_command_parser(subparsers=subparsers)
+    commit_command_parser(subparsers=subparsers)
 
     # Let's go
     args = parser.parse_args()

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -16,6 +16,7 @@
 import argparse
 import base64
 from pathlib import Path
+from time import time
 from typing import List, Optional, TypedDict
 
 import requests
@@ -206,9 +207,14 @@ def push_command(args):
     deletions = create_deletions(args.doc_build_repo_id, args.library_name, args.token)
     create_commit(gql_client, args.doc_build_repo_id, [], deletions, args.token, f"Clean before: {args.commit_msg}")
     # commit file additions
+    time_start = time()
     additions = create_additions(args.library_name)
+    time_end = time()
+    print(f"create_additions took {time_end-time_start} seconds or {(time_end-time_start)/60.0:.2f} mins")
     additions_chunks = chunk_additions(additions)
     partial_commit = False
+
+    time_start = time()
     while number_of_retries:
         try:
             for i, additions in enumerate(additions_chunks):
@@ -229,6 +235,9 @@ def push_command(args):
                     gql_client, args.doc_build_repo_id, [], deletions, args.token, f"Clean before: {args.commit_msg}"
                 )
             raise RuntimeError("create_commit additions failed") from e
+
+    time_end = time()
+    print(f"commit_additions took {time_end-time_start} seconds or {(time_end-time_start)/60.0:.2f} mins")
 
 
 def push_command_parser(subparsers=None):

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -17,7 +17,7 @@ import argparse
 import base64
 from pathlib import Path
 from time import time
-from typing import List, Optional, TypedDict
+from typing import Dict, List, Optional
 
 import requests
 from gql import Client, gql
@@ -40,12 +40,7 @@ def get_head_oid(repo_id: str, token: str, branch: Optional[str] = "main") -> st
     return head_oid
 
 
-class FileAddition(TypedDict):
-    path: str
-    contents: int
-
-
-def create_additions(library_name: str) -> List[FileAddition]:
+def create_additions(library_name: str) -> List[Dict]:
     """
     Given `library_name` dir, returns [FileAddition!]!: [{path: "some_path", contents: "base64_repr_contents"}, ...]
     see more here: https://docs.github.com/en/graphql/reference/input-objects#filechanges
@@ -67,7 +62,7 @@ def create_additions(library_name: str) -> List[FileAddition]:
 MAX_CHUNK_LEN = 3e7  # 30 Megabytes
 
 
-def create_additions_chunks(additions: List[FileAddition]) -> List[List[FileAddition]]:
+def create_additions_chunks(additions: List[Dict]) -> List[List[Dict]]:
     """
     Github GraphQL `createCommitOnBranch` mutation fails when a payload is bigger than 50 MB.
     Therefore, in those cases (transformers doc ~ 100 MB), we need to commit using
@@ -117,7 +112,7 @@ mutation (
 """
 
 
-def create_commit(gql_client: Client, repo_id: str, additions: List[FileAddition], token: str, commit_msg: str):
+def create_commit(gql_client: Client, repo_id: str, additions: List[Dict], token: str, commit_msg: str):
     """
     Commits additions and/or deletions to a repository using Github GraphQL mutation `createCommitOnBranch`
     see more here: https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -96,52 +96,6 @@ def chunk_additions(additions: List[FileAddition]) -> List[List[FileAddition]]:
     return additions_chunks
 
 
-class FileDeletion(TypedDict):
-    path: str
-
-
-def create_deletions(repo_id: str, library_name: str, token: str) -> List[FileDeletion]:
-    """
-    Given `repo_id/library_name` path, returns [FileDeletion!]!: [{path: "some_path"}, ...]
-    see more here: https://docs.github.com/en/graphql/reference/input-objects#filechanges
-    """
-    # GET doc-build-dev/transformers
-    res = requests.get(
-        f"https://api.github.com/repos/{repo_id}/git/trees/heads/main", headers={"Authorization": f"bearer {token}"}
-    )
-    if res.status_code != 200:
-        raise Exception(f"create_deletions failed (GET tree root): {res.message}")
-    json = res.json()
-    node = next(filter(lambda node: node["path"] == library_name, json["tree"]), None)
-    url = node["url"]
-
-    # GET doc-build-dev/transformers/pr_xyz
-    root_folder = Path(library_name)
-    doc_version_folder = next(root_folder.glob("*")).relative_to(root_folder)
-    doc_version_folder = str(doc_version_folder)
-    res = requests.get(url, headers={"Authorization": f"bearer {token}"})
-    if res.status_code != 200:
-        raise Exception(f"create_deletions failed (GET tree root/{repo_id}): {res.message}")
-    json = res.json()
-    node = next(filter(lambda node: node["path"] == doc_version_folder, json["tree"]), None)
-    if node is None:
-        # the no need to delete since the path does not exist
-        return []
-    url = node["url"]
-
-    # GET doc-build-dev/transformers/pr_xyz/**/*
-    res = requests.get(f"{url}?recursive=true", headers={"Authorization": f"bearer {token}"})
-    if res.status_code != 200:
-        raise Exception(f"create_deletions failed (GET tree root/{repo_id}/{doc_version_folder}): {res.message}")
-    json = res.json()
-    tree = json["tree"]
-    deletions = [
-        {"path": f"{library_name}/{doc_version_folder}/{node['path']}"} for node in tree if node["type"] == "blob"
-    ]
-
-    return deletions
-
-
 CREATE_COMMIT_ON_BRANCH_GRAPHQL = """
 mutation (
   $repo_id: String!
@@ -154,7 +108,7 @@ mutation (
     input: {
       branch: { repositoryNameWithOwner: $repo_id, branchName: "main" }
       message: { headline: $commit_msg }
-      fileChanges: { additions: $additions, deletions: $deletions }
+      fileChanges: { additions: $additions }
       expectedHeadOid: $head_oid
     }
   ) {
@@ -164,7 +118,7 @@ mutation (
 """
 
 
-def create_commit(gql_client: Client, repo_id: str, additions, deletions, token: str, commit_msg: str):
+def create_commit(gql_client: Client, repo_id: str, additions: List[FileAddition], token: str, commit_msg: str):
     """
     Commits additions and/or deletions to a repository using Github GraphQL mutation `createCommitOnBranch`
     see more here: https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch
@@ -174,7 +128,6 @@ def create_commit(gql_client: Client, repo_id: str, additions, deletions, token:
     head_oid = get_head_oid(repo_id, token)
     params = {
         "additions": additions,
-        "deletions": deletions,
         "repo_id": repo_id,
         "head_oid": head_oid,
         "commit_msg": commit_msg,
@@ -212,7 +165,7 @@ def push_command(args):
     while number_of_retries:
         try:
             for i, additions in enumerate(additions_chunks):
-                create_commit(gql_client, args.doc_build_repo_id, additions, [], args.token, args.commit_msg)
+                create_commit(gql_client, args.doc_build_repo_id, additions, args.token, args.commit_msg)
                 print(f"Committed additions chunk: {i+1}/{len(additions_chunks)}")
             break
         except Exception as e:

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -116,7 +116,7 @@ def push_command(args):
             error_msg = str(e)
             if "Expected branch to point to" in error_msg:
                 number_of_retries -= 1
-                print(f"Failed on try #{MAX_N_RETRIES-number_of_retries}, pushing again")
+                print(f"Failed on try #{max_n_retries-number_of_retries}, pushing again")
 
 
 def push_command_parser(subparsers=None):

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -167,6 +167,8 @@ def push_command(args):
             print(f"createCommitOnBranch error occurred: {e}")
             if number_of_retries:
                 print(f"Failed on try #{max_n_retries-number_of_retries}, pushing again")
+            else:
+                raise RuntimeError("create_commit additions failed") from e
 
     time_end = time()
     logging.debug(f"commit_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -101,7 +101,11 @@ def push_command(args):
     Commit file additions using Github GraphQL rather than `git`.
     Usage: doc-builder push $args
     """
-    number_of_retries = 5
+    if args.n_retries < 1:
+        raise ValueError(f"CLI arg `n_retries` MUST be positive & non-zero; supplied value was {args.n_retries}")
+
+    MAX_N_RETRIES = args.n_retries + 1
+    number_of_retries = args.n_retries
     additions_str = create_additions(args.path_to_built_docs)
     while number_of_retries:
         try:
@@ -112,7 +116,7 @@ def push_command(args):
             error_msg = str(e)
             if "Expected branch to point to" in error_msg:
                 number_of_retries -= 1
-                print(f"Failed on try #{6-number_of_retries}, pushing again")
+                print(f"Failed on try #{MAX_N_RETRIES-number_of_retries}, pushing again")
 
 
 def push_command_parser(subparsers=None):
@@ -138,6 +142,7 @@ def push_command_parser(subparsers=None):
         help="Git commit message",
         default="Github GraphQL createcommitonbranch commit",
     )
+    parser.add_argument("--n_retries", type=int, help="Number of push retries in the event of conflict", default=1)
 
     if subparsers is not None:
         parser.set_defaults(func=push_command)

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -104,7 +104,7 @@ def push_command(args):
     if args.n_retries < 1:
         raise ValueError(f"CLI arg `n_retries` MUST be positive & non-zero; supplied value was {args.n_retries}")
 
-    MAX_N_RETRIES = args.n_retries + 1
+    max_n_retries = args.n_retries + 1
     number_of_retries = args.n_retries
     additions_str = create_additions(args.path_to_built_docs)
     while number_of_retries:

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -95,7 +95,6 @@ CREATE_COMMIT_ON_BRANCH_GRAPHQL = """
 mutation (
   $repo_id: String!
   $additions: [FileAddition!]!
-  $deletions: [FileDeletion!]!
   $head_oid: GitObjectID!
   $commit_msg: String!
 ) {

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -97,10 +97,10 @@ def commit_additions(additions, repo_id, head_oid, token, commit_msg):
     return result
 
 
-def commit_command(args):
+def push_command(args):
     """
     Commit file additions using Github GraphQL rather than `git`.
-    Usage: doc-builder commit $args
+    Usage: doc-builder push $args
     """
     number_of_retries = 5
     additions_str = create_additions(args.path_to_built_docs)
@@ -116,11 +116,11 @@ def commit_command(args):
                 print(f"Failed on try #{6-number_of_retries}, pushing again")
 
 
-def commit_command_parser(subparsers=None):
+def push_command_parser(subparsers=None):
     if subparsers is not None:
-        parser = subparsers.add_parser("commit")
+        parser = subparsers.add_parser("push")
     else:
-        parser = argparse.ArgumentParser("Doc Builder commit command")
+        parser = argparse.ArgumentParser("Doc Builder push command")
 
     parser.add_argument(
         "path_to_built_docs",
@@ -141,5 +141,5 @@ def commit_command_parser(subparsers=None):
     )
 
     if subparsers is not None:
-        parser.set_defaults(func=commit_command)
+        parser.set_defaults(func=push_command)
     return parser

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -86,8 +86,8 @@ def create_additions_chunks(additions: List[FileAddition]) -> List[List[FileAddi
         else:
             # create a new chunk
             additions_chunks.append(current_chunk)
-            current_chunk = []
-            current_len = 0
+            current_chunk = [addition]
+            current_len = addition_len
 
     if current_chunk:
         additions_chunks.append(current_chunk)

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -67,7 +67,7 @@ def create_additions(library_name: str) -> List[FileAddition]:
 MAX_CHUNK_LEN = 3e7  # 30 Megabytes
 
 
-def chunk_additions(additions: List[FileAddition]) -> List[List[FileAddition]]:
+def create_additions_chunks(additions: List[FileAddition]) -> List[List[FileAddition]]:
     """
     Github GraphQL `createCommitOnBranch` mutation fails when a payload is bigger than 50 MB.
     Therefore, in those cases (transfoerms doc ~ 100 MB), we need to commit using
@@ -159,7 +159,7 @@ def push_command(args):
     additions = create_additions(args.library_name)
     time_end = time()
     print(f"create_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
-    additions_chunks = chunk_additions(additions)
+    additions_chunks = create_additions_chunks(additions)
 
     time_start = time()
     while number_of_retries:

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -77,8 +77,7 @@ def create_additions_chunks(additions: List[FileAddition]) -> List[List[FileAddi
     current_chunk = []
     current_len = 0
 
-    while additions:
-        addition = additions.pop()
+    for addition in additions:
         addition_len = len(addition["contents"])
         if current_len + addition_len < MAX_CHUNK_LEN:
             # can add to current_chunk

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -210,7 +210,7 @@ def push_command(args):
     time_start = time()
     additions = create_additions(args.library_name)
     time_end = time()
-    print(f"create_additions took {time_end-time_start} seconds or {(time_end-time_start)/60.0:.2f} mins")
+    print(f"create_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
     additions_chunks = chunk_additions(additions)
     partial_commit = False
 
@@ -237,7 +237,7 @@ def push_command(args):
             raise RuntimeError("create_commit additions failed") from e
 
     time_end = time()
-    print(f"commit_additions took {time_end-time_start} seconds or {(time_end-time_start)/60.0:.2f} mins")
+    print(f"commit_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
 
 
 def push_command_parser(subparsers=None):

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -22,7 +22,6 @@ from typing import List, Optional, TypedDict
 import requests
 from gql import Client, gql
 from gql.transport.aiohttp import AIOHTTPTransport
-from gql.transport.exceptions import TransportQueryError
 
 
 def get_head_oid(repo_id: str, token: str, branch: Optional[str] = "main") -> str:

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -70,7 +70,7 @@ MAX_CHUNK_LEN = 3e7  # 30 Megabytes
 def create_additions_chunks(additions: List[FileAddition]) -> List[List[FileAddition]]:
     """
     Github GraphQL `createCommitOnBranch` mutation fails when a payload is bigger than 50 MB.
-    Therefore, in those cases (transfoerms doc ~ 100 MB), we need to commit using
+    Therefore, in those cases (transformers doc ~ 100 MB), we need to commit using
     multiple smaller `createCommitOnBranch` mutation calls.
     """
     additions_chunks = []

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -15,6 +15,7 @@
 
 import argparse
 import base64
+import logging
 from pathlib import Path
 from time import time
 from typing import Dict, List, Optional
@@ -152,7 +153,7 @@ def push_command(args):
     time_start = time()
     additions = create_additions(args.library_name)
     time_end = time()
-    print(f"create_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
+    logging.debug(f"create_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
     additions_chunks = create_additions_chunks(additions)
 
     time_start = time()
@@ -169,7 +170,7 @@ def push_command(args):
                 print(f"Failed on try #{max_n_retries-number_of_retries}, pushing again")
 
     time_end = time()
-    print(f"commit_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
+    logging.debug(f"commit_additions took {time_end-time_start:.4f} seconds or {(time_end-time_start)/60.0:.2f} mins")
 
 
 def push_command_parser(subparsers=None):


### PR DESCRIPTION
Problem: read more [here](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1648134906365829)
> Cloning it in a GitHub Action workflow takes about 4 minutes, even with a --depth 1

Solution: as suggested by ~@LysandreJik~ @julien-c (edit by @LysandreJik), use Github GraphQL [createcommitonbranch mutation](https://github.blog/changelog/2021-09-13-a-simpler-api-for-authoring-commits/). And this PR does that


I've tested it on accelerate [here](https://github.com/huggingface/accelerate/pull/372/files) and it is [working here](https://github.com/huggingface/accelerate/runs/6498426135?check_suite_focus=true)
btw, can confirm that pushing with GraphQL is way fater since we do not need to clone doc-build-dev (which is roughly 30GB in size atm)


todo (note for myself):
- [ ] revert to `main` branch use in `ref` for the doc-builder checkout