### PR TITLE
🐛 Fix versioned docs publish

### DIFF
--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -66,8 +66,8 @@ def push_command_add(args):
     zip_file_path_without_ext = create_zip_name(library_name, doc_version_folder, with_ext=False)
     # eg create ./transformers/v4.0.zip with '/transformers/v4.0/*' file architecture inside
     # Use subprocess.run instead of shutil.make_archive to avoid corrupted files, see https://github.com/huggingface/doc-builder/issues/348
-    print(f"Running zip command: zip -r {zip_file_path_without_ext} {path_docs_built}")
-    subprocess.run(["zip", "-r", zip_file_path_without_ext, path_docs_built], check=True)
+    print(f"Running zip command: zip -r {zip_file_path_without_ext}/ {path_docs_built}")
+    subprocess.run(["zip", "-r", zip_file_path_without_ext + "/", path_docs_built], check=True)
     zip_file_path = create_zip_name(library_name, doc_version_folder)
 
     api = HfApi()


### PR DESCRIPTION
If the version is a PR name or something like "main", no issue, but if it contains dots it mess with `zip`'s heuristic