### PR TITLE
FIX html escape regex

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -22,6 +22,11 @@ from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
 
 
 _re_doctest_flags = re.compile(r"^(>>>.*\S)(\s+)# doctest:\s+\+[A-Z_]+\s*$", flags=re.MULTILINE)
+_re_lt_html = re.compile(r"<(((!(DOCTYPE|--))|((\/\s*)?[a-z]+))[^>]*?)>", re.IGNORECASE)
+_re_lcub_svelte = re.compile(
+    r"<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)(((?!<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)).)*)>|&amp;lcub;(#if|:else}|/if})",
+    re.DOTALL,
+)
 
 
 def convert_md_to_mdx(md_text, page_info):
@@ -68,10 +73,6 @@ def convert_special_chars(text):
     """
     Convert { and < that have special meanings in MDX.
     """
-    _re_lcub_svelte = re.compile(
-        r"<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)(((?!<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)).)*)>|&amp;lcub;(#if|:else}|/if})",
-        re.DOTALL,
-    )
     text = text.replace("{", "&amp;lcub;")
     # We don't want to escape `{` that are part of svelte syntax
     text = _re_lcub_svelte.sub(lambda match: match[0].replace("&amp;lcub;", "{"), text)
@@ -79,7 +80,6 @@ def convert_special_chars(text):
     # source is a special tag, it can be standalone (html tag) or closing (doc tag)
 
     # Temporarily replace all valid HTML tags with LTHTML
-    _re_lt_html = re.compile(r"<(((!(DOCTYPE|--))|((\/\s*)?\w+))[^>]*?)>", re.DOTALL)
     text = re.sub(_re_lt_html, r"LTHTML\1>", text)
     # Encode remaining < symbols
     text = text.replace("<", "&amp;lt;")

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -122,6 +122,16 @@ export let fw: "pt" | "tf"
         comment = "<!-- comment -->"
         self.assertEqual(convert_special_chars(comment), comment)
 
+        comment = "<!-- multi line\ncomment -->"
+        self.assertEqual(convert_special_chars(comment), comment)
+
+        # Regression test for huggingface_hub
+        # '<' must not be considered an HTML tag before a number
+        self.assertEqual(
+            convert_special_chars("something <5MB something else -> here"),
+            "something &amp;lt;5MB something else -> here",
+        )
+
     def test_convert_img_links(self):
         page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
 

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -125,7 +125,7 @@ export let fw: "pt" | "tf"
         comment = "<!-- multi line\ncomment -->"
         self.assertEqual(convert_special_chars(comment), comment)
 
-        # Regression test for huggingface_hub
+        # Regression test for https://github.com/huggingface/doc-builder/pull/394
         # '<' must not be considered an HTML tag before a number
         self.assertEqual(
             convert_special_chars("something <5MB something else -> here"),


### PR DESCRIPTION
Related to https://github.com/huggingface/doc-builder/pull/373 which broke the docs in `huggingface_hub` (see https://github.com/huggingface/doc-builder/pull/373#issuecomment-1697142555). The issue is caused by a [docstring](https://github.com/huggingface/huggingface_hub/blob/111fdbe3508a8727da7acf17ee84ec613608b801/src/huggingface_hub/file_download.py#L1026) in which both a `"<"` and a `">"` are written but not as a HTML tag (e.g.`"... <5MB ....  .... something -> something else"`). This PR fixes it, hopefully without breaking other docs.

In details:
- Update `_re_lt_html`:
    - remove `re.DOTALL` (unused in the regex)
    - add `re.IGNORECASE`
    - update from `\w+` to `[a-z]` after the first `"<"` => the start of a tag must be a letter, not an alphanumeric. This way we don't capture string like  `"<5MB"` anymore. This update fixes the `huggingface_hub` issue.
- Move `_re_lt_html` and `_re_lcub_svelte` regexes outside of  `convert_md_to_mdx` to compile them only once.
- Add a regression test.

