### PR TITLE
fix: remove with-hover

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -511,7 +511,7 @@ function headingWithAnchorLink(code) {
 		return `<h${level} class="relative group">
 	<a 
 		id="${id}" 
-		class="header-link block pr-1.5 text-lg no-hover:hidden with-hover:absolute with-hover:p-1.5 with-hover:opacity-0 with-hover:group-hover:opacity-100 with-hover:right-full" 
+		class="header-link block pr-1.5 text-lg hidden md:absolute md:p-1.5 md:opacity-0 md:group-hover:opacity-100 md:right-full" 
 		href="#${id}"
 	>
 		<span><IconCopyLink/></span>

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -104,7 +104,7 @@
 		{@html highlightSignature(name)}
 		<a
 			id={anchor}
-			class="header-link invisible with-hover:group-hover:visible pr-2"
+			class="header-link invisible group-hover:visible pr-2"
 			href="#{anchor}"
 		>
 			<IconCopyLink />
@@ -179,7 +179,7 @@
 						<span class="group flex space-x-1.5 items-start">
 							<a
 								id={anchor}
-								class="header-link block pr-0.5 text-lg no-hover:hidden with-hover:absolute with-hover:p-1.5 with-hover:opacity-0 with-hover:group-hover:opacity-100 with-hover:right-full"
+								class="header-link block pr-0.5 text-lg hidden md:absolute md:p-1.5 md:opacity-0 md:group-hover:opacity-100 md:right-full"
 								href={`#${anchor}`}
 							>
 								<span><IconCopyLink classNames="text-smd" /></span>
@@ -203,7 +203,7 @@
 							<span class="group flex space-x-1.5 items-start">
 								<a
 									id={anchor}
-									class="header-link block pr-0.5 text-lg no-hover:hidden with-hover:absolute with-hover:p-1.5 with-hover:opacity-0 with-hover:group-hover:opacity-100 with-hover:right-full"
+									class="header-link block pr-0.5 text-lg hidden md:absolute md:p-1.5 md:opacity-0 md:group-hover:opacity-100 md:right-full"
 									href={`#${anchor}`}
 								>
 									<span><IconCopyLink classNames="text-smd" /></span>

--- a/kit/src/lib/ExampleCodeBlock.svelte
+++ b/kit/src/lib/ExampleCodeBlock.svelte
@@ -30,7 +30,7 @@
 <div class="relative group rounded-md" bind:this={containerEl}>
 	<a
 		id={anchor}
-		class="header-link block pr-0.5 text-lg no-hover:hidden with-hover:absolute with-hover:p-1.5 with-hover:opacity-0 with-hover:group-hover:opacity-100 with-hover:right-full"
+		class="header-link block pr-0.5 text-lg hidden md:absolute md:p-1.5 md:opacity-0 md:group-hover:opacity-100 md:right-full"
 		href={`#${anchor}`}
 	>
 		<span><IconCopyLink classNames="text-smd" /></span>

--- a/kit/tailwind.config.cjs
+++ b/kit/tailwind.config.cjs
@@ -37,10 +37,6 @@ module.exports = {
 			maxWidth: {
 				"2xs": "16rem"
 			},
-			screens: {
-				"with-hover": { raw: "(hover: hover)" },
-				"no-hover": { raw: "(hover: none)" }
-			},
 			gridTemplateRows: {
 				full: "100%"
 			},


### PR DESCRIPTION
`with-hover` isn't supported by the hf hub anymore.

To prevent 
![image](https://github.com/huggingface/doc-builder/assets/468620/608dc7b2-d7c4-426e-b6a1-fe9b9bfc3fff)
