### PR TITLE
`create_commit` cmd support deletions

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin create_commit_deletions
+          git pull origin main
           pip install .
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin main
+          git pull origin create_commit_deletions
           pip install .
           cd ..
 

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -60,6 +60,48 @@ def create_additions(library_name: str) -> List[Dict]:
     return additions
 
 
+def create_deletions(repo_id: str, library_name: str, token: str) -> List[Dict]:
+    """
+    Given `repo_id/library_name` path, returns [FileDeletion!]!: [{path: "some_path"}, ...]
+    see more here: https://docs.github.com/en/graphql/reference/input-objects#filechanges
+    """
+    # GET doc-build-dev/transformers
+    res = requests.get(
+        f"https://api.github.com/repos/{repo_id}/git/trees/heads/main", headers={"Authorization": f"bearer {token}"}
+    )
+    if res.status_code != 200:
+        raise Exception(f"create_deletions failed (GET tree root): {res.message}")
+    json = res.json()
+    node = next(filter(lambda node: node["path"] == library_name, json["tree"]), None)
+    url = node["url"]
+
+    # GET doc-build-dev/transformers/pr_xyz
+    root_folder = Path(library_name)
+    doc_version_folder = next(root_folder.glob("*")).relative_to(root_folder)
+    doc_version_folder = str(doc_version_folder)
+    res = requests.get(url, headers={"Authorization": f"bearer {token}"})
+    if res.status_code != 200:
+        raise Exception(f"create_deletions failed (GET tree root/{repo_id}): {res.message}")
+    json = res.json()
+    node = next(filter(lambda node: node["path"] == doc_version_folder, json["tree"]), None)
+    if node is None:
+        # there is no need to delete since the path does not exist
+        return []
+    url = node["url"]
+
+    # GET doc-build-dev/transformers/pr_xyz/**/*
+    res = requests.get(f"{url}?recursive=true", headers={"Authorization": f"bearer {token}"})
+    if res.status_code != 200:
+        raise Exception(f"create_deletions failed (GET tree root/{repo_id}/{doc_version_folder}): {res.message}")
+    json = res.json()
+    tree = json["tree"]
+    deletions = [
+        {"path": f"{library_name}/{doc_version_folder}/{node['path']}"} for node in tree if node["type"] == "blob"
+    ]
+
+    return deletions
+
+
 MAX_CHUNK_LEN = 3e7  # 30 Megabytes
 
 
@@ -95,6 +137,7 @@ CREATE_COMMIT_ON_BRANCH_GRAPHQL = """
 mutation (
   $repo_id: String!
   $additions: [FileAddition!]!
+  $deletions: [FileDeletion!]!
   $head_oid: GitObjectID!
   $commit_msg: String!
 ) {
@@ -102,7 +145,7 @@ mutation (
     input: {
       branch: { repositoryNameWithOwner: $repo_id, branchName: "main" }
       message: { headline: $commit_msg }
-      fileChanges: { additions: $additions }
+      fileChanges: { additions: $additions, deletions: $deletions }
       expectedHeadOid: $head_oid
     }
   ) {
@@ -112,7 +155,9 @@ mutation (
 """
 
 
-def create_commit(client: Client, repo_id: str, additions: List[Dict], token: str, commit_msg: str):
+def create_commit(
+    client: Client, repo_id: str, additions: List[Dict], deletions: List[Dict], token: str, commit_msg: str
+):
     """
     Commits additions and/or deletions to a repository using Github GraphQL mutation `createCommitOnBranch`
     see more here: https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch
@@ -122,6 +167,7 @@ def create_commit(client: Client, repo_id: str, additions: List[Dict], token: st
     head_oid = get_head_oid(repo_id, token)
     params = {
         "additions": additions,
+        "deletions": deletions,
         "repo_id": repo_id,
         "head_oid": head_oid,
         "commit_msg": commit_msg,
@@ -143,7 +189,9 @@ def push_command(args):
     number_of_retries = args.n_retries
     n_seconds_sleep = 5
 
-    # commit file additions
+    # file deletions
+    deletions = create_deletions(args.doc_build_repo_id, args.library_name, args.token)
+    # file additions
     time_start = time()
     additions = create_additions(args.library_name)
     time_end = time()
@@ -158,9 +206,13 @@ def push_command(args):
                 url="https://api.github.com/graphql", headers={"Authorization": f"bearer {args.token}"}, verify=True
             )
             with Client(transport=transport, fetch_schema_from_transport=True, execute_timeout=None) as gql_client:
+                # commit file deletions
+                create_commit(
+                    gql_client, args.doc_build_repo_id, [], deletions, args.token, f"Clean before: {args.commit_msg}"
+                )
                 # commit push chunks additions
                 for i, additions in enumerate(additions_chunks):
-                    create_commit(gql_client, args.doc_build_repo_id, additions, args.token, args.commit_msg)
+                    create_commit(gql_client, args.doc_build_repo_id, additions, [], args.token, args.commit_msg)
                     print(f"Committed additions chunk: {i+1}/{len(additions_chunks)}")
             break
         except Exception as e:


### PR DESCRIPTION
Closes https://github.com/huggingface/doc-builder/issues/272

graphQL should commit deletions too:

tested by: [here](https://github.com/huggingface/hub-docs/pull/286/commits/68705ee3f47ddd3241aacf5f642203198f37b011) & [here](https://github.com/huggingface/doc-build-dev/commit/1c325b047e781e40d1f660311b544d593b66a774)