### PR TITLE
Escpaing of svelte characters inside doc body only

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -471,16 +471,16 @@ function escapeSvelteSpecialChars() {
 			hfDocBodyStart = true;
 			hfDocBodyEnd = false;
 			// delete the marker
-			if(node.value === "HF_DOC_BODY_START"){
-				node.value = "";
-			}
+			// if(node.value === "HF_DOC_BODY_START"){
+			// 	node.value = "";
+			// }
 		}
 		if (["<!--HF DOCBUILD BODY END-->", "HF_DOC_BODY_END"].includes(node.value)) {
 			hfDocBodyEnd = true;
 			// delete the marker
-			if(node.value === "HF_DOC_BODY_END"){
-				node.value = "";
-			}
+			// if(node.value === "HF_DOC_BODY_END"){
+			// 	node.value = "";
+			// }
 		}
 		return hfDocBodyStart && !hfDocBodyEnd;
 	}

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -466,21 +466,21 @@ function escapeSvelteSpecialChars() {
 		visit(tree, "html", onHtml);
 	}
 
-	function isWithinDocBody(node) {
+	function isWithinDocBody(node, nodeType) {
 		if (["<!--HF DOCBUILD BODY START-->", "HF_DOC_BODY_START"].includes(node.value)) {
 			hfDocBodyStart = true;
 			hfDocBodyEnd = false;
 			// delete the marker
-			// if(node.value === "HF_DOC_BODY_START"){
-			// 	node.value = "";
-			// }
+			if(node.value === "HF_DOC_BODY_START"){
+				node.value = "";
+			}
 		}
 		if (["<!--HF DOCBUILD BODY END-->", "HF_DOC_BODY_END"].includes(node.value)) {
 			hfDocBodyEnd = true;
 			// delete the marker
-			// if(node.value === "HF_DOC_BODY_END"){
-			// 	node.value = "";
-			// }
+			if(node.value === "HF_DOC_BODY_END"){
+				node.value = "";
+			}
 		}
 		return hfDocBodyStart && !hfDocBodyEnd;
 	}

--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -466,7 +466,7 @@ function escapeSvelteSpecialChars() {
 		visit(tree, "html", onHtml);
 	}
 
-	function isWithinDocBody(node, nodeType) {
+	function isWithinDocBody(node) {
 		if (["<!--HF DOCBUILD BODY START-->", "HF_DOC_BODY_START"].includes(node.value)) {
 			hfDocBodyStart = true;
 			hfDocBodyEnd = false;

--- a/kit/src/lib/DropdownEntry.svelte
+++ b/kit/src/lib/DropdownEntry.svelte
@@ -16,7 +16,7 @@
 	export let useDeprecatedJS = true;
 </script>
 
-<li>
+<li class="not-prose">
 	<a
 		class="flex items-center hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer px-3 py-1.5 whitespace-nowrap 
 			{classNames}

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -63,11 +63,16 @@ onMount(() => {
 
 <!--HF DOCBUILD BODY START-->
 
+HF_DOC_BODY_START
+
 """
         + process_md(md_text, page_info)
         + """
 
 <!--HF DOCBUILD BODY END-->
+
+HF_DOC_BODY_END
+
 """
     )
 

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -65,9 +65,14 @@ onMount(() => {
 
 <!--HF DOCBUILD BODY START-->
 
+HF_DOC_BODY_START
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit
 
 <!--HF DOCBUILD BODY END-->
+
+HF_DOC_BODY_END
+
 """
         print(convert_md_to_mdx(md_text, page_info))
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)


### PR DESCRIPTION
### Problem

With https://github.com/huggingface/doc-builder/pull/401, we are escaping `{` so that it gets treated as string rather than inline svelte js. However, that caused line below to get treated as literal string rather than js https://github.com/huggingface/doc-builder/blob/787f9afb98805dbce39f8e5ae59c175fee104daf/kit/src/lib/DropdownEntry.svelte#L40

### Solution

Escape `{`, `<` only in user written markdown doc. Don't escape for [svelte components](https://github.com/huggingface/doc-builder/tree/main/kit/src/lib) (i.e. treat `{` as regular svelte inline js)