### PR TITLE
Fix _versions.yml merge collisions

### DIFF
--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -50,7 +50,13 @@ def create_additions(library_name: str) -> List[Dict]:
     files = [x for x in p.glob("**/*") if x.is_file()]
     additions = []
 
+    doc_version_folder = next(filter(lambda x: not x.is_file(), p.glob("*")), None).relative_to(p)
+    doc_version_folder = str(doc_version_folder)
+
     for fpath in files:
+        # do NOT commit _versions.yml on `main` branch builds as change in `_versions.yml` can collide with other doc builds
+        if doc_version_folder == "main" and str(fpath).endswith("_versions.yml"):
+            continue
         with open(fpath, "rb") as reader:
             content = reader.read()
             content_base64 = base64.b64encode(content)


### PR DESCRIPTION
Closes https://github.com/huggingface/doc-builder/issues/292

What was going on:
1. [This commit](https://github.com/huggingface/doc-build/commit/a1712d853c879966994cb4b476e07cfbebd34731) increments the version as transformers v.4.22 in _versions.yml
2. But afterwards immediately, [this commit](https://github.com/huggingface/doc-build/commit/9c940d6baa4f317db12f18fc4492621c6f339da9) removes v4.22 _versions.yml when transformers.__version__ changes back to dev mode

The explanation is that step2 had "old" _version.yml file before step1 finished committing the "new" _versions.yml

As a solution, we will not commit changes to _versions.yml when the branch is `main`