### PR TITLE
Escape { in user supplied html

### DIFF
--- a/kit/package-lock.json
+++ b/kit/package-lock.json
@@ -16,6 +16,7 @@
 				"@tailwindcss/typography": "^0.5.10",
 				"@typescript-eslint/eslint-plugin": "^6.7.2",
 				"autoprefixer": "^10.4.14",
+				"cheerio": "^1.0.0-rc.12",
 				"domutils": "^2.8.0",
 				"eslint": "^8.50.0",
 				"eslint-config-prettier": "^9.0.0",
@@ -1142,6 +1143,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"dev": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1271,6 +1278,173 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/cheerio": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+			"dev": true,
+			"dependencies": {
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1367,6 +1541,77 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-select/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/css-tree": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -1378,6 +1623,18 @@
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/cssesc": {
@@ -2688,6 +2945,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2772,6 +3041,58 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+			"dev": true,
+			"dependencies": {
+				"entities": "^4.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"dev": true,
+			"dependencies": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/parse5/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {

--- a/kit/package.json
+++ b/kit/package.json
@@ -20,6 +20,7 @@
 		"@tailwindcss/typography": "^0.5.10",
 		"@typescript-eslint/eslint-plugin": "^6.7.2",
 		"autoprefixer": "^10.4.14",
+		"cheerio": "^1.0.0-rc.12",
 		"domutils": "^2.8.0",
 		"eslint": "^8.50.0",
 		"eslint-config-prettier": "^9.0.0",

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -486,6 +486,10 @@ function escapeSvelteSpecialChars() {
 			if (!validTags.includes(tagName)) {
 				node.value = node.value.replaceAll("<", "&#60;");
 			}else if(hfDocBodyStart && !hfDocBodyEnd && htmlTags.includes(tagName)){
+				const REGEX_VALID_START_END_TAG = /^<(\w+)[^>]*>.*<\/\1>$/s;
+				if(!REGEX_VALID_START_END_TAG.test(node.value.trim())){
+					return;
+				}
 				const $ = cheerio.load(node.value);
 				// Go through each text node in the HTML and replace "{" with "&#123;"
 				$('*').contents().each((index, element) => {

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -364,6 +364,7 @@ export const mdsvexPreprocess = {
 			// 	content = addCourseImports(content);
 			// }
 			content = markKatex(content, markedKatex);
+			content = escapeSvelteConditiols(content)
 			const processed = await _mdsvexPreprocess.markup({ content, filename });
 			processed.code = renderKatex(processed.code, markedKatex);
 			processed.code = headingWithAnchorLink(processed.code);
@@ -598,4 +599,14 @@ function headingWithAnchorLink(code) {
 	</span>
 </h${level}>\n`;
 	});
+}
+
+function escapeSvelteConditiols(code){
+	const REGEX_SVELTE_IF_START = /(\{#if[^}]+\})/g;
+	const SVELTE_ELSE = "{:else}";
+	const SVELTE_IF_END = "{/if}";
+	code = code.replace(REGEX_SVELTE_IF_START, '\n\n$1\n\n');
+	code = code.replaceAll(SVELTE_ELSE, `\n\n${SVELTE_ELSE}\n\n`);
+	code = code.replaceAll(SVELTE_IF_END, `\n\n${SVELTE_IF_END}\n\n`);
+	return code;
 }

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -364,7 +364,7 @@ export const mdsvexPreprocess = {
 			// 	content = addCourseImports(content);
 			// }
 			content = markKatex(content, markedKatex);
-			content = escapeSvelteConditiols(content)
+			content = escapeSvelteConditionals(content)
 			const processed = await _mdsvexPreprocess.markup({ content, filename });
 			processed.code = renderKatex(processed.code, markedKatex);
 			processed.code = headingWithAnchorLink(processed.code);
@@ -605,7 +605,7 @@ function headingWithAnchorLink(code) {
 	});
 }
 
-function escapeSvelteConditiols(code){
+function escapeSvelteConditionals(code){
 	const REGEX_SVELTE_IF_START = /(\{#if[^}]+\})/g;
 	const SVELTE_ELSE = "{:else}";
 	const SVELTE_IF_END = "{/if}";

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -221,9 +221,13 @@ export const frameworkcontentPreprocess = {
 					FRAMEWORKS[i].isExist = true;
 					const fwContent = fwcontentBody.match(REGEX_FW)[1];
 					svelteSlots += `<svelte:fragment slot="${framework}">
+
 					<Markdown>
+
 					\n\n${fwContent}\n\n
+
 					</Markdown>
+					
 					</svelte:fragment>`;
 				}
 			}

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -221,20 +221,16 @@ export const frameworkcontentPreprocess = {
 					FRAMEWORKS[i].isExist = true;
 					const fwContent = fwcontentBody.match(REGEX_FW)[1];
 					svelteSlots += `<svelte:fragment slot="${framework}">
-
-<Markdown>
-
-\n\n${fwContent}\n\n
-
-</Markdown>
-
-</svelte:fragment>`;
+					<Markdown>
+					\n\n${fwContent}\n\n
+					</Markdown>
+					</svelte:fragment>`;
 				}
 			}
 
 			const svelteProps = FRAMEWORKS.map((fw) => `${fw.framework}={${fw.isExist}}`).join(" ");
 
-			return `<FrameworkContent ${svelteProps}>\n${svelteSlots}\n</FrameworkContent>`;
+			return `\n\n<FrameworkContent ${svelteProps}>\n${svelteSlots}\n</FrameworkContent>\n\n`;
 		});
 
 		return { code: content };

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -222,13 +222,13 @@ export const frameworkcontentPreprocess = {
 					const fwContent = fwcontentBody.match(REGEX_FW)[1];
 					svelteSlots += `<svelte:fragment slot="${framework}">
 
-					<Markdown>
+<Markdown>
 
-					\n\n${fwContent}\n\n
+\n\n${fwContent}\n\n
 
-					</Markdown>
-					
-					</svelte:fragment>`;
+</Markdown>
+
+</svelte:fragment>`;
 				}
 			}
 

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -504,7 +504,7 @@ def autodoc(object_name, package, methods=None, return_anchors=False, page_info=
             )
             if check is not None:
                 errors.append(check)
-            documentation += f'\n<div class="{docstring_css_classes}">' + method_doc + "</div>"
+            documentation += f'\n<div class="{docstring_css_classes}">\n\n' + method_doc + "</div>"
             if return_anchors:
                 # The anchor name of the method might be different from its
                 method = find_object_in_package(f"{anchors[0]}.{method}", package=package)
@@ -513,7 +513,7 @@ def autodoc(object_name, package, methods=None, return_anchors=False, page_info=
                     anchors.append(anchor_name)
                 else:
                     anchors.append((anchor_name, method_name))
-    documentation = f'<div class="{docstring_css_classes}">\n' + documentation + "</div>\n"
+    documentation = f'<div class="{docstring_css_classes}">\n\n' + documentation + "</div>\n"
 
     return (documentation, anchors, errors) if return_anchors else documentation
 

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -28,7 +28,8 @@ def convert_md_to_mdx(md_text, page_info):
     """
     Convert a document written in md to mdx.
     """
-    return """<script lang="ts">
+    return (
+        """<script lang="ts">
 import {onMount} from "svelte";
 import Tip from "$lib/Tip.svelte";
 import Youtube from "$lib/Youtube.svelte";
@@ -59,8 +60,15 @@ onMount(() => {
 <svelte:head>
   <meta name="hf:doc:metadata" content={JSON.stringify(metadata)} >
 </svelte:head>
-""" + process_md(
-        md_text, page_info
+
+<!--HF DOCBUILD BODY START-->
+
+"""
+        + process_md(md_text, page_info)
+        + """
+
+<!--HF DOCBUILD BODY END-->
+"""
     )
 
 

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -89,6 +89,7 @@ def convert_img_links(text, page_info):
 
 
 _re_md_img_tag_alt = re.compile(r"!\[([^\]]+)\]", re.I)
+_re_html_img_tag_alt = re.compile(r"<img [^>]*?alt=([\"'])([^\1]*?)\1[^>]*?>", re.I)
 
 
 def escape_img_alt_description(text):
@@ -96,13 +97,23 @@ def escape_img_alt_description(text):
     Escapes ` with ' inside <img> alt description since it causes svelte/mdsvex compiler error.
     """
 
-    def replace_alt_content(match):
+    def replace_md_alt_content(match):
         alt_content = match.group(1)
         new_alt_content = alt_content.replace("`", "'")
         return match.group(0).replace(alt_content, new_alt_content)
 
+    def replace_html_alt_content(match):
+        alt_content = match.group(2)  # group(2) contains the alt text for the HTML regex
+        new_alt_content = alt_content.replace("`", "'")
+        return match.group(0).replace(alt_content, new_alt_content)
+
+    # Replace markdown style image alt text
     if _re_md_img_tag_alt.search(text):
-        text = _re_md_img_tag_alt.sub(replace_alt_content, text)
+        text = _re_md_img_tag_alt.sub(replace_md_alt_content, text)
+
+    # Replace HTML style image alt text
+    if _re_html_img_tag_alt.search(text):
+        text = _re_html_img_tag_alt.sub(replace_html_alt_content, text)
 
     return text
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -521,6 +521,7 @@ before.
         documentation = autodoc("AddedToken.content", tokenizers, return_anchors=False)
         expected_documentation = """<div class="docstring border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6 mt-8">
 
+
 <docstring><name>content</name><anchor>None</anchor><parameters>[]</parameters><isgetsetdescriptor></docstring>
 Get the content of this `AddedToken`
 

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -88,14 +88,26 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit
 
 ### Some heading
 
+<img src="somesrc" alt="Animation exploring `model_args.pipeline_tag`">
+
 ![Animation exploring `model_args.pipeline_tag`](imgsrc)
+
+<img src="somesrc" alt='Animation exploring `model_args.pipeline_tag`'>
+
+<img src="somesrc">
 
 ![Animation exploring model_args.pipeline_tag](imgsrc)"""
         expected_conversion = """![Animation exploring 'model_args.pipeline_tag'](imgsrc)
 
 ### Some heading
 
+<img src="somesrc" alt="Animation exploring 'model_args.pipeline_tag'">
+
 ![Animation exploring 'model_args.pipeline_tag'](imgsrc)
+
+<img src="somesrc" alt='Animation exploring 'model_args.pipeline_tag''>
+
+<img src="somesrc">
 
 ![Animation exploring model_args.pipeline_tag](imgsrc)"""
         self.assertEqual(escape_img_alt_description(multiple_imgs_md), expected_conversion)

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -62,7 +62,14 @@ onMount(() => {
 <svelte:head>
   <meta name="hf:doc:metadata" content={JSON.stringify(metadata)} >
 </svelte:head>
-Lorem ipsum dolor sit amet, consectetur adipiscing elit"""
+
+<!--HF DOCBUILD BODY START-->
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+
+<!--HF DOCBUILD BODY END-->
+"""
+        print(convert_md_to_mdx(md_text, page_info))
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)
 
     def test_convert_img_links(self):


### PR DESCRIPTION
### Problem

When there `{` is within a user supplied html string, it was causing svelte compiler error since `{` is a reserved character.

### Solution

Escape `{` with `&#123;`

Description of steps:
1. When there a html string inside mdsvex files, marked AST parses the outer most tag without without further parsing. For example, `<div><p>test</p></div>` will be parsed as single node without children. [AST playground](https://astexplorer.net/#/gist/0a92bbf654aca4fdfb3f139254cf0bad/62221cb9b1e5f555f3752553572e4abb296dd1a4)
2. Therefore, when there is a html node, parse it further with [cheerio](https://cheerio.js.org/docs/intro) and replace `{` with `&#123;` within texts
3. Problem solved

Should fix https://github.com/xenova/transformers.js/actions/runs/6300637437/job/17103917897?pr=320


todos:
- [x] failing on course https://github.com/huggingface/course/actions/runs/6310776836/job/17133417160?pr=620
- [x] check docstring style issue