### PR TITLE
Add `workflow_dispatch` to events that trigger upload PR doc

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.event == 'pull_request_target') &&
+      github.event.workflow_run.event == 'pull_request_target' ||
+      github.event.workflow_run.event == 'workflow_dispatch') &&
       github.event.workflow_run.conclusion == 'success'
 
     steps:
@@ -83,7 +84,7 @@ jobs:
             echo "Encountered an invalid commit_sha"
             exit 1
           fi
-          
+
           content_pr_number=$(cat ./build_dir/pr_number)
           if [[ $content_pr_number =~ ^[0-9]+$ ]]; then
             echo "pr_number=$content_pr_number" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In Optimum, we sometimes need to trigger the PR doc build manually: when modifying the [PR doc build workflow](https://github.com/huggingface/optimum/blob/main/.github/workflows/build_pr_documentation.yml) in a PR, the only way to execute the PR version of this workflow (and not the one from `main`) is with a `workflow_dispatch` event. This happens because we use the `pull_request_target` event to be able to access secrets during doc generation.

This PR adds the `workflow_dispatch` event as a compatible event for the doc upload workflow.