### PR TITLE
Fix concurrent uploads

### DIFF
--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -15,7 +15,6 @@
 
 import argparse
 import logging
-import os
 import shutil
 from pathlib import Path
 from time import sleep, time


### PR DESCRIPTION
### Problem

When [upload_version_yml](https://github.com/huggingface/doc-builder/blob/8ad63afbad27c3d1fd400042a92f0f7f88b895d8/src/doc_builder/commands/push.py#L179-L183) flag is on, doc-builder pushes two updates to hf hub: 1. updated _version.yml files 2. zipped doc built artifacts. However, this was causing a concurrency problem as two files were being uploaded same time


### Solution

Put the two files in a same folder and upload the folder instead of uploading two files separately

