### PR TITLE
use github-like Tip & Warning syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ markers.
 
 Syntax:
 
+```md
+> [!TIP]
+> Here is a tip. Go to this url [website](www.tip.com)
+> 
+> Second line
+```
+
+or
+
 ```html
 <Tip>
 
@@ -249,6 +258,13 @@ Example: [here](https://github.com/huggingface/transformers/blob/0f0e1a2c2bff685
 For warnings, change the introduction to:
 
 Syntax:
+
+```md
+> [!WARNING]
+```
+
+or
+
 ```html
 `<Tip warning={true}>`
 ```


### PR DESCRIPTION
Markdown below

```md
# Tips & Blockquotes

> [!TIP]
> Here is a tip. Go to this url [website](www.tip.com)
> 
> Second line


> [!WARNING]
> Here is a warning. Go to this url [website](www.warning.com)
> 
> Second line

> Just a regular blockquote
> 
> Second line
```

gets rendered as 

![image](https://github.com/huggingface/doc-builder/assets/11827707/cdaa5856-93d1-4464-a477-d6b4caab54c9)

See https://github.com/orgs/community/discussions/16925 for the information
