### PR TITLE
Handle windows paths with back slashes

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -455,6 +455,7 @@ def check_toc_integrity(doc_folder, output_dir):
     toc_file = Path(doc_folder) / "_toctree.yml"
     with open(toc_file, "r", encoding="utf-8") as f:
         toc_content = f.read()
+        print("DEBUG: HANDLE WINDOWS BACK SLASH")
         if os.name == "nt":
             # windows uses back slash for paths
             toc_content = toc_content.replace("/", "\\")

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -451,6 +451,8 @@ def check_toc_integrity(doc_folder, output_dir):
     """
     output_dir = Path(output_dir)
     doc_files = [str(f.relative_to(output_dir).with_suffix("").as_posix()) for f in output_dir.glob("**/*.mdx")]
+    if os.name == "nt":
+        doc_files = [file.replace("/", "\\") for file in doc_files]
 
     toc_file = Path(doc_folder) / "_toctree.yml"
     with open(toc_file, "r", encoding="utf-8") as f:

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -455,7 +455,6 @@ def check_toc_integrity(doc_folder, output_dir):
     toc_file = Path(doc_folder) / "_toctree.yml"
     with open(toc_file, "r", encoding="utf-8") as f:
         toc_content = f.read()
-        print("DEBUG: HANDLE WINDOWS BACK SLASH")
         if os.name == "nt":
             # windows uses back slash for paths
             toc_content = toc_content.replace("/", "\\")

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -454,7 +454,11 @@ def check_toc_integrity(doc_folder, output_dir):
 
     toc_file = Path(doc_folder) / "_toctree.yml"
     with open(toc_file, "r", encoding="utf-8") as f:
-        toc = yaml.safe_load(f.read())
+        toc_content = f.read()
+        if os.name == "nt":
+            # windows uses back slash for paths
+            toc_content = toc_content.replace("/", "\\")
+        toc = yaml.safe_load(toc_content)
 
     toc_sections = []
     sphinx_refs = []

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -135,6 +135,9 @@ def build_command(args):
 
             # Build doc with node
             working_dir = str(tmp_dir / "kit")
+            if os.name == "nt":
+                # windows uses back slash for paths
+                working_dir = working_dir.replace("/", "\\")
             print("Installing node dependencies")
             subprocess.run(
                 ["npm", "ci"],

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -128,6 +128,9 @@ def start_sveltekit_dev(tmp_dir, env, args):
     Installs sveltekit node dependencies & starts sveltekit in dev mode in a temp dir.
     """
     working_dir = str(tmp_dir / "kit")
+    if os.name == "nt":
+        # windows uses back slash for paths
+        working_dir = working_dir.replace("/", "\\")
     print("Installing node dependencies")
     subprocess.run(
         ["npm", "ci"],


### PR DESCRIPTION
Closes #306 
Closes #298

Could you test it locally on your machine? Thanks a lot

You can test this branch locally by:
```bash
# 1. install from source in dev mode (if not already)
git clone https://github.com/huggingface/doc-builder
cd doc-builder
pip install -e .
# 2. switch to this branch
git checkout windows_path
# 3. preview locally
doc-builder preview ...
```

cc: @dylanebert github is not letting me add you as a reviewer (probably, some credentials issue)