### PR TITLE
Add version suffix option

### DIFF
--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -103,6 +103,7 @@ def build_command(args):
         language=args.language,
         notebook_dir=notebook_dir,
         is_python_module=not args.not_python_module,
+        version_tag_suffix=args.version_tag_suffix,
     )
 
     # dev build should not update _versions.yml
@@ -195,6 +196,12 @@ def build_command_parser(subparsers=None):
         "--not_python_module",
         action="store_true",
         help="Whether docs files do NOT have correspoding python module (like HF course & hub docs).",
+    )
+    parser.add_argument(
+        "--version_tag_suffix",
+        type=str,
+        default="src/",
+        help="Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links. For example, the default `src/` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.",
     )
 
     if subparsers is not None:


### PR DESCRIPTION
Add an option to set the suffix (e.g. by default `src/`) after the version tag.

This will help fixing the broken documentation links in Optimum documentation as the structure is not `src/optimum/` but directly `optimum/` (see e.g. the broken links in https://huggingface.co/docs/optimum/main/en/onnxruntime/quantization#optimum.onnxruntime.ORTQuantizer ). Passing `doc-builder build --version_tag_suffix ""` will fix the issue.

An other approach could be to use an environment variable, let me know if you prefer it this way.