### PR TITLE
Optimize html tag replace regex (Fixes #331)

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -78,10 +78,12 @@ def convert_special_chars(text):
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
     # source is a special tag, it can be standalone (html tag) or closing (doc tag)
 
-    # NOTE: \w+ necessary since tags must start with a letter
-    _re_lt_html = re.compile(r"<(\s*\/?\s*\w+[^>]*?)>", re.DOTALL)
+    # Temporarily replace all valid HTML tags with LTHTML
+    _re_lt_html = re.compile(r"<(((!(DOCTYPE|--))|((\/\s*)?\w+))[^>]*?)>", re.DOTALL)
     text = re.sub(_re_lt_html, r"LTHTML\1>", text)
-    text = re.sub(r"(^|[^<])<([^(<|!)]|$)", r"\1&amp;lt;\2", text)
+    # Encode remaining < symbols
+    text = text.replace("<", "&amp;lt;")
+    # Put back the HTML tags
     text = text.replace("LTHTML", "<")
     return text
 

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -77,16 +77,14 @@ def convert_special_chars(text):
     text = _re_lcub_svelte.sub(lambda match: match[0].replace("&amp;lcub;", "{"), text)
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
     # source is a special tag, it can be standalone (html tag) or closing (doc tag)
+    
+    # NOTE: \w+ necessary since tags must start with a letter
+    _re_lt_html = re.compile(r"<(\s*\/?\s*\w+[^>]*?)>", re.DOTALL)
     text = re.sub(
-        r"<(img|video|br|hr|/?source|Youtube|Question|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)",
-        r"LTHTML\1",
-        text,
-    )  # html void elements with no closing counterpart
-
-    _re_lt_html = re.compile(r"<(\S+)([^>]*>)", re.DOTALL)
-    while _re_lt_html.search(text):
-        text = _re_lt_html.sub(r"LTHTML\1\2", text)
-
+        _re_lt_html,
+        r"LTHTML\1>",
+        text
+    )
     text = re.sub(r"(^|[^<])<([^(<|!)]|$)", r"\1&amp;lt;\2", text)
     text = text.replace("LTHTML", "<")
     return text

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -77,14 +77,10 @@ def convert_special_chars(text):
     text = _re_lcub_svelte.sub(lambda match: match[0].replace("&amp;lcub;", "{"), text)
     # We don't want to replace those by the HTML code, so we temporarily set them at LTHTML
     # source is a special tag, it can be standalone (html tag) or closing (doc tag)
-    
+
     # NOTE: \w+ necessary since tags must start with a letter
     _re_lt_html = re.compile(r"<(\s*\/?\s*\w+[^>]*?)>", re.DOTALL)
-    text = re.sub(
-        _re_lt_html,
-        r"LTHTML\1>",
-        text
-    )
+    text = re.sub(_re_lt_html, r"LTHTML\1>", text)
     text = re.sub(r"(^|[^<])<([^(<|!)]|$)", r"\1&amp;lt;\2", text)
     text = text.replace("LTHTML", "<")
     return text

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -82,9 +82,11 @@ def convert_special_chars(text):
         r"LTHTML\1",
         text,
     )  # html void elements with no closing counterpart
-    _re_lt_html = re.compile(r"<(\S+)([^>]*>)(((?!</\1>).)*)<(/\1>)", re.DOTALL)
+
+    _re_lt_html = re.compile(r"<(\S+)([^>]*>)", re.DOTALL)
     while _re_lt_html.search(text):
-        text = _re_lt_html.sub(r"LTHTML\1\2\3LTHTML\5", text)
+        text = _re_lt_html.sub(r"LTHTML\1\2", text)
+
     text = re.sub(r"(^|[^<])<([^(<|!)]|$)", r"\1&amp;lt;\2", text)
     text = text.replace("LTHTML", "<")
     return text

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -82,6 +82,11 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
         self.assertEqual(convert_special_chars("<p>5 <= 10"), "<p>5 &amp;lt;= 10")  # no closing tag
         self.assertEqual(convert_special_chars("5 <= 10</p>"), "5 &amp;lt;= 10</p>")  # no opening tag
         self.assertEqual(convert_special_chars("<a>test</b>"), "<a>test</b>")  # mismatched tags
