### PR TITLE
Use GITHUB_OUTPUTS, not GITHUB_ENV for security reasons

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -1,121 +1,124 @@
-# name: Upload PR documentation
+name: Upload PR documentation
 
-# on:
-#   workflow_call:
-#     inputs:
-#       package_name:
-#         required: true
-#         type: string
-#       hub_base_path:
-#         type: string
-#       repo_owner:
-#         type: string
-#         default: 'huggingface'
-#         description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
-#     secrets:
-#       hf_token:
-#         required: true
-#       comment_bot_token:
-#         required: true
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        required: true
+        type: string
+      hub_base_path:
+        type: string
+      repo_owner:
+        type: string
+        default: 'huggingface'
+        description: "Owner of the repo to build documentation for. Defaults to 'huggingface'."
+    secrets:
+      hf_token:
+        required: true
+      comment_bot_token:
+        required: true
 
-# jobs:
-#   upload_pr_documentation:
-#     runs-on: ubuntu-latest
-#     if: >
-#       (github.event.workflow_run.event == 'pull_request' ||
-#       github.event.workflow_run.event == 'pull_request_target') &&
-#       github.event.workflow_run.conclusion == 'success'
+jobs:
+  upload_pr_documentation:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'pull_request_target') &&
+      github.event.workflow_run.conclusion == 'success'
 
-#     steps:
-#       - uses: actions/checkout@v2
-#         with:
-#           repository: 'huggingface/doc-builder'
-#           path: doc-builder
-#           # Uncomment the following line to use a specific revision of doc-builder
-#           # ref: fix-corrupted-zip
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'huggingface/doc-builder'
+          path: doc-builder
+          # Uncomment the following line to use a specific revision of doc-builder
+          # ref: fix-corrupted-zip
 
-#       - name: Setup environment
-#         shell: bash
-#         run: |
-#           pip install black
-#           cd doc-builder
-#           pip install .
-#           cd ..
-#           echo "current_work_dir=$(pwd)" >> $GITHUB_ENV
+      - name: Setup environment
+        shell: bash
+        id: setup-env
+        run: |
+          pip install black
+          cd doc-builder
+          pip install .
+          cd ..
+          echo "current_work_dir=$(pwd)" >> $GITHUB_OUTPUT
 
-#       - name: 'Download artifact'
-#         uses: actions/github-script@v3.1.0
-#         with:
-#           script: |
-#             var artifacts = await github.actions.listWorkflowRunArtifacts({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               run_id: ${{github.event.workflow_run.id }},
-#             });
-#             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-#               return artifact.name == "doc-build-artifact"
-#             })[0];
-#             var download = await github.actions.downloadArtifact({
-#               owner: context.repo.owner,
-#               repo: context.repo.repo,
-#               artifact_id: matchArtifact.id,
-#               archive_format: 'zip',
-#             });
-#             var fs = require('fs');
-#             fs.writeFileSync('${{env.current_work_dir}}/doc-build-artifact.zip', Buffer.from(download.data));
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "doc-build-artifact"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{steps.setup-env.outputs.current_work_dir}}/doc-build-artifact.zip', Buffer.from(download.data));
 
-#       - run: |
-#           mkdir build_dir
-#           unzip doc-build-artifact.zip -d build_dir
+      - run: |
+          mkdir build_dir
+          unzip doc-build-artifact.zip -d build_dir
 
-#       - name: Display structure of downloaded files
-#         run: ls -l
+      - name: Display structure of downloaded files
+        run: ls -l
 
-#       - name: Get commit_sha & pr_number
-#         run: |
-#           echo "commit_sha=$(cat ./build_dir/commit_sha)" >> $GITHUB_ENV
-#           rm -rf ./build_dir/commit_sha
-#           echo "pr_number=$(cat ./build_dir/pr_number)" >> $GITHUB_ENV
-#           rm -rf ./build_dir/pr_number
+      - name: Get commit_sha & pr_number
+        id: github-context
+        run: |
+          echo "commit_sha=$(cat ./build_dir/commit_sha)" >> $GITHUB_OUTPUT
+          rm -rf ./build_dir/commit_sha
+          echo "pr_number=$(cat ./build_dir/pr_number)" >> $GITHUB_OUTPUT
+          rm -rf ./build_dir/pr_number
 
-#       - name: Set hub_docs_url
-#         run: |
-#           if [ -z "${{ inputs.hub_base_path }}" ]
-#           then
-#             echo "hub_docs_url=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package_name }}/pr_${{ env.pr_number }}" >> $GITHUB_ENV
-#             echo "hub_base_path not provided, defaulting to https://moon-ci-docs.huggingface.co/docs"
-#           else
-#             echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package_name }}/pr_${{ env.pr_number }}" >> $GITHUB_ENV
-#           fi
+      - name: Set hub_docs_url
+        id: hfhub-context
+        run: |
+          if [ -z "${{ inputs.hub_base_path }}" ]
+          then
+            echo "hub_docs_url=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package_name }}/pr_${{ steps.github-context.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "hub_base_path not provided, defaulting to https://moon-ci-docs.huggingface.co/docs"
+          else
+            echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package_name }}/pr_${{ steps.github-context.outputs.pr_number }}" >> $GITHUB_OUTPUT
+          fi
 
