### PR TITLE
Add `<include>` block for including non-code files

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -150,8 +150,8 @@ def convert_file_include_helper(match, page_info, is_code=True):
             raise ValueError(f"The following '{include_name}' does NOT exist:\n{match[0]}")
         include = lines[start_after:end_before]
     include = [indent + line[include_info.get("dedent", 0) :] for line in include]
-    include = "".join(include)
-    return f"""{indent}```{include_info.get('language', '')}\n{include.rstrip()}\n{indent}```""" if is_code else include
+    include = "".join(include).rstrip()
+    return f"""{indent}```{include_info.get('language', '')}\n{include}\n{indent}```""" if is_code else include
 
 
 def convert_include(text, page_info):

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -116,8 +116,8 @@ def clean_doctest_syntax(text):
 
 
 _re_include_template = r"([ \t]*)<{include_name}>(((?!<{include_name}>).)*)<\/{include_name}>"
-_re_include = re.compile(_re_include_template.format(include_name='include'), re.DOTALL)
-_re_literalinclude = re.compile(_re_include_template.format(include_name='literalinclude'), re.DOTALL)
+_re_include = re.compile(_re_include_template.format(include_name="include"), re.DOTALL)
+_re_literalinclude = re.compile(_re_include_template.format(include_name="literalinclude"), re.DOTALL)
 
 
 def convert_file_include_helper(match, page_info, is_code=True):
@@ -130,7 +130,7 @@ def convert_file_include_helper(match, page_info, is_code=True):
     """
     include_info = json.loads(match[2].strip())
     indent = match[1]
-    include_name = 'literalinclude' if is_code else 'include'
+    include_name = "literalinclude" if is_code else "include"
     if tempfile.gettempdir() in str(page_info["path"]):
         return f"\n`Please restart doc-builder preview commands to see {include_name} rendered`\n"
     file = page_info["path"].parent / include_info["path"]

--- a/tests/data/convert_include_dummy.txt
+++ b/tests/data/convert_include_dummy.txt
@@ -1,0 +1,14 @@
+<!-- START header_1 -->
+# This is the first header
+Other text 1
+<!-- END header_1 -->
+
+<!-- START header_2 -->
+# This is the second header
+Other text 2
+<!-- END header_2 -->
+
+<!-- START header_3 -->
+# This is the third header
+Other text 3
+<!-- END header_3 -->

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -145,7 +145,7 @@ export let fw: "pt" | "tf"
         text = """<include>
 {"path": "./data/convert_include_dummy.txt"}
 </include>"""
-        expected_conversion = '''<!-- START header_1 -->
+        expected_conversion = """<!-- START header_1 -->
 # This is the first header
 Other text 1
 <!-- END header_1 -->
@@ -158,7 +158,7 @@ Other text 2
 <!-- START header_3 -->
 # This is the third header
 Other text 3
-<!-- END header_3 -->'''
+<!-- END header_3 -->"""
         self.assertEqual(convert_include(text, page_info), expected_conversion)
 
         # test with indent

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -170,8 +170,7 @@ Other text 3
 </include>"""
         expected_conversion = """Some text
     # This is the first header
-    Other text 1
-"""
+    Other text 1"""
         self.assertEqual(convert_include(text, page_info), expected_conversion)
 
         # test with dedent
@@ -184,8 +183,7 @@ Other text 3
 </include>"""
         expected_conversion = """Some text
     the first header
-     1
-"""
+     1"""
         self.assertEqual(convert_include(text, page_info), expected_conversion)
 
     def test_convert_literalinclude(self):

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from doc_builder.convert_md_to_mdx import (
     convert_img_links,
+    convert_include,
     convert_literalinclude,
     convert_md_to_mdx,
     convert_special_chars,
@@ -128,6 +129,64 @@ export let fw: "pt" | "tf"
 &amp;lcub;}
 &amp;lt;>"""
         self.assertEqual(process_md(text, page_info), expected_conversion)
+
+    def test_convert_include(self):
+        path = Path(__file__).resolve()
+        page_info = {"path": path}
+
+        # test canonical
+        text = """<include>
+{"path": "./data/convert_include_dummy.txt",
+"start-after": "START header_1",
+"end-before": "END header_1"}
+</include>"""
+
+        # test entire file
+        text = """<include>
+{"path": "./data/convert_include_dummy.txt"}
+</include>"""
+        expected_conversion = '''<!-- START header_1 -->
+# This is the first header
+Other text 1
+<!-- END header_1 -->
+
+<!-- START header_2 -->
+# This is the second header
+Other text 2
+<!-- END header_2 -->
+
+<!-- START header_3 -->
+# This is the third header
+Other text 3
+<!-- END header_3 -->'''
+        self.assertEqual(convert_include(text, page_info), expected_conversion)
+
+        # test with indent
+        text = """Some text
+    <include>
+{"path": "./data/convert_include_dummy.txt",
+"start-after": "START header_1",
+"end-before": "END header_1"}
+</include>"""
+        expected_conversion = """Some text
+    # This is the first header
+    Other text 1
+"""
+        self.assertEqual(convert_include(text, page_info), expected_conversion)
+
+        # test with dedent
+        text = """Some text
+    <include>
+{"path": "./data/convert_include_dummy.txt",
+"start-after": "START header_1",
+"end-before": "END header_1",
+"dedent": 10}
+</include>"""
+        expected_conversion = """Some text
+    the first header
+     1
+"""
+        self.assertEqual(convert_include(text, page_info), expected_conversion)
 
     def test_convert_literalinclude(self):
         path = Path(__file__).resolve()

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -134,12 +134,14 @@ export let fw: "pt" | "tf"
         path = Path(__file__).resolve()
         page_info = {"path": path}
 
-        # test canonical
-        text = """<include>
-{"path": "./data/convert_include_dummy.txt",
-"start-after": "START header_1",
-"end-before": "END header_1"}
-</include>"""
+        # canonical test:
+        # <include>
+        # {
+        #     "path": "./data/convert_include_dummy.txt",
+        #     "start-after": "START header_1",
+        #     "end-before": "END header_1"
+        # }
+        # </include>
 
         # test entire file
         text = """<include>
@@ -189,13 +191,17 @@ Other text 3
     def test_convert_literalinclude(self):
         path = Path(__file__).resolve()
         page_info = {"path": path}
-        # test canonical
-        text = """<literalinclude>
-{"path": "./data/convert_literalinclude_dummy.txt",
-"language": "python",
-"start-after": "START python_import",
-"end-before": "END python_import"}
-</literalinclude>"""
+
+        # canonical test:
+        # <literalinclude>
+        # {
+        #     "path": "./data/convert_literalinclude_dummy.txt",
+        #     "language": "python",
+        #     "start-after": "START python_import",
+        #     "end-before": "END python_import"
+        # }
+        # </literalinclude>
+
         # test entire file
         text = """<literalinclude>
 {"path": "./data/convert_literalinclude_dummy.txt",


### PR DESCRIPTION
Allow markdown files to include other (non-code) files. Useful to ensure minimal duplication across files.

I added a few test cases (copy-pasted and edited from `literalinclude`)