### PR TITLE
Resolve typos in comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ doc_folder
     ...
 ```
 
-Note that each language directory has it's own table of contents file `_toctree.yml` and that all languages are arranged under a single `doc_folder` directory - see the [`course`](https://github.com/huggingface/course/tree/main/chapters) repo for an example. You can then build the individual language subsets as follows:
+Note that each language directory has its own table of contents file `_toctree.yml` and that all languages are arranged under a single `doc_folder` directory - see the [`course`](https://github.com/huggingface/course/tree/main/chapters) repo for an example. You can then build the individual language subsets as follows:
 
 ```bash
 doc-builder {package_name} {path_to_docs} --build_dir {build_dir} --language {lang_id}
@@ -131,14 +131,14 @@ Values that should be put in `code` should either be surrounded by backticks: \`
 and objects like True, None or any strings should usually be put in `code`.
 
 When mentioning a class, function or method, it is recommended to use the following syntax for internal links so that our tool
-automarically adds a link to its documentation: \[\`XXXClass\`\] or \[\`function\`\]. This requires the class or 
+automatically adds a link to its documentation: \[\`XXXClass\`\] or \[\`function\`\]. This requires the class or 
 function to be in the main package.
 
 If you want to create a link to some internal class or function, you need to
-provide its path. For instance, in the Transformers documentation \[\`file_utils.ModelOutput\`\] will create a link to the documnetation of `ModelOutput`. This link will have `file_utils.ModelOutput` in the description. To get rid of the path and only keep the name of the object you are
+provide its path. For instance, in the Transformers documentation \[\`file_utils.ModelOutput\`\] will create a link to the documentation of `ModelOutput`. This link will have `file_utils.ModelOutput` in the description. To get rid of the path and only keep the name of the object you are
 linking to in the description, add a ~: \[\`~file_utils.ModelOutput\`\] will generate a link with `ModelOutput` in the description.
 
-The same works for methods so you can either use \[\`XXXClass.method\`\] or \[~\`XXXClass.method\`\].
+The same works for methods, so you can either use \[\`XXXClass.method\`\] or \[~\`XXXClass.method\`\].
 
 Multi-line code blocks can be useful for displaying examples. They are done between two lines of three backticks as usual in Markdown:
 

--- a/kit/postbuild.sh
+++ b/kit/postbuild.sh
@@ -17,7 +17,7 @@ cd build
 find . -name '*.html' -exec perl -pi -e 's/rel="stylesheet"/rel="modulepreload"/g' {} +
 cd ..
 
-# Replace hash in filenames of build artifcats with substring `hf-doc-builder`
+# Replace hash in filenames of build artifacts with substring `hf-doc-builder`
 # so that git diff can be smaller since different hashes create new files that dont share git history
 # ex: assets/paths-4b3c6e7e.js -> assets/paths-hf-doc-builder.js
 cd build

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -53,7 +53,7 @@ export const docstringPreprocess = {
 						${tipContent}
 					</div>`;
 				});
