### PR TITLE
Rm `[hash]` from doc-build artifcats

### DIFF
--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -10,3 +10,7 @@ cp src/routes/_toctree.yml build/_toctree.yml
 > $(find . -regex '.*build.*.css')
 cd build
 find . -name '*.html' -exec perl -pi -e 's/rel="stylesheet"/rel="modulepreload"/g' {} +
+
+# Remove hash from files
+find . -name '*.html' -exec perl -pi -e 's/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' {} +
+find . -name '*.js' -o -name '*.css' | perl -pe 'print $_; s/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' | xargs -n2 mv

--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -11,6 +11,8 @@ cp src/routes/_toctree.yml build/_toctree.yml
 cd build
 find . -name '*.html' -exec perl -pi -e 's/rel="stylesheet"/rel="modulepreload"/g' {} +
 
-# Remove hash from files
+# Replace hash in filenames of build artifcats with substring `hf-doc-builder`
+# so that git diff can be smaller since different hashes create new files that dont share git history
+# ex: assets/paths-4b3c6e7e.js -> assets/paths-hf-doc-builder.js
 find . -name '*.html' -exec perl -pi -e 's/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' {} +
 find . -name '*.js' -o -name '*.css' | perl -pe 'print $_; s/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' | xargs -n2 mv

--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -10,9 +10,12 @@ cp src/routes/_toctree.yml build/_toctree.yml
 > $(find . -regex '.*build.*.css')
 cd build
 find . -name '*.html' -exec perl -pi -e 's/rel="stylesheet"/rel="modulepreload"/g' {} +
+cd ..
 
 # Replace hash in filenames of build artifcats with substring `hf-doc-builder`
 # so that git diff can be smaller since different hashes create new files that dont share git history
 # ex: assets/paths-4b3c6e7e.js -> assets/paths-hf-doc-builder.js
+cd build
 find . -name '*.html' -exec perl -pi -e 's/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' {} +
 find . -name '*.js' -o -name '*.css' | perl -pe 'print $_; s/-[a-z0-9]{8}\.(js|css)/-hf-doc-builder\.$1/g' | xargs -n2 mv
+cd ..


### PR DESCRIPTION
Replace hash in filenames of build artifcats with substring `hf-doc-builder` so that git diff can be smaller since different hashes create new files that dont share git history.

[See more here
](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1653058266060879?thread_ts=1652694685.797019&cid=C02GLJ5S0E9)
example: `assets/paths-4b3c6e7e.js` -> `assets/paths-hf-doc-builder.js`

ideally, we use [output.assetFileNames](https://rollupjs.org/guide/en/#outputassetfilenames) in [vite build config](https://vitejs.dev/config/#build-rollupoptions) used [here in doc-builder](https://github.com/huggingface/doc-builder/blob/2ee7c63f4945b63762ffa61a52c1d227a7ccb415/kit/svelte.config.js#L38-L42).
However, svelte-kit does not allow it; see https://github.com/sveltejs/kit/issues/1410

Therefore, using a brute force approach using `kit/postbuild.sh` (perl regex to the rescue once again)

Note: this PR should be merged before https://github.com/huggingface/doc-builder/pull/214