### PR TITLE
Fix regex to catch HTML tags

### DIFF
--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -22,7 +22,21 @@ from .convert_rst_to_mdx import parse_rst_docstring, remove_indent
 
 
 _re_doctest_flags = re.compile(r"^(>>>.*\S)(\s+)# doctest:\s+\+[A-Z_]+\s*$", flags=re.MULTILINE)
-_re_lt_html = re.compile(r"<(((!(DOCTYPE|--))|((\/\s*)?[a-z]+))[^>]*?)>", re.IGNORECASE)
+_re_lt_html = re.compile(
+    r"""
+    <(                   # HTML tag with...
+    (
+        !DOCTYPE         # ... !DOCTYPE
+    |
+        ((\/\s*)?[a-z]+) # ... or any regular tag (i.e. starts with [a-z]
+    )
+    [^><]*?              # ... followed by anything until next closing ">"
+    )>
+    |
+    <(!--[^>]*?--)>      # Or an HTML comment
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 _re_lcub_svelte = re.compile(
     r"<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)(((?!<(Question|Tip|Added|Changed|Deprecated|DocNotebookDropdown|CourseFloatingBanner|FrameworkSwitch|audio|PipelineIcon|PipelineTag)).)*)>|&amp;lcub;(#if|:else}|/if})",
     re.DOTALL,
@@ -80,11 +94,14 @@ def convert_special_chars(text):
     # source is a special tag, it can be standalone (html tag) or closing (doc tag)
 
     # Temporarily replace all valid HTML tags with LTHTML
-    text = re.sub(_re_lt_html, r"LTHTML\1>", text)
+    # Replace with '\1\5' => 2 possible groups to catch the tag but in practice only one is not empty.
+    text = re.sub(_re_lt_html, r"LTHTML\1\5>", text)
+
     # Encode remaining < symbols
     text = text.replace("<", "&amp;lt;")
     # Put back the HTML tags
     text = text.replace("LTHTML", "<")
+
     return text
 
 

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -132,6 +132,13 @@ export let fw: "pt" | "tf"
             "something &amp;lt;5MB something else -> here",
         )
 
+        # Regression test for
+        # '10K<n<100K' must be caught correctly and not grouped with the next HTML tag.
+        self.assertEqual(
+            convert_special_chars("""10K<n<100K\n<Tip>\nThis is a tip.\n</Tip>"""),
+            "10K&amp;lt;n&amp;lt;100K\n<Tip>\nThis is a tip.\n</Tip>",
+        )
+
     def test_convert_img_links(self):
         page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}
 


### PR DESCRIPTION
This PR fixes the CI for https://github.com/huggingface/course and in particular [./es/chapter5/5.mdx](https://github.com/huggingface/course/blob/main/chapters/es/chapter5/5.mdx).
Related to this [slack thread](https://huggingface.slack.com/archives/C02GLJ5S0E9/p1695213043653059) (internal) and this [failing CI](https://github.com/huggingface/course/actions/runs/6237243960/job/16963364452?pr=614).

The failing doc had this form:

```
10K<n<100K

<Tip>

This is a tip.

</Tip>
```

in which the `_re_lt_html` regex detected `<n<100K    \n<Tip>` as a single HTML tag. The `_re_lt_html` is meant to detect the `<` characters that are not part of a HTML tag.

I fixed the regex for this use case + added a regression test for it. All previous unit tests are still passing so hopefully it doesn't break something in the wild. I also took the liberty to add verbose mode to explain a bit more what the regex is doing (too me a bit of time to remember :roll_eyes:).

cc @mishig25 @MKhalusova @xenova 

(also related to https://github.com/huggingface/doc-builder/pull/373 and https://github.com/huggingface/doc-builder/pull/394 which introduced and modified this regex)
