### PR TITLE
Fix off-by-one error on safety condition in while loop

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -78,7 +78,7 @@ def get_shortest_path(obj, package):
     path_splits = long_path.split(".")
     module = package
     idx = module.__name__.count(".")
-    while idx < len(path_splits) and not hasattr(module, short_name):
+    while idx + 1 < len(path_splits) and not hasattr(module, short_name):
         idx += 1
         module = getattr(module, path_splits[idx])
     return ".".join(path_splits[: idx + 1]) + "." + long_name

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -36,7 +36,7 @@ from doc_builder.autodoc import (
     remove_example_tags,
     resolve_links_in_text,
 )
-from transformers import BertModel, BertTokenizer, BertTokenizerFast
+from transformers import BertModel, BertTokenizer, BertTokenizerFast, TrainingArguments
 from transformers.utils import PushToHubMixin
 
 
@@ -170,6 +170,10 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_shortest_path(BertModel, transformers), "transformers.BertModel")
         self.assertEqual(get_shortest_path(BertModel.forward, transformers), "transformers.BertModel.forward")
         self.assertEqual(get_shortest_path(PushToHubMixin, transformers), "transformers.utils.PushToHubMixin")
+        self.assertEqual(
+            get_shortest_path(TrainingArguments.__init__, transformers),
+            "transformers.training_args.__create_fn__.<locals>.__init__",
+        )
 
     def test_get_type_name(self):
         self.assertEqual(get_type_name(str), "str")


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix off-by-one error on safety condition in while loop, causing crash

## Details
I encountered this off-by-one error when trying to build docs for SetFit with an incorrectly formatted .mdx file. Clearly, the `idx < len(path_splits)` exists to prevent `path_splits[idx]` from failing, but `idx += 1` exists between the indexing and the checking, so we need `idx + 1 < len(path_splits)` in the check.

The docs still look good after applying the fix, but I didn't write any tests for this. I can supply tests if necessary.
You can reproduce this with e.g.:
```
[[autodoc]] TrainingArguments
  - __init__
```
(I realise that you shouldn't use `__init__`.)

- Tom Aarsen