### PR TITLE
Add black as dependency at install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-install_requires = ["GitPython", "tqdm", "pyyaml", "packaging", "nbformat", "huggingface_hub"]
+install_requires = ["black", "GitPython", "tqdm", "pyyaml", "packaging", "nbformat", "huggingface_hub"]
 
 extras = {}
 


### PR DESCRIPTION
Add `black` as dependency at install.

Note that, besides `make quality`, `black` is also used in `style_doc.py`: https://github.com/huggingface/doc-builder/blob/e00174632acfddbf3da975dffca90a87aa334f55/src/doc_builder/style_doc.py#L21