### PR TITLE
Use `whitespace-pre-wrap` for wrapping code blocks

### DIFF
--- a/kit/src/lib/CodeBlock.svelte
+++ b/kit/src/lib/CodeBlock.svelte
@@ -27,5 +27,5 @@
 			value={code}
 		/>
 	</div>
-	<pre class={wrap ? "whitespace-normal" : ""}>{@html highlighted}</pre>
+	<pre class={wrap ? "whitespace-pre-wrap" : ""}>{@html highlighted}</pre>
 </div>

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -36,7 +36,7 @@
 				value={group1.code}
 			/>
 		</div>
-		<pre class={wrap ? "whitespace-normal" : ""}><FrameworkSwitch
+		<pre class={wrap ? "whitespace-pre-wrap" : ""}><FrameworkSwitch
 				{ids}
 			/>{@html group1.highlighted}</pre>
 	{:else}
@@ -47,7 +47,7 @@
 				value={group2.code}
 			/>
 		</div>
-		<pre class={wrap ? "whitespace-normal" : ""}><FrameworkSwitch
+		<pre class={wrap ? "whitespace-pre-wrap" : ""}><FrameworkSwitch
 				{ids}
 			/>{@html group2.highlighted}</pre>
 	{/if}


### PR DESCRIPTION
Follow up to #420 

[whitespace-normal](https://tailwindcss.com/docs/whitespace#normal) (before)

<img width="700" alt="image" src="https://github.com/huggingface/doc-builder/assets/11827707/a2e5ae2b-ec3a-406f-b2b2-6f4e2bda6627">

[whitespace-pre-wrap](https://tailwindcss.com/docs/whitespace#pre-wrap) (this PR)

<img width="700" alt="image" src="https://github.com/huggingface/doc-builder/assets/11827707/abad8e1e-748a-4909-8c0c-95e66e8ba87b">