-				// render <Addded>, <Changed>, <Deprecated> components that are inside parameter descriptions
+				// render <Added>, <Changed>, <Deprecated> components that are inside parameter descriptions
 				code = code.replace(REGEX_CHANGED, (_, componentType, version, __, descriptionContent) => {
 					const color = /Added|Changed/.test(componentType) ? "green" : "orange";
 					if(!descriptionContent){
@@ -379,7 +379,7 @@ function renderSvelteChars(code) {
 }
 
 /**
- * The mdx file contains unnecessarily espaced underscores in the docstring's name
+ * The mdx file contains unnecessarily escaped underscores in the docstring's name
  */
 function unescapeUnderscores(content) {
 	return content.replace(/\\_/g, "_");

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -305,7 +305,7 @@ def generate_frontmatter_in_text(text, file_name=None):
         if header_level == 1:
             root = node
             # doc writers may choose to disable frontmatter generation
-            # currenly used in Quiz sections of hf course
+            # currently used in Quiz sections of hf course
             if is_disabled:
                 break
         else:

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -85,7 +85,7 @@ def build_command(args):
         version_ = version[1:]  # v2.1.0 -> 2.1.0
         version_tag = f"{version_prefix}{version_}"
 
-    # Disable notebook building for non-master verion
+    # Disable notebook building for non-master version
     if version != default_version:
         args.notebook_dir = None
 
@@ -197,7 +197,7 @@ def build_command_parser(subparsers=None):
     parser.add_argument(
         "--not_python_module",
         action="store_true",
-        help="Whether docs files do NOT have correspoding python module (like HF course & hub docs).",
+        help="Whether docs files do NOT have corresponding python module (like HF course & hub docs).",
     )
     parser.add_argument(
         "--version_tag_suffix",

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -229,7 +229,7 @@ def preview_command_parser(subparsers=None):
     parser.add_argument(
         "--not_python_module",
         action="store_true",
-        help="Whether docs files do NOT have correspoding python module (like HF course & hub docs).",
+        help="Whether docs files do NOT have corresponding python module (like HF course & hub docs).",
     )
 
     if subparsers is not None:

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -38,7 +38,7 @@ def create_zip_name(library_name, version, with_ext=True, legacy_separator=False
 
 def push_command(args):
     """
-    Commit file doc builds changes using: 1. zip doc build artifcats 2. hf_hub client to upload/delete zip file
+    Commit file doc builds changes using: 1. zip doc build artifacts 2. hf_hub client to upload/delete zip file
     Usage: doc-builder push $args
     """
     if args.n_retries < 1:
@@ -64,7 +64,7 @@ def push_command(args):
 
 def push_command_add(args):
     """
-    Commit file changes using: 1. zip doc build artifcats 2. hf_hub client to upload zip file
+    Commit file changes using: 1. zip doc build artifacts 2. hf_hub client to upload zip file
     Used in: build_main_documentation.yml & build_pr_documentation.yml
     """
     max_n_retries = args.n_retries + 1
@@ -181,9 +181,9 @@ def push_command_parser(subparsers=None):
     parser.add_argument(
         "--doc_build_repo_id",
         type=str,
-        help="Repo to which doc artifcats will be committed (e.g. `huggingface/doc-build-dev`)",
+        help="Repo to which doc artifacts will be committed (e.g. `huggingface/doc-build-dev`)",
     )
-    parser.add_argument("--token", type=str, help="Github token that has write/push premission to `doc_build_repo_id`")
+    parser.add_argument("--token", type=str, help="Github token that has write/push permission to `doc_build_repo_id`")
     parser.add_argument(
         "--commit_msg",
         type=str,

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -120,7 +120,7 @@ _re_literalinclude = re.compile(r"([ \t]*)<literalinclude>(((?!<literalinclude>)
 def convert_literalinclude_helper(match, page_info):
     """
     Convert a literalinclude regex match into markdown code blocks by opening a file and
-    copying specificed start-end section into markdown code block.
+    copying specified start-end section into markdown code block.
     """
     literalinclude_info = json.loads(match[2].strip())
     indent = match[1]

--- a/src/doc_builder/convert_to_notebook.py
+++ b/src/doc_builder/convert_to_notebook.py
@@ -37,7 +37,7 @@ _re_header = re.compile("^#+\s+\S+")
 _re_python_code = re.compile("^```\s*(py|python)\s*$")
 # Re pattern matching markdown links
 _re_markdown_links = re.compile(r"\[([^\]]*)\]\(([^\)]*)\)")
-# Re pattern matchin framework headers like <pytorch> or <tensorflow>
+# Re pattern matching framework headers like <pytorch> or <tensorflow>
 _re_framework = re.compile("^\s*<([a-z]*)>\s*$")
 
 

--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -91,7 +91,7 @@ def get_objects_map(package_name, version="main", language="en", repo_owner="hug
     Args:
         package_name (`str`): The name of the external package.
         version (`str`, *optional*, defaults to `"main"`): The version of the package for which documentation is built.
-        language (`str`, *optional*, defaults to `"en"`): The langauge of the documentation being built.
+        language (`str`, *optional*, defaults to `"en"`): The language of the documentation being built.
         repo_owner (`str`, *optional*, defaults to `"huggingface"`): The owner of the GitHub repo.
         repo_name (`str`, *optional*, defaults to `package_name`):
             The name of the GitHub repo. If not provided, it will be the same as the package name.

--- a/src/doc_builder/style_doc.py
+++ b/src/doc_builder/style_doc.py
@@ -51,7 +51,7 @@ def parse_code_example(code_lines):
 
     Args:
         code_lines (`List[str]`): The code lines to parse.
-        max_len (`int`): The maximum lengh per line.
+        max_len (`int`): The maximum length per line.
 
     Returns:
         (List[`str`], List[`str`]): The list of code samples and the list of outputs.
@@ -98,7 +98,7 @@ def format_code_example(code: str, max_len: int, in_docstring: bool = False):
 
     Args:
         code (`str`): The code example to format.
-        max_len (`int`): The maximum lengh per line.
+        max_len (`int`): The maximum length per line.
         in_docstring (`bool`, *optional*, defaults to `False`): Whether or not the code example is inside a docstring.
 
     Returns:

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -77,7 +77,7 @@ class BuildDocTester(unittest.TestCase):
             '---\nlocal: someheader\ntitle: SomeHeader 🤗\n---\n<h1 id="someheader">SomeHeader 🤗</h1>\n```\n',
         )
 
-        # test headers with exisitng ids
+        # test headers with existing ids
         self.assertEqual(
             generate_frontmatter_in_text("# Bert[[id1]]\n## BertTokenizer[[id2]]\n### BertTokenizerMethod"),
             '---\nlocal: id1\nsections:\n- local: id2\n  sections:\n  - local: berttokenizermethod\n    title: BertTokenizerMethod\n  title: BertTokenizer\ntitle: Bert\n---\n<h1 id="id1">Bert</h1>\n<h2 id="id2">BertTokenizer</h2>\n<h3 id="berttokenizermethod">BertTokenizerMethod</h3>',


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve a handful of typos in comments throughout this repository, as well as the README.

## Details
The typos were automatically detected using [`codespell`](https://github.com/codespell-project/codespell) and manually fixed if they indeed were a typo. For the README I also did some further manual checking.

- Tom Aarsen