### PR TITLE
Rm package name check when intralinking

### DIFF
--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -32,6 +32,7 @@ HUGGINFACE_LIBS = [
     "optimum",
     "tokenizers",
     "transformers",
+    "trl",
 ]
 
 


### PR DESCRIPTION
Follow up to https://github.com/huggingface/doc-builder/issues/258

Support trl objects in docs intralinking
![image](https://github.com/huggingface/doc-builder/assets/11827707/4537f865-1f54-4646-b7c9-513078d889ca)

cc: @lvwerra 