### PR TITLE
[Feature] Option to wrap code blocks

### DIFF
--- a/kit/preprocess.js
+++ b/kit/preprocess.js
@@ -356,6 +356,9 @@ function renderCode(code) {
 	);
 }
 
+const WRAP_CODE_BLOCKS_FLAG = "<!-- WRAP CODE BLOCKS -->";
+let wrapCodeBlocks = false;
+
 export const mdsvexPreprocess = {
 	markup: async ({ content, filename }) => {
 		if (filename.endsWith(".svelte")) {
@@ -363,6 +366,7 @@ export const mdsvexPreprocess = {
 			// if (filename.includes("course/")) {
 			// 	content = addCourseImports(content);
 			// }
+			wrapCodeBlocks = content.includes(WRAP_CODE_BLOCKS_FLAG);
 			content = markKatex(content, markedKatex);
 			content = escapeSvelteConditionals(content);
 			const processed = await _mdsvexPreprocess.markup({ content, filename });
@@ -570,6 +574,7 @@ const _mdsvexPreprocess = mdsvex({
 			code: \`${base64(codeGroup2)}\`,
 			highlighted: \`${escape(highlightedTf)}\`
 		}}
+		wrap={${wrapCodeBlocks}}
 	/>`;
 			} else {
 				const highlighted = _highlight(code);
@@ -586,6 +591,7 @@ const _mdsvexPreprocess = mdsvex({
 	<CodeBlock 
 		code={\`${base64(code)}\`}
 		highlighted={\`${escape(highlighted)}\`}
+		wrap={${wrapCodeBlocks}}
 	/>`;
 			}
 		},

--- a/kit/src/lib/CodeBlock.svelte
+++ b/kit/src/lib/CodeBlock.svelte
@@ -3,6 +3,7 @@
 	let hideCopyButton = true;
 	export let code = "";
 	export let highlighted = "";
+	export let wrap = false;
 
 	function handleMouseOver() {
 		hideCopyButton = false;
@@ -26,5 +27,5 @@
 			value={code}
 		/>
 	</div>
-	<pre>{@html highlighted}</pre>
+	<pre class={wrap ? "whitespace-normal" : ""}>{@html highlighted}</pre>
 </div>

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -5,6 +5,7 @@
 
 	export let group1: { id: string; code: string; highlighted: string };
 	export let group2: { id: string; code: string; highlighted: string };
+	export let wrap = false;
 
 	const ids = [group1.id, group2.id];
 	const storeKey = ids.join("-");
@@ -35,7 +36,9 @@
 				value={group1.code}
 			/>
 		</div>
-		<pre><FrameworkSwitch {ids} />{@html group1.highlighted}</pre>
+		<pre class={wrap ? "whitespace-normal" : ""}><FrameworkSwitch
+				{ids}
+			/>{@html group1.highlighted}</pre>
 	{:else}
 		<div class="absolute top-2.5 right-4">
 			<CopyButton
@@ -44,6 +47,8 @@
 				value={group2.code}
 			/>
 		</div>
-		<pre><FrameworkSwitch {ids} />{@html group2.highlighted}</pre>
+		<pre class={wrap ? "whitespace-normal" : ""}><FrameworkSwitch
+				{ids}
+			/>{@html group2.highlighted}</pre>
 	{/if}
 </div>


### PR DESCRIPTION
### Non-wrapped code block (has a scroller) (default option)

<img width="600" alt="Screenshot 2023-09-28 at 16 30 10" src="https://github.com/huggingface/doc-builder/assets/11827707/529ce96e-a29a-477b-822c-ffa8f17a077e">


### Wrapped code block

<img width="600" alt="Screenshot 2023-09-28 at 16 30 38" src="https://github.com/huggingface/doc-builder/assets/11827707/45fc65e3-753e-4595-8a28-e3ac69f5aff2">

### Instruction

If you want to wrap your code blocks in a file, you need to put this html comment `<!-- WRAP CODE BLOCKS -->` which acts as a flag


feature was requested by @Narsil for making long CLI options more readable https://huggingface.co/docs/text-generation-inference/basic_tutorials/launcher