### PR TITLE
Allow overriding docstrings of superclass methods

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -394,15 +394,18 @@ def document_object(object_name, package, page_info, full_name=True, anchor_name
     signature_name = prefix + name
     signature = format_signature(obj)
     check = None
-    if getattr(obj, "__doc__", None) is not None and len(obj.__doc__) > 0:
-        object_doc = obj.__doc__
+    if hasattr(obj, "__overridden_doc__"):
+        object_doc = obj.__overridden_doc__ or ""
+    elif hasattr(obj, "__doc__"):
+        object_doc = obj.__doc__ or ""
+    if object_doc:
         if is_dataclass_autodoc(obj):
             object_doc = ""
         elif is_rst_docstring(object_doc):
-            object_doc = convert_rst_docstring_to_mdx(obj.__doc__, page_info)
+            object_doc = convert_rst_docstring_to_mdx(object_doc, page_info)
         else:
             check = quality_check_docstring(object_doc, object_name=object_name)
-            object_doc = convert_md_docstring_to_mdx(obj.__doc__, page_info)
+            object_doc = convert_md_docstring_to_mdx(object_doc, page_info)
 
     try:
         source_link = get_source_link(obj, page_info, version_tag_suffix)


### PR DESCRIPTION
Hello!

## Pull Request overview
* Allow docstrings of methods implemented in superclasses to be modified in the documentation.

## Details
This is a draft PR (hence no tests, etc.) to discuss the idea of some new functionality: overriding docstrings without overriding methods. 

### Why is this useful?
It is quite common for functionality to be directly taken from a superclass, e.g. [ModelHubMixin.from_pretrained](https://huggingface.co/docs/huggingface_hub/v0.19.3/en/package_reference/mixins#huggingface_hub.ModelHubMixin.from_pretrained) or [TrainingArguments](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments). In some cases, you'll want to adopt the functionality without overriding the method, but you *do* want to update the docstring.

To my knowledge, this isn't possible in Python. All documentation builders that I know don't actually initialize a class before reading the docstrings from its methods, and the `__doc__` attribute can't be modified outside of the class, so the docstrings can't be updated on the fly. E.g.:

```py
class Foo:
    @classmethod
    def from_pretrained(cls):
        """This is the original docstring"""
        return cls()

class Bar(Foo):
    pass

Bar.from_pretrained.__doc__ = "This is the overridden docstring"
print(Bar.from_pretrained.__doc__)
```
```
Traceback (most recent call last):
  File "[sic]\setfit\test_doc.py", line 11, in <module>
    Bar.from_pretrained.__doc__ = "This is the overridden docstring"
AttributeError: attribute '__doc__' of 'method' objects is not writable
```

### The proposal
It *is* possible to add a new argument to a method, e.g. `__overridden_doc__`, and set it to whatever you wish. Consider the following scenario:

```py
...

class SetFitModel(ModelHubMixin):
    ...
```
Which becomes:
![image](https://github.com/huggingface/doc-builder/assets/37621491/8677cc61-e0cd-420a-a910-d14b8a3e9c4a)

And I want to update `SetFitModel.from_pretrained` by replacing the `model_kwargs` with the actual model keyword arguments, then I can add:
```py
docstring = SetFitModel.from_pretrained.__doc__
try:
    docstring = docstring[:docstring.index("model_kwargs")]
except:
    pass
else:
    docstring += """multi_target_strategy (`str`, *optional*):
                The strategy to use with multi-label classification. One of "one-vs-rest", "multi-output",
                    or "classifier-chain".
            use_differentiable_head (`bool`, *optional*):
                Whether to load SetFit using a differentiable (i.e., Torch) head instead of Logistic Regression.
            normalize_embeddings (`bool`, *optional*):
                Whether to apply normalization on the embeddings produced by the Sentence Transformer body.
            device (`Union[torch.device, str]`, *optional*):
                The device on which to load the SetFit model, e.g. `"cuda:0"`, `"mps"` or `torch.device("cuda")`."""
    SetFitModel.from_pretrained.__dict__["__overridden_doc__"] = docstring
```
at the bottom of that same file.

When compiled, this results in:
![image](https://github.com/huggingface/doc-builder/assets/37621491/a9f68641-1fe1-408f-9238-b6d37031b11c)

This is exactly what I'm after.

---

This PR is just a draft to showcase an idea. Note that this would be "advanced behaviour" that only few people would need to use, and everyone else can just ignore it. I'm open to different names than `__overridden_doc__` as well (e.g. `__preferred_doc__`, or perhaps leave the `__` out as that's normally for core Python functionality only)

cc: @lewtun would also benefit from this change

- Tom Aarsen