-#       - name: Push to repositories
-#         shell: bash
-#         run: |
-#           cd build_dir
-#           doc-builder push ${{ inputs.package_name }} --doc_build_repo_id "hf-doc-build/doc-build-dev" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ env.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package_name }}/commit/${{ env.commit_sha }}"
+      - name: Push to repositories
+        shell: bash
+        run: |
+          cd build_dir
+          doc-builder push ${{ inputs.package_name }} --doc_build_repo_id "hf-doc-build/doc-build-dev" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ steps.github-context.outputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package_name }}/commit/${{ steps.github-context.outputs.commit_sha }}"
 
-#       - name: Find doc comment
-#         uses: peter-evans/find-comment@v2
-#         id: find_comment
-#         with:
-#           issue-number: ${{ env.pr_number }}
-#           body-includes: docs for this PR
+      - name: Find doc comment
+        uses: peter-evans/find-comment@v2
+        id: find_comment
+        with:
+          issue-number: ${{ steps.github-context.outputs.pr_number }}
+          body-includes: docs for this PR
 
-#       - name: Add doc comment if not present
-#         uses: thollander/actions-comment-pull-request@v2
-#         if: steps.find_comment.outputs.comment-id == ''
+      - name: Add doc comment if not present
+        uses: thollander/actions-comment-pull-request@v2
+        if: steps.find_comment.outputs.comment-id == ''
 
-#         with:
-#           message: 'The docs for this PR live [here](${{ env.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.'
-#           pr_number: ${{ env.pr_number }}
-#           GITHUB_TOKEN: ${{ secrets.comment_bot_token }}
+        with:
+          message: 'The docs for this PR live [here](${{ steps.hfhub-context.outputs.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.'
+          pr_number: ${{ steps.github-context.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.comment_bot_token }}
 
-#       - name: Update doc comment if necessary
-#         if: github.event.action == 'reopened' && steps.find_comment.outputs.comment-id != ''
-#         uses: peter-evans/create-or-update-comment@v1
-#         with:
-#           comment-id: ${{ steps.find_comment.outputs.comment-id }}
-#           token: ${{ secrets.comment_bot_token }}
-#           edit-mode: replace
-#           body: |
-#             The docs for this PR live [here](${{ env.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.
+      - name: Update doc comment if necessary
+        if: github.event.action == 'reopened' && steps.find_comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          token: ${{ secrets.comment_bot_token }}
+          edit-mode: replace
+          body: |
+            The docs for this PR live [here](${{ steps.hfhub-context.outputs.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint.

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -75,10 +75,23 @@ jobs:
       - name: Get commit_sha & pr_number
         id: github-context
         run: |
-          echo "commit_sha=$(cat ./build_dir/commit_sha)" >> $GITHUB_OUTPUT
-          rm -rf ./build_dir/commit_sha
-          echo "pr_number=$(cat ./build_dir/pr_number)" >> $GITHUB_OUTPUT
-          rm -rf ./build_dir/pr_number
+          content_commit_sha=$(cat ./build_dir/commit_sha)
+          if [[ $content_commit_sha =~ ^[0-9a-zA-Z]{40}$ ]]; then
+            echo "commit_sha=$content_commit_sha" >> $GITHUB_OUTPUT
+            rm -rf ./build_dir/commit_sha
+          else
+            echo "Encountered an invalid commit_sha"
+            exit 1
+          fi
+          
+          content_pr_number=$(cat ./build_dir/pr_number)
+          if [[ $content_pr_number =~ ^[0-9]+$ ]]; then
+            echo "pr_number=$content_pr_number" >> $GITHUB_OUTPUT
+            rm -rf ./build_dir/pr_number
+          else
+            echo "Encountered an invalid pr_number"
+            exit 1
+          fi
 
       - name: Set hub_docs_url
         id: hfhub-context


### PR DESCRIPTION
Use `echo >> GITHUB_OUTPUT` rather than `echo >> GITHUB_ENV` because the lines below were previously security vulnerability with `echo >> GITHUB_ENV` (see hackerrank one)

https://github.com/huggingface/doc-builder/blob/c33e00834df8e85b18cdefccd56e26acb53a5be0/.github/workflows/upload_pr_documentation.yml#L75-L81


Unlikes `GITHUB_ENV`, `GITHUB_OUTPUT` gets sanitized