### PR TITLE
Handle the case where there is no empty line before the argument block

### DIFF
--- a/tests/test_style_doc.py
+++ b/tests/test_style_doc.py
@@ -162,3 +162,18 @@ Params:
 """
 
         self.assertEqual(style_docstring(test_docstring, 119)[0], expected_result)
+
+    def test_format_docstring_handle_params_without_empty_line_after_description(self):
+        test_docstring = """Function description
+Params:
+    x (`int`): This is x.
+    y (`float`): this is y.
+"""
+        expected_result = """Function description
+
+Params:
+    x (`int`): This is x.
+    y (`float`): this is y.
+"""
+
+        self.assertEqual(style_docstring(test_docstring, 119)[0], expected_result)


### PR DESCRIPTION
As the title says, handles the case where there is no empty line before the argument block, which was causing weird patterns to pop up in other libraries (like `transformers`).

For instance, 
```
Some description
Args:
    - foo
```

was being converted to

```
Args:
Some description
    - foo
```

This was because the paragraph was not seen as completed (no blank line), and the `Args:` line was appended as soon as it was seen. After this PR, the example above is converted to 

```
Some description

Args:
    - foo
```

i.e. an empty line before `Args:` is added when it is missing.