### PR TITLE
Update README.md with missing build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ doc_folder
 Note that each language directory has its own table of contents file `_toctree.yml` and that all languages are arranged under a single `doc_folder` directory - see the [`course`](https://github.com/huggingface/course/tree/main/chapters) repo for an example. You can then build the individual language subsets as follows:
 
 ```bash
-doc-builder {package_name} {path_to_docs} --build_dir {build_dir} --language {lang_id}
+doc-builder build {package_name} {path_to_docs} --build_dir {build_dir} --language {lang_id}
 ```
 
 To automatically build the documentation for all languages via the GitHub Actions templates, simply provide the `languages` argument to your workflow, with a space-separated list of the languages you wish to build, e.g. `languages: en es`.


### PR DESCRIPTION
I think this is right. Setting up doc-builder for RLHF-handbook this time. Cheers.