### PR TITLE
[Fix] trl doc build

### DIFF
--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -30,6 +30,7 @@ const config = {
 
 		prerender: {
 			crawl: false, // Do not throw if linked page doesn't exist (eg when forgetting the language prefix)
+			handleHttpError: "warn", // Otherwise, TRL docs is failing https://github.com/huggingface/trl/actions/runs/6316410973/job/17150947986
 		},
 
 		paths: {


### PR DESCRIPTION
### Problem

Page https://huggingface.co/docs/trl/v0.7.1/en/ddpo_trainer was [failing](https://github.com/huggingface/trl/actions/runs/6316410973/job/17169856790) with:
```
node:internal/event_target:1083
  process.nextTick(() => { throw err; });
                           ^
Error: 500 /docs/trl/main/en/ddpo_trainer
```

### Solution

Setting `sveltekit.prerender.handleHttpError` option from `fail` to `warn` solves the issue. Need a better fix. I'm not exactly sure why this error is happening at the moment. Tested the new builds locally to make sure of correctness.

<img width="600" alt="image" src="https://github.com/huggingface/doc-builder/assets/11827707/bace5e87-b242-45b6-b9d7-4ed6fc8b9c9f">
