### PR TITLE
Optimize example code block regex

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -259,7 +259,7 @@ def is_rst_docstring(docstring):
 
 
 # Re pattern to catch example introduction & example code block.
-_re_example_codeblock = re.compile(r"((.*:\s+)?^```(((?!```)(.|\n))*)+```)", re.MULTILINE)
+_re_example_codeblock = re.compile(r"((.*:\s+)?^```((?!```)(.|\n))*```)", re.MULTILINE)
 
 
 def hashlink_example_codeblock(object_doc, object_anchor):


### PR DESCRIPTION
Fix the example code block regex to avoid the so-called "catastrophic backtracking" scenario, which causes CI to hang. For the reproduction, check [this](https://github.com/huggingface/datasets/blob/18e7454d53633577250452616e6991af064ac050/src/datasets/arrow_dataset.py#L959-L963) commit from https://github.com/huggingface/datasets/pull/4957 (notice the missing closing `` ``` ``).
 
