### PR TITLE
Script to delete old docs

### DIFF
--- a/.github/workflows/delete_old_pr_documentations.yml
+++ b/.github/workflows/delete_old_pr_documentations.yml
@@ -1,0 +1,20 @@
+name: Delete old PRs docs
+on:
+  schedule:
+    - cron: "11 11 * * *"
+
+
+defaults:
+  run:
+    working-directory: scripts
+
+jobs:
+  delete_old_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno run --allow-env --allow-net --allow-run --allow-read ./delete-old-prs.ts
+        env:
+          HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}

--- a/scripts/.prettierrc
+++ b/scripts/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"tabWidth": 2,
+	"useTabs": true,
+	"printWidth": 120
+}

--- a/scripts/delete-old-prs.ts
+++ b/scripts/delete-old-prs.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net --allow-run --allow-read
+// To format: npx prettier --write .
+import { commit, listFiles } from "npm:@huggingface/hub@0.1.2";
+
+const oneMonthAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+
+const allFiles = listFiles({
+	repo: { type: "dataset", name: "hf-doc-build/doc-build-dev" },
+	recursive: true,
+});
+
+const filesToDelete: string[] = [];
+
+for await (const file of allFiles) {
+	if (file.type !== "file" || !file.path.endsWith(".zip")) {
+		continue;
+	}
+
+	const date = file.lastCommit?.author.date;
+
+	if (!date) {
+		continue;
+	}
+
+	if (oneMonthAgo < new Date(date)) {
+		continue;
+	}
+
+	filesToDelete.push(file.path);
+}
+
+if (filesToDelete.length) {
+	console.log("deleting", filesToDelete.length, "files");
+	await commit({
+		repo: { type: "dataset", name: "hf-doc-build/doc-build-dev" },
+		credentials: { accessToken: Deno.env.get("HF_ACCESS_TOKEN") },
+		title: "Delete old docs",
+		operations: filesToDelete.map((file) => ({
+			operation: "delete",
+			path: file,
+		})),
+	});
+}

--- a/scripts/delete-old-prs.ts
+++ b/scripts/delete-old-prs.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-env --allow-net --allow-run --allow-read
 // To format: npx prettier --write .
-import { commit, listFiles } from "npm:@huggingface/hub@0.1.2";
+import { commit, listFiles } from "npm:@huggingface/hub@0.1.3";
 
 const oneMonthAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
 
@@ -16,7 +16,7 @@ for await (const file of allFiles) {
 		continue;
 	}
 
-	const date = file.lastCommit?.author.date;
+	const date = file.lastCommit?.date;
 
 	if (!date) {
 		continue;


### PR DESCRIPTION
Use `@huggingface/hub` to delete old docs, docs older than 1 month. I wanted to do three months but we're going to periodically squash the repo, and docs can be regenrated anyway.

Use Deno to run the script without the need for a `package.json`.

The Github Action will run every day.