### PR TITLE
Add repo owner to doc source links

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -9,9 +9,10 @@ on:
       package:
         required: true
         type: string
+        description: "Name of the GitHub repo."
       package_name:
         type: string
-        description: "Should be used when a package name differs from its repostory name"
+        description: "Name of the Python package if it differs from repo name."
       path_to_docs:
         type: string
       notebook_folder:
@@ -130,7 +131,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --html ${{ inputs.additional_args }}"
+          args="--build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
 
           if [ ! -z "${{ inputs.notebook_folder }}" ];
           then

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -33,6 +33,10 @@ on:
         type: string
         default: 'huggingface'
         description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
+      version_tag_suffix:
+        type: string
+        default: "src/"
+        description: "Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links."
     secrets:
       token:
         required: false
@@ -131,7 +135,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
+          args="--build_dir ../build_dir --clean --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix=${{ inputs.version_tag_suffix }}"
 
           if [ ! -z "${{ inputs.notebook_folder }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
-          ref: repo-owner-bugfix
 
       - uses: actions/checkout@v2
         with:
@@ -113,7 +112,6 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin repo-owner-bugfix
           pip install .
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix ${{ inputs.version_tag_suffix }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix '${{ inputs.version_tag_suffix }}'"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix '${{ inputs.version_tag_suffix }}'"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix "${{ inputs.version_tag_suffix }}""
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -35,10 +35,6 @@ on:
         type: string
         default: 'huggingface'
         description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
-      version_tag_suffix:
-        type: string
-        default: 'src/'
-        description: Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links. For example, the default `src/` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.
     secrets:
       token:
         required: false
@@ -139,7 +135,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix "${{ inputs.version_tag_suffix }}""
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
+          ref: repo-owner-bugfix  # TODO - remove this line before merging
 
       - uses: actions/checkout@v2
         with:
@@ -112,6 +113,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
+          git pull origin repo-owner-bugfix  # TODO - switch back to main
           pip install .
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -35,6 +35,10 @@ on:
         type: string
         default: 'huggingface'
         description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
+      version_tag_suffix:
+        type: string
+        default: 'src/'
+        description: Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links. For example, the default `src/` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.
     secrets:
       token:
         required: false
@@ -135,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
+          ref: repo-owner-bugfix
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
-          ref: repo-owner-bugfix  # TODO - remove this line before merging
 
       - uses: actions/checkout@v2
         with:
@@ -117,7 +116,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin repo-owner-bugfix  # TODO - switch back to main
+          git pull origin main
           pip install .
           cd ..
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix ${{ inputs.version_tag_suffix }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix=${{ inputs.version_tag_suffix }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -35,6 +35,10 @@ on:
         type: string
         default: 'huggingface'
         description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
+      version_tag_suffix:
+        type: string
+        default: "src/"
+        description: "Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links."
     secrets:
       token:
         required: false
@@ -135,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix ${{ inputs.version_tag_suffix }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           echo "doc_folder has been set to ${{ env.doc_folder }}"
           cd doc-builder
-          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }}"
+          args="--build_dir ../build_dir --clean --version pr_${{ inputs.pr_number }} --html ${{ inputs.additional_args }} --repo_owner ${{ inputs.repo_owner }} --repo_name ${{ inputs.package }} --version_tag_suffix ${{ inputs.version_tag_suffix }}"
 
           if [ -z "${{ inputs.languages }}" ];
           then

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           pip uninstall -y doc-builder
           cd doc-builder
-          git pull origin main
+          git pull origin repo-owner-bugfix
           pip install .
           cd ..
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = ["GitPython", "tqdm", "pyyaml", "packaging", "nbformat", "hug
 extras = {}
 
 extras["transformers"] = ["transformers[dev]"]
-extras["testing"] = ["pytest", "pytest-xdist", "torch", "transformers", "tokenizers"]
+extras["testing"] = ["pytest", "pytest-xdist", "torch", "transformers", "tokenizers", "timm"]
 extras["quality"] = ["black~=22.0", "isort>=5.5.4", "flake8>=3.8.3"]
 
 extras["all"] = extras["testing"] + extras["quality"]

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -329,7 +329,8 @@ def get_source_link(obj, page_info, version_tag_suffix="src/"):
     """
     Returns the link to the source code of an object on GitHub.
     """
-    repo_name = page_info["repo_name"]
+    # Repo name defaults to package_name, but if provided in page_info, it will be used instead.
+    repo_name = page_info.get("repo_name", page_info.get("package_name"))
     version_tag = page_info.get("version_tag", "main")
     repo_owner = page_info.get("repo_owner", "huggingface")
     base_link = f"https://github.com/{repo_owner}/{repo_name}/blob/{version_tag}/{version_tag_suffix}"

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -329,10 +329,10 @@ def get_source_link(obj, page_info, version_tag_suffix="src/"):
     """
     Returns the link to the source code of an object on GitHub.
     """
-    package_name = page_info["package_name"]
+    repo_name = page_info["repo_name"]
     version_tag = page_info.get("version_tag", "main")
     repo_owner = page_info.get("repo_owner", "huggingface")
-    base_link = f"https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/{version_tag_suffix}"
+    base_link = f"https://github.com/{repo_owner}/{repo_name}/blob/{version_tag}/{version_tag_suffix}"
     module = obj.__module__.replace(".", "/")
     line_number = inspect.getsourcelines(obj)[1]
     source_file = inspect.getsourcefile(obj)

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -331,7 +331,8 @@ def get_source_link(obj, page_info, version_tag_suffix="src/"):
     """
     package_name = page_info["package_name"]
     version_tag = page_info.get("version_tag", "main")
-    base_link = f"https://github.com/huggingface/{package_name}/blob/{version_tag}/{version_tag_suffix}"
+    repo_owner = page_info.get("repo_owner", "huggingface")
+    base_link = f"https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/{version_tag_suffix}"
     module = obj.__module__.replace(".", "/")
     line_number = inspect.getsourcelines(obj)[1]
     source_file = inspect.getsourcefile(obj)
@@ -364,8 +365,8 @@ def document_object(object_name, package, page_info, full_name=True, anchor_name
         anchor_name (`str`, *optional*): The name to give to the anchor for this object.
         version_tag_suffix (`str`, *optional*, defaults to `"src/"`):
             Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links.
-            For example, the default `"src/"` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.
-            For example, `version_tag_suffix=""` will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/`.
+            For example, the default `"src/"` suffix will result in a base link as `https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/src/`.
+            For example, `version_tag_suffix=""` will result in a base link as `https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/`.
     """
     if page_info is None:
         page_info = {}
@@ -460,8 +461,8 @@ def autodoc(object_name, package, methods=None, return_anchors=False, page_info=
         page_info (`Dict[str, str]`, *optional*): Some information about the page.
         version_tag_suffix (`str`, *optional*, defaults to `"src/"`):
             Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links.
-            For example, the default `"src/"` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.
-            For example, `version_tag_suffix=""` will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/`.
+            For example, the default `"src/"` suffix will result in a base link as `https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/src/`.
+            For example, `version_tag_suffix=""` will result in a base link as `https://github.com/{repo_owner}/{package_name}/blob/{version_tag}/`.
     """
     if page_info is None:
         page_info = {}

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -388,6 +388,7 @@ def build_doc(
     watch_mode=False,
     version_tag_suffix="src/",
     repo_owner="huggingface",
+    repo_name=None,
 ):
     """
     Build the documentation of a package.
@@ -415,6 +416,8 @@ def build_doc(
             For example, `version_tag_suffix=""` will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/`.
         repo_owner (`str`, *optional*, defaults to `"huggingface"`):
             The owner of the repository on GitHub. In most cases, this is `"huggingface"`. However, for the `timm` library, the owner is `"rwightman"`.
+        repo_name (`str`, *optional*):
+            The name of the repository on GitHub. In most cases, this is the same as `package_name`. However, for the `timm` library, the name is `"pytorch-image-models"` instead of `"timm"`.
     """
     page_info = {
         "version": version,
@@ -422,6 +425,7 @@ def build_doc(
         "language": language,
         "package_name": package_name,
         "repo_owner": repo_owner,
+        "repo_name": repo_name or package_name,
     }
     if clean and Path(output_dir).exists():
         shutil.rmtree(output_dir)

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -387,6 +387,7 @@ def build_doc(
     is_python_module=False,
     watch_mode=False,
     version_tag_suffix="src/",
+    repo_owner="huggingface",
 ):
     """
     Build the documentation of a package.
@@ -412,8 +413,16 @@ def build_doc(
             Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links.
             For example, the default `"src/"` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.
             For example, `version_tag_suffix=""` will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/`.
+        repo_owner (`str`, *optional*, defaults to `"huggingface"`):
+            The owner of the repository on GitHub. In most cases, this is `"huggingface"`. However, for the `timm` library, the owner is `"rwightman"`.
     """
-    page_info = {"version": version, "version_tag": version_tag, "language": language, "package_name": package_name}
+    page_info = {
+        "version": version,
+        "version_tag": version_tag,
+        "language": language,
+        "package_name": package_name,
+        "repo_owner": repo_owner,
+    }
     if clean and Path(output_dir).exists():
         shutil.rmtree(output_dir)
 

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -416,7 +416,7 @@ def build_doc(
             For example, `version_tag_suffix=""` will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/`.
         repo_owner (`str`, *optional*, defaults to `"huggingface"`):
             The owner of the repository on GitHub. In most cases, this is `"huggingface"`. However, for the `timm` library, the owner is `"rwightman"`.
-        repo_name (`str`, *optional*):
+        repo_name (`str`, *optional*, defaults to `package_name`):
             The name of the repository on GitHub. In most cases, this is the same as `package_name`. However, for the `timm` library, the name is `"pytorch-image-models"` instead of `"timm"`.
     """
     page_info = {

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -425,7 +425,7 @@ def build_doc(
         "language": language,
         "package_name": package_name,
         "repo_owner": repo_owner,
-        "repo_name": repo_name or package_name,
+        "repo_name": repo_name if repo_name is not None else package_name,
     }
     if clean and Path(output_dir).exists():
         shutil.rmtree(output_dir)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -215,7 +215,7 @@ def build_command_parser(subparsers=None):
         "--repo_name",
         type=str,
         default=None,
-        help="Name of the repo (e.g. transformers, timm, etc.). By default, this is the same as the library_name.",
+        help="Name of the repo (e.g. transformers, pytorch-image-models, etc.). By default, this is the same as the library_name.",
     )
     if subparsers is not None:
         parser.set_defaults(func=build_command)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -105,6 +105,7 @@ def build_command(args):
         is_python_module=not args.not_python_module,
         version_tag_suffix=args.version_tag_suffix,
         repo_owner=args.repo_owner,
+        repo_name=args.repo_name,
     )
 
     # dev build should not update _versions.yml
@@ -209,6 +210,12 @@ def build_command_parser(subparsers=None):
         type=str,
         default="huggingface",
         help="Owner of the repo (e.g. huggingface, rwightman, etc.).",
+    )
+    parser.add_argument(
+        "--repo_name",
+        type=str,
+        default=None,
+        help="Name of the repo (e.g. transformers, timm, etc.). By default, this is the same as the library_name.",
     )
     if subparsers is not None:
         parser.set_defaults(func=build_command)

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -104,6 +104,7 @@ def build_command(args):
         notebook_dir=notebook_dir,
         is_python_module=not args.not_python_module,
         version_tag_suffix=args.version_tag_suffix,
+        repo_owner=args.repo_owner,
     )
 
     # dev build should not update _versions.yml
@@ -203,7 +204,12 @@ def build_command_parser(subparsers=None):
         default="src/",
         help="Suffix to add after the version tag (e.g. 1.3.0 or main) in the documentation links. For example, the default `src/` suffix will result in a base link as `https://github.com/huggingface/{package_name}/blob/{version_tag}/src/`.",
     )
-
+    parser.add_argument(
+        "--repo_owner",
+        type=str,
+        default="huggingface",
+        help="Owner of the repo (e.g. huggingface, rwightman, etc.).",
+    )
     if subparsers is not None:
         parser.set_defaults(func=build_command)
     return parser

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -54,14 +54,15 @@ def post_process_objects_inv(object_data, doc_url):
     return links
 
 
-def get_stable_version(package_name):
+def get_stable_version(package_name, repo_owner):
     """
     Gets the version of the last release of a package.
 
     Args:
         package_name (`str`): The name of the package.
+        repo_owner (`str`): The owner of the GitHub repo.
     """
-    github_url = f"https://github.com/huggingface/{package_name}"
+    github_url = f"https://github.com/{repo_owner}/{package_name}"
     try:
         # Get the version tags from the GitHub repo in decreasing order (that's what '-v:refname' means)
         result = git.cmd.Git().ls_remote(github_url, sort="-v:refname", tags=True)
@@ -80,7 +81,7 @@ def get_stable_version(package_name):
     return "main"
 
 
-def get_objects_map(package_name, version="main", language="en"):
+def get_objects_map(package_name, version="main", language="en", repo_owner="huggingface"):
     """
     Downloads the `objects.inv` for a package and post-processes it to get a nice dictionary.
 
@@ -93,7 +94,7 @@ def get_objects_map(package_name, version="main", language="en"):
     if version in ["main", "master"] or version.startswith("pr_"):
         package_version = "main"
     else:
-        package_version = get_stable_version(package_name)
+        package_version = get_stable_version(package_name, repo_owner)
 
     doc_url = f"{HF_DOC_PREFIX}{package_name}/{package_version}/{language}"
     url = f"{doc_url}/objects.inv"

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -63,7 +63,7 @@ def get_stable_version(package_name, repo_owner="huggingface", repo_name=None):
         repo_owner (`str`): The owner of the GitHub repo.
         repo_name (`str`): The name of the GitHub repo. If not provided, will be the same as the package name.
     """
-    repo_name = repo_name or package_name
+    repo_name = repo_name if repo_name is not None else package_name
     github_url = f"https://github.com/{repo_owner}/{repo_name}"
     try:
         # Get the version tags from the GitHub repo in decreasing order (that's what '-v:refname' means)
@@ -94,7 +94,7 @@ def get_objects_map(package_name, version="main", language="en", repo_owner="hug
         repo_owner (`str`, *optional*, defaults to `"huggingface"`): The owner of the GitHub repo.
         repo_name (`str`, *optional*): The name of the GitHub repo. If not provided, will be the same as the package name.
     """
-    repo_name = repo_name or package_name
+    repo_name = repo_name if repo_name is not None else package_name
     # We link to main in `package_name` from the main doc (or PR docs) but to the last stable release otherwise.
     if version in ["main", "master"] or version.startswith("pr_"):
         package_version = "main"

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -61,7 +61,8 @@ def get_stable_version(package_name, repo_owner="huggingface", repo_name=None):
     Args:
         package_name (`str`): The name of the package.
         repo_owner (`str`): The owner of the GitHub repo.
-        repo_name (`str`): The name of the GitHub repo. If not provided, will be the same as the package name.
+        repo_name (`str`, *optional*, defaults to `package_name`):
+            The name of the GitHub repo. If not provided, will be the same as the package name.
     """
     repo_name = repo_name if repo_name is not None else package_name
     github_url = f"https://github.com/{repo_owner}/{repo_name}"
@@ -92,7 +93,8 @@ def get_objects_map(package_name, version="main", language="en", repo_owner="hug
         version (`str`, *optional*, defaults to `"main"`): The version of the package for which documentation is built.
         language (`str`, *optional*, defaults to `"en"`): The langauge of the documentation being built.
         repo_owner (`str`, *optional*, defaults to `"huggingface"`): The owner of the GitHub repo.
-        repo_name (`str`, *optional*): The name of the GitHub repo. If not provided, will be the same as the package name.
+        repo_name (`str`, *optional*, defaults to `package_name`):
+            The name of the GitHub repo. If not provided, it will be the same as the package name.
     """
     repo_name = repo_name if repo_name is not None else package_name
     # We link to main in `package_name` from the main doc (or PR docs) but to the last stable release otherwise.

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -54,15 +54,17 @@ def post_process_objects_inv(object_data, doc_url):
     return links
 
 
-def get_stable_version(package_name, repo_owner):
+def get_stable_version(package_name, repo_owner="huggingface", repo_name=None):
     """
     Gets the version of the last release of a package.
 
     Args:
         package_name (`str`): The name of the package.
         repo_owner (`str`): The owner of the GitHub repo.
+        repo_name (`str`): The name of the GitHub repo. If not provided, will be the same as the package name.
     """
-    github_url = f"https://github.com/{repo_owner}/{package_name}"
+    repo_name = repo_name or package_name
+    github_url = f"https://github.com/{repo_owner}/{repo_name}"
     try:
         # Get the version tags from the GitHub repo in decreasing order (that's what '-v:refname' means)
         result = git.cmd.Git().ls_remote(github_url, sort="-v:refname", tags=True)
@@ -81,7 +83,7 @@ def get_stable_version(package_name, repo_owner):
     return "main"
 
 
-def get_objects_map(package_name, version="main", language="en", repo_owner="huggingface"):
+def get_objects_map(package_name, version="main", language="en", repo_owner="huggingface", repo_name=None):
     """
     Downloads the `objects.inv` for a package and post-processes it to get a nice dictionary.
 
@@ -89,14 +91,17 @@ def get_objects_map(package_name, version="main", language="en", repo_owner="hug
         package_name (`str`): The name of the external package.
         version (`str`, *optional*, defaults to `"main"`): The version of the package for which documentation is built.
         language (`str`, *optional*, defaults to `"en"`): The langauge of the documentation being built.
+        repo_owner (`str`, *optional*, defaults to `"huggingface"`): The owner of the GitHub repo.
+        repo_name (`str`, *optional*): The name of the GitHub repo. If not provided, will be the same as the package name.
     """
+    repo_name = repo_name or package_name
     # We link to main in `package_name` from the main doc (or PR docs) but to the last stable release otherwise.
     if version in ["main", "master"] or version.startswith("pr_"):
         package_version = "main"
     else:
-        package_version = get_stable_version(package_name, repo_owner)
+        package_version = get_stable_version(package_name, repo_owner, repo_name)
 
-    doc_url = f"{HF_DOC_PREFIX}{package_name}/{package_version}/{language}"
+    doc_url = f"{HF_DOC_PREFIX}{repo_name}/{package_version}/{language}"
     url = f"{doc_url}/objects.inv"
     try:
         request = requests.get(url, stream=True)

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -101,7 +101,7 @@ def get_objects_map(package_name, version="main", language="en", repo_owner="hug
     else:
         package_version = get_stable_version(package_name, repo_owner, repo_name)
 
-    doc_url = f"{HF_DOC_PREFIX}{repo_name}/{package_version}/{language}"
+    doc_url = f"{HF_DOC_PREFIX}{package_name}/{package_version}/{language}"
     url = f"{doc_url}/objects.inv"
     try:
         request = requests.get(url, stream=True)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -254,7 +254,7 @@ Users should refer to this superclass for more information regarding those metho
         self.assertEqual(get_source_link(transformers.pipeline, page_info), self.test_source_link_init)
 
     def test_get_source_link_different_repo_owner(self):
-        page_info = {"package_name": "pytorch-image-models", "repo_owner": "rwightman"}
+        page_info = {"package_name": "timm", "repo_owner": "rwightman", "repo_name": "pytorch-image-models"}
         self.assertEqual(
             get_source_link(timm.create_model, page_info, version_tag_suffix=""), self.test_source_link_timm
         )

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -255,7 +255,9 @@ Users should refer to this superclass for more information regarding those metho
 
     def test_get_source_link_different_repo_owner(self):
         page_info = {"package_name": "pytorch-image-models", "repo_owner": "rwightman"}
-        self.assertEqual(get_source_link(timm.create_model, page_info), self.test_source_link_timm)
+        self.assertEqual(
+            get_source_link(timm.create_model, page_info, version_tag_suffix=""), self.test_source_link_timm
+        )
 
     def test_document_object(self):
         page_info = {"package_name": "transformers"}

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -19,6 +19,7 @@ import unittest
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
+import timm
 import transformers
 from doc_builder.autodoc import (
     autodoc,
@@ -39,9 +40,10 @@ from transformers import BertModel, BertTokenizer, BertTokenizerFast
 from transformers.utils import PushToHubMixin
 
 
-# This is dynamic since the Transformers library is not frozen.
+# This is dynamic since the Transformers/timm libraries are not frozen.
 TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 TEST_LINE_NUMBER2 = inspect.getsourcelines(transformers.pipeline)[1]
+TEST_LINE_NUMBER_TIMM = inspect.getsourcelines(timm.create_model)[1]
 
 TEST_DOCSTRING = """Constructs a BERTweet tokenizer, using Byte-Pair-Encoding.
 
@@ -140,6 +142,9 @@ class AutodocTester(unittest.TestCase):
         f"https://github.com/huggingface/transformers/blob/main/src/transformers/utils/generic.py#L{TEST_LINE_NUMBER}"
     )
     test_source_link_init = f"https://github.com/huggingface/transformers/blob/main/src/transformers/pipelines/__init__.py#L{TEST_LINE_NUMBER2}"
+    test_source_link_timm = (
+        f"https://github.com/rwightman/pytorch-image-models/blob/main/timm/models/factory.py#L{TEST_LINE_NUMBER_TIMM}"
+    )
 
     def test_find_object_in_package(self):
         self.assertEqual(find_object_in_package("BertModel", transformers), BertModel)
@@ -247,6 +252,10 @@ Users should refer to this superclass for more information regarding those metho
         page_info = {"package_name": "transformers"}
         self.assertEqual(get_source_link(transformers.utils.ModelOutput, page_info), self.test_source_link)
         self.assertEqual(get_source_link(transformers.pipeline, page_info), self.test_source_link_init)
+
+    def test_get_source_link_different_repo_owner(self):
+        page_info = {"package_name": "pytorch-image-models", "repo_owner": "rwightman"}
+        self.assertEqual(get_source_link(timm.create_model, page_info), self.test_source_link_timm)
 
     def test_document_object(self):
         page_info = {"package_name": "transformers"}


### PR DESCRIPTION
While adding some reference docs to `timm`'s Docs, I noticed the "Source" links were incorrect in the API documentation - they always pointed to `github.com/huggingface/timm`. We want them to point to `github.com/rwightman/pytorch-image-models`. 

This PR aims to make that happen. 

As of the time of creating this PR, there is an ambiguity between `package` and `package_name`, which still makes links generate incorrectly with `package_name=timm`, as the github repo name should still be `pytorch-image-models`. Will sort out a fix for that...