+        self.assertEqual(convert_special_chars("<p>5 < 10</p>"), "<p>5 &amp;lt; 10</p>")
+        self.assertEqual(convert_special_chars("<p>5 > 10</p>"), "<p>5 > 10</p>")
+        self.assertEqual(convert_special_chars("<!--...-->"), "<!--...-->")  # comment
+        self.assertEqual(convert_special_chars("<!-- < -->"), "<!-- &amp;lt; -->")  # comment
+        self.assertEqual(convert_special_chars("<!DOCTYPE html> 1 < 2"), "<!DOCTYPE html> 1 &amp;lt; 2")
 
         longer_test = """<script lang="ts">
 import Tip from "$lib/Tip.svelte";

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -76,10 +76,12 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
         self.assertEqual(convert_special_chars("</br>"), "</br>")
         self.assertEqual(convert_special_chars("<br />"), "<br />")
         self.assertEqual(convert_special_chars("<p>5 <= 10</p>"), "<p>5 &amp;lt;= 10</p>")
-        self.assertEqual(convert_special_chars("<p align='center'>5 <= 10</p>"), "<p align='center'>5 &amp;lt;= 10</p>")
-        self.assertEqual(convert_special_chars("<p>5 <= 10"), "<p>5 &amp;lt;= 10") # no closing tag
-        self.assertEqual(convert_special_chars("5 <= 10</p>"), "5 &amp;lt;= 10</p>") # no opening tag
-        self.assertEqual(convert_special_chars("<a>test</b>"), "<a>test</b>") # mismatched tags
+        self.assertEqual(
+            convert_special_chars("<p align='center'>5 <= 10</p>"), "<p align='center'>5 &amp;lt;= 10</p>"
+        )
+        self.assertEqual(convert_special_chars("<p>5 <= 10"), "<p>5 &amp;lt;= 10")  # no closing tag
+        self.assertEqual(convert_special_chars("5 <= 10</p>"), "5 &amp;lt;= 10</p>")  # no opening tag
+        self.assertEqual(convert_special_chars("<a>test</b>"), "<a>test</b>")  # mismatched tags
 
         longer_test = """<script lang="ts">
 import Tip from "$lib/Tip.svelte";

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -73,6 +73,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
         self.assertEqual(convert_special_chars("<hr>"), "<hr>")
         self.assertEqual(convert_special_chars("<source>"), "<source>")
         self.assertEqual(convert_special_chars("<Youtube id='my_vid' />"), "<Youtube id='my_vid' />")
+        self.assertEqual(convert_special_chars("</br>"), "</br>")
+        self.assertEqual(convert_special_chars("<br />"), "<br />")
+        self.assertEqual(convert_special_chars("<p>5 <= 10</p>"), "<p>5 &amp;lt;= 10</p>")
+        self.assertEqual(convert_special_chars("<p align='center'>5 <= 10</p>"), "<p align='center'>5 &amp;lt;= 10</p>")
+        self.assertEqual(convert_special_chars("<p>5 <= 10"), "<p>5 &amp;lt;= 10") # no closing tag
+        self.assertEqual(convert_special_chars("5 <= 10</p>"), "5 &amp;lt;= 10</p>") # no opening tag
+        self.assertEqual(convert_special_chars("<a>test</b>"), "<a>test</b>") # mismatched tags
 
         longer_test = """<script lang="ts">
 import Tip from "$lib/Tip.svelte";


### PR DESCRIPTION
Building/previewing the docs for Transformers.js takes >12 minutes on my system and ~15 minutes with GitHub actions:
![image](https://github.com/huggingface/doc-builder/assets/26504141/a9c51905-befd-4148-96d8-38ffcb126751)

After investigating further, its due to this line of code, which consumes >99% of build time:

https://github.com/huggingface/doc-builder/blob/c59346e932a62f9edb9bfbb68c6ac8096ee50282/src/doc_builder/convert_md_to_mdx.py#L85-L87

The regex is very strict, and requires that the start and end tag match. However, in practice, this is not necessary at all (and in fact, will break on slightly malformed html tags). A better (and much faster approach) is to just replace the `<` character of any valid start/end tag (regardless of whether they have a matching pair). That is the purpose of this PR.

---

Before:
```bash
Building the MDX files: 100%|██████████| 30/30 [10:35<00:00, 22.71s/it]
```

After:
```bash
Building the MDX files: 100%|██████████| 30/30 [00:00<00:00, 124.46it/s]
```

which is a ~3000x speedup.

---

This fixes https://github.com/huggingface/doc-builder/issues/331, which reported the same issue.