### PR TITLE
Allow "none" in autodoc

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -492,6 +492,8 @@ def autodoc(object_name, package, methods=None, return_anchors=False, page_info=
             methods.remove("all")
             methods_to_add = find_documented_methods(obj)
             methods.extend([m for m in methods_to_add if m not in methods])
+        elif "none" in methods:
+            methods = []
         for method in methods:
             anchor_name = f"{anchors[0]}.{method}"
             method_doc, check = document_object(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -324,6 +324,12 @@ before.
             ],
         )
 
+        _, anchors, _ = autodoc("BertTokenizer", transformers, methods=["none"], return_anchors=True)
+        self.assertListEqual(anchors, ["transformers.BertTokenizer"])
+
+        _, anchors, _ = autodoc("BertTokenizer", transformers, methods=["none", "__call__"], return_anchors=True)
+        self.assertListEqual(anchors, ["transformers.BertTokenizer"])
+
         _, anchors, _ = autodoc("BertTokenizer", transformers, methods=["__call__"], return_anchors=True)
         self.assertListEqual(
             anchors,


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow "none" in autodoc
* Add tests showing that "none" behaves like the opposite of "all"

## Details
This PR introduces another special word to autodoc beyond "all": `"none"`. Sometimes I just want it to show __init__, i.e. the default, and nothing else. This is (to my knowledge) not currently possible as providing no methods will default to using all methods.

The downside is if there's users who have a property/method etc. called `none` that they explicitly wanted to document, i.e. the exact same downside for `"all"`.

- Tom Aarsen