### PR TITLE
[Fix] parsing html node ending correctly

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -616,9 +616,11 @@ function headingWithAnchorLink(code) {
 		<span><IconCopyLink/></span>
 	</a>
 	<span>
-		${text.replace(REGEX_CODE, (_, group1) => `<code>${group1.replaceAll("<", "&#60;")}</code>`)}
+		${text
+			.replaceAll("{", "&#123;")
+			.replace(REGEX_CODE, (_, group1) => `<code>${group1.replaceAll("<", "&#60;")}</code>`)}
 	</span>
-</h${level}>\n`;
+</h${level}>\n\n`;
 	});
 }
 

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -30,7 +30,6 @@ const config = {
 
 		prerender: {
 			crawl: false, // Do not throw if linked page doesn't exist (eg when forgetting the language prefix)
-			handleHttpError: "warn", // Otherwise, TRL docs is failing https://github.com/huggingface/trl/actions/runs/6316410973/job/17150947986
 		},
 
 		paths: {


### PR DESCRIPTION
This PR:

1. Reverts changes in https://github.com/huggingface/doc-builder/pull/416. As written in the comment [here](https://github.com/huggingface/doc-builder/pull/416#issuecomment-1739002796), my initial assumption of sveltekit http error 500 being not critical was wrong
2. Escape HTML heading node correctly

```
<h3 id="id">My heading</h3>
Some markdown paragraph
```
get interpreted as one big html node by marked (see AST [here](https://astexplorer.net/#/gist/9e50bf2c3e282f02687d66eb1d80bd5a/8c57fd832328284fc405e955432a6cbfc19c28b5)). We would need space between them (see [here](https://github.com/huggingface/doc-builder/pull/419/commits/e6e2083125af846ad11e7c0f17fcce5a33fe5e9d#diff-15664fa10638c7e348d5f6f87bec05dde2e095d76b27797481462687c6a6dab3)).
Below is how it should look like
```
<h3 id="id">My heading</h3>

Some markdown paragraph
```


cc: @Wauplin 