### PR TITLE
[Fix] metadata post processing

### DIFF
--- a/kit/postprocess.js
+++ b/kit/postprocess.js
@@ -19,24 +19,20 @@ function readFiles(directory) {
 	});
 }
 
+// Regex to match `meta name="hf:doc:metadata"`
+const REGEX_HF_METADATA = /<!-- HEAD_svelte-.{7}_START -->(.+)<!-- HEAD_svelte-.{7}_END -->/s;
+
 function processFile(filePath) {
-	const content = fs.readFileSync(filePath, "utf-8");
-
-	const metas = Array.from(content.matchAll(/<meta[^>]*>/g)).map((m) => m[0]);
-
-	if (metas.length) {
-		let newContent = content;
-
-		// Remove all meta tags from their original locations
-		for (const tag of metas) {
-			newContent = newContent.replace(tag, "");
-		}
-
-		// Add them back at the start of the head
-		newContent = newContent.replace("<!-- META HERE -->", "<!-- META HERE -->" + metas.join(""));
-
-		fs.writeFileSync(filePath, newContent);
-	}
+    // Read the file synchronously
+    const data = fs.readFileSync(filePath, 'utf8');
+    // Extract the matched group using the regex
+    const match = data.match(REGEX_HF_METADATA);
+	// Append macthed group 1 to the first line
+	const lines = data.split('\n');
+	lines[0] += match[1];
+	// Join the lines back and write to the file synchronously
+	const updatedData = lines.join('\n');
+	fs.writeFileSync(filePath, updatedData, 'utf8');
 }
 
 readFiles(directoryPath);

--- a/kit/src/app.html
+++ b/kit/src/app.html
@@ -1,1 +1,1 @@
-<!-- META HERE --><meta charset="utf-8" />%sveltekit.head% %sveltekit.body%
+<meta charset="utf-8" />%sveltekit.head% %sveltekit.body%


### PR DESCRIPTION
Previous `kit/postprocess.js` regex didn't cover all cases, which caused page to go 500: https://huggingface.co/docs/transformers.js/api/pipelines

This PR fixes with a better regex