### PR TITLE
Fix svelte special chars escaping problem

### DIFF
--- a/kit/package-lock.json
+++ b/kit/package-lock.json
@@ -37,7 +37,8 @@
 				"svelte-preprocess": "^4.10.1",
 				"tailwindcss": "^3.0.22",
 				"tslib": "^2.3.1",
-				"typescript": "~4.5.4"
+				"typescript": "~4.5.4",
+				"unist-util-visit": "^5.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -3471,6 +3472,25 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is/node_modules/@types/unist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+			"integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+			"dev": true
+		},
 		"node_modules/unist-util-stringify-position": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
@@ -3483,6 +3503,47 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+			"integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+			"dev": true
+		},
+		"node_modules/unist-util-visit/node_modules/@types/unist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+			"integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==",
+			"dev": true
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/kit/package-lock.json
+++ b/kit/package-lock.json
@@ -26,6 +26,7 @@
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-svelte3": "^3.2.1",
 				"highlight.js": "^11.4.0",
+				"html-tags": "^3.3.1",
 				"htmlparser2": "^7.2.0",
 				"katex": "^0.15.2",
 				"mdsvex": "^0.10.5",
@@ -2059,6 +2060,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/html-tags": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/htmlparser2": {

--- a/kit/package.json
+++ b/kit/package.json
@@ -38,7 +38,8 @@
 		"svelte-preprocess": "^4.10.1",
 		"tailwindcss": "^3.0.22",
 		"tslib": "^2.3.1",
-		"typescript": "~4.5.4"
+		"typescript": "~4.5.4",
+		"unist-util-visit": "^5.0.0"
 	},
 	"type": "module",
 	"dependencies": {

--- a/kit/package.json
+++ b/kit/package.json
@@ -27,6 +27,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-svelte3": "^3.2.1",
 		"highlight.js": "^11.4.0",
+		"html-tags": "^3.3.1",
 		"htmlparser2": "^7.2.0",
 		"katex": "^0.15.2",
 		"mdsvex": "^0.10.5",

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -392,7 +392,7 @@ function unescapeUnderscores(content) {
  * @param {Record<any, any>} markedKatex
  */
 function markKatex(content, markedKatex) {
-	const REGEX_LATEX_DISPLAY = /\n\$\$([\s\S]+?)\$\$/g;
+	const REGEX_LATEX_DISPLAY = /\$\$([\s\S]+?)\$\$/g;
 	const REGEX_LATEX_INLINE = /\\\\\(([\s\S]+?)\\\\\)/g;
 	let counter = 0;
 	return content
@@ -412,11 +412,14 @@ function markKatex(content, markedKatex) {
 
 function renderKatex(code, markedKatex) {
 	return code.replace(/KATEXPARSE[0-9]+MARKER/g, (marker) => {
-		const { tex, displayMode } = markedKatex[marker];
-		const html = katex.renderToString(renderSvelteChars(tex), {
+		let { tex, displayMode } = markedKatex[marker];
+		tex = tex.replaceAll('&#123;', "{");
+		tex = tex.replaceAll('&#60;', "<");
+		let html = katex.renderToString(renderSvelteChars(tex), {
 			displayMode,
 			throwOnError: false
 		});
+		html = html.replace("katex-html", "katex-html hidden");
 		if (html.includes(`katex-error`)) {
 			throw new Error(`[KaTeX] Error while parsing markdown\n ${html}`);
 		}

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -3,7 +3,8 @@ import htmlparser2 from "htmlparser2";
 import hljs from "highlight.js";
 import { mdsvex } from "mdsvex";
 import katex from "katex";
-import { visit } from 'unist-util-visit'
+import { visit } from 'unist-util-visit';
+import htmlTags from 'html-tags';
 
 // Preprocessor that converts markdown into Docstring
 // svelte component using mdsvexPreprocess
@@ -432,12 +433,21 @@ function escapeSvelteSpecialChars() {
 	return transform;
 
 	function transform(tree) {
-		visit(tree, 'text', ontext);
+		visit(tree, 'text', onText);
+		visit(tree, 'html', onHtml);
 	}
 
-	function ontext(node) {
+	function onText(node) {
 		node.value = node.value.replaceAll("{", '&#123;');
 		node.value = node.value.replaceAll("<", '&#60;');
+	}
+
+	function onHtml(node) {
+		const RE_TAG_NAME = /<\/?(\w+)/;
+		const tagName = node.value.match(RE_TAG_NAME)[1];
+		if(!htmlTags.includes(tagName)){
+			node.value = node.value.replaceAll("<", '&#60;');
+		}
 	}
 }
 

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -469,10 +469,12 @@ function escapeSvelteSpecialChars() {
 
 	function onHtml(node) {
 		const RE_TAG_NAME = /<\/?(\w+)/;
-		// TODO: list current dir in lib and list all of our own stuff
-		const tagName = node.value.match(RE_TAG_NAME)[1];
-		if(!validTags.includes(tagName)){
-			node.value = node.value.replaceAll("<", '&#60;');
+		const match = node.value.match(RE_TAG_NAME);
+		if(match){
+			const tagName = match[1];
+			if(!validTags.includes(tagName)){
+				node.value = node.value.replaceAll("<", '&#60;');
+			}
 		}
 	}
 }

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -3,6 +3,7 @@ import htmlparser2 from "htmlparser2";
 import hljs from "highlight.js";
 import { mdsvex } from "mdsvex";
 import katex from "katex";
+import { visit } from 'unist-util-visit'
 
 // Preprocessor that converts markdown into Docstring
 // svelte component using mdsvexPreprocess
@@ -423,7 +424,22 @@ function renderKatex(code, markedKatex) {
 	});
 }
 
+
+function escapeSvelteSpecialChars() {
+	return transform;
+
+	function transform(tree) {
+		visit(tree, 'text', ontext);
+	}
+
+	function ontext(node) {
+		node.value = node.value.replaceAll("{", '&#123;');
+		node.value = node.value.replaceAll("<", '&#60;');
+	}
+}
+
 const _mdsvexPreprocess = mdsvex({
+	remarkPlugins: [escapeSvelteSpecialChars],
 	extensions: ["mdx"],
 	highlight: {
 		highlighter: function (code, lang) {

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -82,8 +82,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
 {}
 <>"""
         expected_conversion = """[img](/docs/transformers/v4.10.0/fr/imgs/img.gif)
-&amp;lcub;}
-&amp;lt;>"""
+{}
+<>"""
         self.assertEqual(process_md(text, page_info), expected_conversion)
 
     def test_convert_include(self):

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -22,7 +22,6 @@ from doc_builder.convert_md_to_mdx import (
     convert_include,
     convert_literalinclude,
     convert_md_to_mdx,
-    convert_special_chars,
     process_md,
 )
 
@@ -64,80 +63,6 @@ onMount(() => {
 </svelte:head>
 Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)
-
-    def test_convert_special_chars(self):
-        self.assertEqual(convert_special_chars("{ lala }"), "&amp;lcub; lala }")
-        self.assertEqual(convert_special_chars("< blo"), "&amp;lt; blo")
-        self.assertEqual(convert_special_chars("<source></source>"), "<source></source>")
-        self.assertEqual(convert_special_chars("<br>"), "<br>")
-        self.assertEqual(convert_special_chars("<hr>"), "<hr>")
-        self.assertEqual(convert_special_chars("<source>"), "<source>")
-        self.assertEqual(convert_special_chars("<Youtube id='my_vid' />"), "<Youtube id='my_vid' />")
-        self.assertEqual(convert_special_chars("</br>"), "</br>")
-        self.assertEqual(convert_special_chars("<br />"), "<br />")
-        self.assertEqual(convert_special_chars("<p>5 <= 10</p>"), "<p>5 &amp;lt;= 10</p>")
-        self.assertEqual(
-            convert_special_chars("<p align='center'>5 <= 10</p>"), "<p align='center'>5 &amp;lt;= 10</p>"
-        )
-        self.assertEqual(convert_special_chars("<p>5 <= 10"), "<p>5 &amp;lt;= 10")  # no closing tag
-        self.assertEqual(convert_special_chars("5 <= 10</p>"), "5 &amp;lt;= 10</p>")  # no opening tag
-        self.assertEqual(convert_special_chars("<a>test</b>"), "<a>test</b>")  # mismatched tags
-        self.assertEqual(convert_special_chars("<p>5 < 10</p>"), "<p>5 &amp;lt; 10</p>")
-        self.assertEqual(convert_special_chars("<p>5 > 10</p>"), "<p>5 > 10</p>")
-        self.assertEqual(convert_special_chars("<!--...-->"), "<!--...-->")  # comment
-        self.assertEqual(convert_special_chars("<!-- < -->"), "<!-- &amp;lt; -->")  # comment
-        self.assertEqual(convert_special_chars("<!DOCTYPE html> 1 < 2"), "<!DOCTYPE html> 1 &amp;lt; 2")
-
-        longer_test = """<script lang="ts">
-import Tip from "$lib/Tip.svelte";
-import Youtube from "$lib/Youtube.svelte";
-import Docstring from "$lib/Docstring.svelte";
-import CodeBlock from "$lib/CodeBlock.svelte";
-export let fw: "pt" | "tf"
-</script>"""
-        self.assertEqual(convert_special_chars(longer_test), longer_test)
-
-        nested_test = """<blockquote>
-   sometext
-   <blockquote>
-        sometext
-   </blockquote>
-</blockquote>"""
-        self.assertEqual(convert_special_chars(nested_test), nested_test)
-
-        html_code = '<a href="Some URl">some_text</a>'
-        self.assertEqual(convert_special_chars(html_code), html_code)
-
-        inner_less = """<blockquote>
-   sometext 4 &amp;lt; 5
-</blockquote>"""
-        self.assertEqual(convert_special_chars(inner_less), inner_less)
-
-        img_code = '<img src="someSrc">'
-        self.assertEqual(convert_special_chars(img_code), img_code)
-
-        video_code = '<video src="someSrc">'
-        self.assertEqual(convert_special_chars(video_code), video_code)
-
-        comment = "<!-- comment -->"
-        self.assertEqual(convert_special_chars(comment), comment)
-
-        comment = "<!-- multi line\ncomment -->"
-        self.assertEqual(convert_special_chars(comment), comment)
-
-        # Regression test for https://github.com/huggingface/doc-builder/pull/394
-        # '<' must not be considered an HTML tag before a number
-        self.assertEqual(
-            convert_special_chars("something <5MB something else -> here"),
-            "something &amp;lt;5MB something else -> here",
-        )
-
-        # Regression test for https://github.com/huggingface/doc-builder/pull/398
-        # '10K<n<100K' must be caught correctly and not grouped with the next HTML tag.
-        self.assertEqual(
-            convert_special_chars("""10K<n<100K\n<Tip>\nThis is a tip.\n</Tip>"""),
-            "10K&amp;lt;n&amp;lt;100K\n<Tip>\nThis is a tip.\n</Tip>",
-        )
 
     def test_convert_img_links(self):
         page_info = {"package_name": "transformers", "version": "v4.10.0", "language": "fr"}


### PR DESCRIPTION
### Problem description

`<` & `{` are special characters in svelte syntax. Therefore, you can't write a doc content like `4<5`. To fix this problem, we were escaping those characters with their respective html codes (`lt;` & `lcub;`) in our python code using regexes. These regexs were slow, which was fixed in #373 and #394. However, there were still [some errors](https://github.com/huggingface/course/actions/runs/6237243960/job/16994401348?pr=614#step:11:70)

### Solution

Fix it at markdown/mdsvex AST level using a [custom remark plugin](https://mdsvex.com/docs#remarkplugins--rehypeplugins)
[AST Playground](https://astexplorer.net/#/gist/0a92bbf654aca4fdfb3f139254cf0bad/1274c6b594302bbf4e7f9c798504837ae01093e5)

### Description of the custom remark plugin

When AST tree is being traversed, if a node type is "text" (rather than "html"), then escape `<` & `{` with `&#60;` & `&#123;`. This solution works great! The only catch is that we lost the full capability of svelte syntax. `{4+5}` will be evaluated as string `{4+5}` rather than js compute statement of `9`. I think it is fine since we dont't have any inline js compute statements in the docs mdx files. Usage of custom components (such as `<Tip>, <Question>`) should still work as expected


As a side effect, this PR should also decrease the build time since we are removing a lot regex checks in python and using already done AST tree traversal in mdsvex

todo:
- [x] [katex issue](https://github.com/huggingface/doc-builder/issues/397) should be fixed in this PR as well (fixed in https://github.com/huggingface/doc-builder/pull/401/commits/fd61ec108e648903b4ddedbe95660dec205f60fe)