### PR TITLE
[New syntax] Hf Options

### DIFF
--- a/kit/preprocessors/hfOptions.js
+++ b/kit/preprocessors/hfOptions.js
@@ -1,0 +1,25 @@
+import { replaceAsync, generateTagRegexWithId } from "./utils.js";
+
+// Preprocessor that converts markdown into HfOptions
+// svelte component using mdsvexPreprocess
+export const hfOptionsPreprocess = {
+	markup: async ({ content }) => {
+		const REGEX_HF_OPTIONS = generateTagRegexWithId("hfoptions", true);
+		const REGEX_HF_OPTION = generateTagRegexWithId("hfoption", true);
+		content = await replaceAsync(content, REGEX_HF_OPTIONS, async (_, id, hfOptionsContent) => {
+			const options = [];
+			hfOptionsContent = await replaceAsync(
+				hfOptionsContent,
+				REGEX_HF_OPTION,
+				async (__, option, hfOptionContent) => {
+					options.push(option);
+					return `<HfOption id="${id}" option="${option}">\n\n${hfOptionContent}\n\n</HfOption>`;
+				}
+			);
+			return `<HfOptions id="${id}" options={${JSON.stringify(
+				options
+			)}}>\n${hfOptionsContent}\n</HfOptions>`;
+		});
+		return { code: content };
+	},
+};

--- a/kit/preprocessors/index.js
+++ b/kit/preprocessors/index.js
@@ -3,3 +3,4 @@ export { docstringPreprocess } from "./docstring.js";
 export { inferenceSnippetPreprocess } from "./inferenceSnippet.js";
 export { tokenizersLangPreprocess } from "./tokenizersLang.js";
 export { mdsvexPreprocess } from "./mdsvex/index.js";
+export { hfOptionsPreprocess } from "./hfOptions.js";

--- a/kit/preprocessors/utils.js
+++ b/kit/preprocessors/utils.js
@@ -45,3 +45,17 @@ export function generateTagRegex(tag, global = false) {
 	const pattern = new RegExp(`<${tag}>(.*?)<\\/${tag}>`, flags);
 	return pattern;
 }
+
+/**
+ * Create a regex that captures html-like opening and closing tag with attribute "id" and its contents.
+ * used for parsing hf custom syntax
+ * example: generateTagRegex("inferenceSnippet", true) -> /<inferenceSnippet\s+id=["'](.+)["']\s*>(.*?)<\/inferenceSnippet>/msg
+ * @param {string} tag - The name of the tag to match content within.
+ * @param {boolean} [global=false] - Whether to create a global pattern that matches all occurrences.
+ * @returns {RegExp} - The generated RegExp pattern.
+ */
+export function generateTagRegexWithId(tag, global = false) {
+	const flags = global ? "msg" : "ms";
+	const pattern = new RegExp(`<${tag}\\s+id=["'](.+?)["']\\s*>(.*?)<\\/${tag}>`, flags);
+	return pattern;
+}

