### PR TITLE
Don't show [lang] inference snippet if it was not supplied

### DIFF
--- a/kit/src/lib/InferenceApi.svelte
+++ b/kit/src/lib/InferenceApi.svelte
@@ -30,10 +30,12 @@
 	export let python = false;
 	export let js = false;
 	export let curl = false;
+
+	const snippetExists = {python, js, curl};
 </script>
 
 <div class="flex space-x-2 items-center my-1.5 mr-8 h-7 !pl-0 -mx-3 md:mx-0">
-	{#each LANGUAGES_CONFIG as language}
+	{#each LANGUAGES_CONFIG.filter(c => snippetExists[c.id]) as language}
 		<div
 			class="flex items-center border rounded-lg px-1.5 py-1 leading-none select-none text-smd
 			{$selectedInferenceLang === language.id


### PR DESCRIPTION
Fixes a bug where `curl` button was showing under inference snippet even though no curl snippet was supplied in the doc file

![image](https://user-images.githubusercontent.com/11827707/229724531-cb20f25e-9e79-495c-a4f0-e0d922b51f64.png)
