### PR TITLE
Add `requests` test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = ["black", "GitPython", "tqdm", "pyyaml", "packaging", "nbform
 extras = {}
 
 extras["transformers"] = ["transformers[dev]"]
-extras["testing"] = ["pytest", "pytest-xdist", "torch", "transformers", "tokenizers", "timm", "google-api-python-client"]
+extras["testing"] = ["pytest", "pytest-xdist", "torch", "transformers", "tokenizers", "timm", "google-api-python-client", "requests"]
 extras["quality"] = ["black~=22.0", "isort>=5.5.4", "flake8>=3.8.3"]
 
 extras["all"] = extras["testing"] + extras["quality"]


### PR DESCRIPTION
`requests` is imported here: [src/doc_builder/external.py#L22](https://github.com/huggingface/doc-builder/blob/c4e348ea1c844d659c65261d914e9cb9237a84e3/src/doc_builder/external.py#L22)