### PR TITLE
Escape html vid tag

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -77,7 +77,7 @@ def convert_special_chars(text):
     text = _re_lcub_svelte.sub(lambda match: match[0].replace("&amp;lcub;", "{"), text)
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
     text = re.sub(
-        r"<(img|br|hr|Youtube|Question|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)",
+        r"<(img|video|br|hr|Youtube|Question|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)",
         r"LTHTML\1",
         text,
     )  # html void elements with no closing counterpart

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -98,6 +98,9 @@ export let fw: "pt" | "tf"
         img_code = '<img src="someSrc">'
         self.assertEqual(convert_special_chars(img_code), img_code)
 
+        video_code = '<video src="someSrc">'
+        self.assertEqual(convert_special_chars(video_code), video_code)
+
         comment = "<!-- comment -->"
         self.assertEqual(convert_special_chars(comment), comment)
 


### PR DESCRIPTION
`<video xyz></video>` was already working since doc-builder detects opening & closing tags of html. However, when they are combined `<video xyz/>` was not being detected as HTML video tag. This PR solves it