### PR TITLE
Add Windows support to `preview` with minimal changes & CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,11 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
@@ -13,7 +17,7 @@ jobs:
         python-version: 3.7
     - name: Install Python dependencies
       run: |
-        pip install -e .[all]
+        pip install -e ".[all]"
         pip install git+https://github.com/huggingface/transformers
     - name: Run Tests
-      run: make test
+      run: python -m pytest -n 1 --dist=loadfile -s -v ./tests/

--- a/kit/src/routes/endpoints/toc.ts
+++ b/kit/src/routes/endpoints/toc.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import yaml from "js-yaml";
+import { fileURLToPath } from "url";
 
 export interface RawChapter {
   title: string;
@@ -23,7 +24,7 @@ const flattener = (_flatChapters: RawChapter[], chapter: RawChapter): RawChapter
 };
 
 export async function get() {
-  const filepath = path.join(import.meta.url.replace('file://', ''), '../..', '_toctree.yml');
+  const filepath = path.join(fileURLToPath(import.meta.url), '../..', '_toctree.yml');
   const content = (await fs.promises.readFile(filepath)).toString("utf-8");
 
   const chapters: RawChapter[] = yaml.load(content) as RawChapter[];

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -463,7 +463,7 @@ def check_toc_integrity(doc_folder, output_dir):
         output_dir (`str` or `os.PathLike`): The folder where the doc is built.
     """
     output_dir = Path(output_dir)
-    doc_files = [str(f.relative_to(output_dir).with_suffix("").as_posix()) for f in output_dir.glob("**/*.mdx")]
+    doc_files = [str(f.relative_to(output_dir).with_suffix("")) for f in output_dir.glob("**/*.mdx")]
 
     toc_file = Path(doc_folder) / "_toctree.yml"
     with open(toc_file, "r", encoding="utf-8") as f:
@@ -489,6 +489,8 @@ def check_toc_integrity(doc_folder, output_dir):
         # Toc has some nested sections in the API doc for instance, so we recurse.
         toc.extend([sec for sec in part["sections"] if "sections" in sec])
 
+    # normalize paths to current OS
+    toc_sections = [str(Path(path)) for path in toc_sections]
     files_not_in_toc = [f for f in doc_files if f not in toc_sections]
     doc_config = get_doc_config()
     disable_toc_check = getattr(doc_config, "disable_toc_check", False)

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -16,6 +16,7 @@
 
 import argparse
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
@@ -135,6 +136,7 @@ def start_sveltekit_dev(tmp_dir, env, args):
         check=True,
         encoding="utf-8",
         cwd=working_dir,
+        shell=platform.system() == "Windows",
     )
 
     # start sveltekit in dev mode
@@ -144,6 +146,7 @@ def start_sveltekit_dev(tmp_dir, env, args):
         encoding="utf-8",
         cwd=working_dir,
         env=env,
+        shell=platform.system() == "Windows",
     )
 
 


### PR DESCRIPTION
Closes #306
Closes #298
Closes #307 (supersedes it)

Hello!

## Pull Request overview
* Allow `doc-builder preview` on Windows without drastic implementation changes.
* Add Windows to the CI test suite.

## Scope
This PR is intended to add support for `doc-builder preview` for Windows. Other commands, such as building with `--html` are out of scope, as I don't believe that these commands are as useful. However, this support can also be added if requested in the future.

## Details
My experimentation has shown me that there were at least three main issues that prevented doc-builder from working on Windows. This PR tackles these three without negatively affecting other OSes.

### Issue 1
Windows users of `doc-builder preview` will be greeted with this Exception:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```
This is caused by these `subprocess.run` commands:
https://github.com/huggingface/doc-builder/blob/f398867d96150637e1bd4356969e5bf8fb12ac72/src/doc_builder/commands/preview.py#L132-L147
On windows, `shell=True` must be set (`False` is the default) to run a command in this manner. 

#### The fix
I have set this behaviour using `platform.system() == "Windows"`, causing these changes to only affect Windows users. See the `platform.system()` docs [here](https://docs.python.org/3.10/library/platform.html#platform.system).

### Issue 2
The `_toctree.yml` file will commonly contain files in directories, e.g. `api/main`. However, on Windows, `doc-builder` finds those files as `api\\main`. Exceptions are thrown due to this mismatch in `check_doc_integrity`. A workaround is to use `api\\main` in the `_toctree.yml`, but that will then *only* work for Windows users, which is even worse than the current behaviour.

#### The fix
The fix is elementary, we already rely on [`Path`](https://docs.python.org/3/library/pathlib.html#pathlib.Path) in this `check_doc_integrity`, so all we have to do is normalize both the toctree paths and the locally-discovered paths using `str(path)` with `path` as a `Path` instance. No need for OS-dependent conditionals here.

### Issue 3
This issue originates from improper URL modification in the TypeScript `get` endpoint, causing endless exceptions trying to load a path starting with `C:\C:\` when the browser is started up:
![Schermafbeelding_20230224_130847](https://user-images.githubusercontent.com/37621491/221189660-da3a4ff9-efb6-44e3-a679-661e3a0b50c9.png)

This issue originates here:
https://github.com/huggingface/doc-builder/blob/f398867d96150637e1bd4356969e5bf8fb12ac72/kit/src/routes/endpoints/toc.ts#L26

In this line, the `file://` is replaced in a non-recommended manner. Please have a look at the [this comment](https://github.com/nodejs/node/issues/28114#issuecomment-499977502) and the [FileURLToPath documentation](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_url_fileurltopath_url), which shows that improper use of slicing or replacing can have unintended consequences for cross-platform URLs.

#### The fix
The cross-platform fix is uses the recommended `FileURLToPath` function, which works for all platforms.

## Tests
For convenience, I have added Windows to the CI test runner. Although I can imagine that the test suite doesn't cover all cases, I imagine the Windows support in the CI would be useful.

## Closed issues
As mentioned, this PR closes some issues. I'd like to briefly discuss each:
* #306. This is not a bug. `tmp_dir` in the example is a `Path` instance, which is responsible for correctly handling paths through the `__truediv__` method.
* #298. The first item in thislist is indeed an issue. The second item is somewhat right: the preview indeed raises an error, but it is not caused by a forward slash for `working_dir` in `start_sveltekit_dev`. 
* #307. This PR makes unnecessarily many changes I'm afraid. It also mixes `os.path.join` with `Path` instances, which is not necessary. The true problem with this PR is that it adds `shell=True` at all times, modifying behaviour for Unix users. My PR only makes changes for Windows users.

---
Let me know if you need anything else from me at this point!

- Tom Aarsen
