### PR TITLE
Adapt index for namespace packages in autodoc.get_shortest_path

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -76,8 +76,8 @@ def get_shortest_path(obj, package):
     long_name = obj.__qualname__ if hasattr(obj, "__qualname__") else obj.__name__
     short_name = long_name.split(".")[0]
     path_splits = long_path.split(".")
-    idx = 0
     module = package
+    idx = module.__name__.count(".")
     while idx < len(path_splits) and not hasattr(module, short_name):
         idx += 1
         module = getattr(module, path_splits[idx])


### PR DESCRIPTION
When building the documentation for namespace packages such as Optimum subpackages (Graphcore/Habana/Intel), the package name is `optimum.{subpackage_name}`. For class or methods that are not imported in the root `__init__.py` of the subpackage, the command `[[autodoc]] path_to_my_class_or_method` will fail [here](https://github.com/huggingface/doc-builder/blob/77bf777999bb71f5f3c018f4d3b54b1616b544a2/src/doc_builder/autodoc.py#L83) because:
- no short name is available
- it will try to access the attribute `XXX` of the module `optimum.XXX`

You can find an example of such failure [here](https://github.com/huggingface/optimum-habana/runs/7620419218?check_suite_focus=true).

This PR proposes to initialize the value of the index `idx` at `module.__name__.count(".")` to take into account the `.` in the subpackage names.