### PR TITLE
Node version 18 -> 20

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -10,9 +10,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -70,9 +70,9 @@ jobs:
           path: notebooks
           token: ${{ secrets.token }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache-dependency-path: "kit/package-lock.json" 
 
       - name: Set env variables

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
 
       - name: Set env variables


### PR DESCRIPTION
Couldn't reproduce [this error](https://github.com/huggingface/huggingface_hub/actions/runs/6295850155/job/17090652777) locally:
```
Unexpected token (Note that you need plugins to import files that are not JavaScript)
file: /tmp/tmp2zqefn3k/kit/src/routes/guides/search/+page.svelte:202:169
200:   let t105;
201:   let p15;
202:   let textContent_20 = `<img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/search_text_classification.gif" alt="Animation exploring `model_args...
```

Locally, I'm running node 20 while the gh workflows were running node 18. Therefore, bumping up the versions to node 20 to see if it solves the issue

cc: @Wauplin 