### PR TITLE
Fix bug in styler when line after Parameter block is empty

### DIFF
--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -260,7 +260,9 @@ def style_docstring(docstring, max_len):
     ):
         param_indent = find_indent(lines[idx])
 
-    for idx, line in enumerate(lines):
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
         # Doing all re searches once for the one we need to repeat.
         list_search = _re_list.search(line)
         code_search = _re_code.search(line)
@@ -316,7 +318,13 @@ def style_docstring(docstring, max_len):
             current_paragraph = [line[current_indent:]]
         elif _re_args.search(line):
             new_lines.append(line)
-            param_indent = find_indent(lines[idx + 1])
+            idx += 1
+            while idx < len(lines) and is_empty_line(lines[idx]):
+                idx += 1
+            if idx < len(lines):
+                param_indent = find_indent(lines[idx])
+                # We still need to treat that line
+                idx -= 1
         elif _re_tip.search(line):
             # Add a new line before if not present
             if not is_empty_line(new_lines[-1]):
@@ -355,6 +363,8 @@ def style_docstring(docstring, max_len):
                 prefix = ""
         elif current_paragraph is not None:
             current_paragraph.append(line.lstrip())
+
+        idx += 1
 
     if current_paragraph is not None and len(current_paragraph) > 0:
         paragraph = " ".join(current_paragraph)

--- a/tests/test_style_doc.py
+++ b/tests/test_style_doc.py
@@ -24,6 +24,7 @@ from doc_builder.style_doc import (
     format_code_example,
     format_text,
     parse_code_example,
+    style_docstring,
 )
 
 
@@ -144,3 +145,20 @@ class BuildDocTester(unittest.TestCase):
             for i, line in enumerate(formatted_text.split("\n")):
                 self.assertTrue(line.startswith("    " if i > 0 else "  - "))
                 self.assertTrue(len(line) <= max_len)
+
+    def test_format_docstring_empty_line(self):
+        test_docstring = """Function description
+
+Params:
+
+    x (`int`): This is x.
+    y (`float`): this is y.
+"""
+        expected_result = """Function description
+
+Params:
+    x (`int`): This is x.
+    y (`float`): this is y.
+"""
+
+        self.assertEqual(style_docstring(test_docstring, 119)[0], expected_result)


### PR DESCRIPTION
There is currently a bug in the doc styler when there is an empty line after the parameter introduction:
```py
"""
Function description

Params:

    x (`int`): This is x.
    y (`float`): this is y.
"""
```
This will reformat all arguments on the same line after, an issue we have seen recently in Transformers with a generate doc PR. It will give:
```py
"""
Function description

Params:

    x (`int`): This is x. y (`float`): this is y.
"""
```

This PR fixes the bug and removes the extra empty lines so reformats the above as:
```py
"""
Function description

Params:
    x (`int`): This is x.
    y (`float`): this is y.
"""
```

Note: after being merged, we will need a release and a quick update to Transformers as this changes 16 files currently.