--- a/kit/src/lib/HfOption.svelte
+++ b/kit/src/lib/HfOption.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { selectedHfOptions } from "./stores";
+
+	export let id: string;
+	export let option: string;
+</script>
+
+{#if $selectedHfOptions[id] === option}
+	<slot />
+{/if}

--- a/kit/src/lib/HfOptions.svelte
+++ b/kit/src/lib/HfOptions.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { onMount } from "svelte";
+	import { selectedHfOptions } from "./stores";
+	import { getQueryParamValue, updateQueryParamAndPushToHistory } from "./utils";
+
+	export let id: string;
+	export let options: string[];
+
+	$selectedHfOptions[id] = options[0];
+
+	function updateSelectedOption(option: string) {
+		$selectedHfOptions[id] = option;
+		updateQueryParamAndPushToHistory(id, option);
+	}
+
+	onMount(() => {
+		const valueFromQueryParams = getQueryParamValue(id);
+		if (valueFromQueryParams && options.includes(valueFromQueryParams)) {
+			$selectedHfOptions[id] = valueFromQueryParams;
+		}
+	});
+</script>
+
+<div class="flex space-x-2 items-center my-1.5 mr-8 h-7 !pl-0 -mx-3 md:mx-0">
+	{#each options as option}
+		<div
+			class="flex items-center border rounded-lg px-1.5 py-1 leading-none select-none text-smd
+			{$selectedHfOptions[id] === option
+				? 'border-gray-800 bg-black dark:bg-gray-700 text-white'
+				: 'text-gray-500 cursor-pointer opacity-90 hover:text-gray-700 dark:hover:text-gray-200 hover:shadow-sm'}"
+			on:click={() => updateSelectedOption(option)}
+		>
+			{option}
+		</div>
+	{/each}
+</div>
+
+<div class="language-select">
+	<slot />
+</div>

--- a/kit/src/lib/stores.ts
+++ b/kit/src/lib/stores.ts
@@ -30,3 +30,6 @@ export const selectedInferenceLang = writable<InferenceSnippetLang>("python");
 
 // used for TokenizersLanguageContent.svelte
 export const selectedTokenizersLang = writable<TokenizersLanguage>("python");
+
+// used for HfOptions.svelte
+export const selectedHfOptions = writable<Record<string, string>>({});

--- a/kit/src/lib/utils.ts
+++ b/kit/src/lib/utils.ts
@@ -1,0 +1,20 @@
+export function updateQueryParamAndPushToHistory(key: string, value: string) {
+	// 1. Parse the current URL.
+	const currentUrl = new URL(window.location.href);
+	// 2. Use URLSearchParams to manipulate the query parameters.
+	const searchParams = new URLSearchParams(currentUrl.search);
+	// 3. Update the specific query parameter.
+	searchParams.set(key, value);
+	// 4. Construct the new URL.
+	currentUrl.search = searchParams.toString();
+	// 5. Push the new URL to browser's history.
+	history.pushState(null, "", currentUrl.toString());
+}
+
+export function getQueryParamValue(key: string) {
+	// 1. Parse the current URL.
+	const currentUrl = new URL(window.location.href);
+	// 2. Use URLSearchParams to get the value of the specified query parameter.
+	const searchParams = new URLSearchParams(currentUrl.search);
+	return searchParams.get(key); // This will return the value or null if the key is not found.
+}

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -7,6 +7,7 @@ import {
 	mdsvexPreprocess,
 	inferenceSnippetPreprocess,
 	tokenizersLangPreprocess,
+	hfOptionsPreprocess,
 } from "./preprocessors/index.js";
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -18,6 +19,7 @@ const config = {
 		frameworkcontentPreprocess,
 		inferenceSnippetPreprocess,
 		tokenizersLangPreprocess,
+		hfOptionsPreprocess,
 		mdsvexPreprocess,
 		vitePreprocess({}),
 	],

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -52,6 +52,8 @@ import Deprecated from "$lib/Deprecated.svelte";
 import PipelineIcon from "$lib/PipelineIcon.svelte";
 import PipelineTag from "$lib/PipelineTag.svelte";
 import Heading from "$lib/Heading.svelte";
+import HfOptions from "$lib/HfOptions.svelte";
+import HfOption from "$lib/HfOption.svelte";
 let fw: "pt" | "tf" = "pt";
 onMount(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -54,6 +54,8 @@ import Deprecated from "$lib/Deprecated.svelte";
 import PipelineIcon from "$lib/PipelineIcon.svelte";
 import PipelineTag from "$lib/PipelineTag.svelte";
 import Heading from "$lib/Heading.svelte";
+import HfOptions from "$lib/HfOptions.svelte";
+import HfOption from "$lib/HfOption.svelte";
 let fw: "pt" | "tf" = "pt";
 onMount(() => {
     const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
### Description

New syntax to add different options.

```html
<hfoptions id="id for this entire block">
<hfoption id="id for option 1">
option 1 content markdown
</hfoption>
<hfoption id="id for option 2">
option 2 content markdown
</hfoption>
...
there can be however many options
...
</hfoptions>
```


Syntax example:
<img width="360" alt="image" src="https://github.com/huggingface/doc-builder/assets/11827707/7667a932-0ec6-444c-9e11-82304cb6e60b">


### Screenshots

<img src="https://github.com/huggingface/doc-builder/assets/11827707/8849c02f-c481-427b-911b-0085a4b0fbbd" width="400px">

<img src="https://github.com/huggingface/doc-builder/assets/11827707/5bc4cad1-29e0-4319-9a3b-5218b5897bda" width="400px">

cc: @stevhliu 