### PR TITLE
Test build pr outside container

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -46,6 +46,10 @@ on:
       convert_notebooks:
         type: boolean
         description: "Convert notebooks to markdown files before building docs."
+      container_image:
+        type: string
+        default: "huggingface/transformers-doc-builder"
+        description: "Docker image to use for the build."
     secrets:
       hf_token:
         required: true
@@ -56,7 +60,7 @@ jobs:
   build_main_documentation:
     runs-on: ubuntu-latest
     container:
-      huggingface/transformers-doc-builder
+      ${{ inputs.container_image }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -46,7 +46,10 @@ on:
       convert_notebooks:
         type: boolean
         description: "Convert notebooks to markdown files before building docs."
-      container_image:
+      # Docker image to use for the build. Set custom_container="" if you don't need any.
+      # Default containers is "huggingface/transformers-doc-builder" which has all the necessary dependencies (torch,
+      # transformers, tensorflow, etc.) but is quite heavy to download.
+      custom_container:
         type: string
         default: "huggingface/transformers-doc-builder"
         description: "Docker image to use for the build."
@@ -60,7 +63,7 @@ jobs:
   build_main_documentation:
     runs-on: ubuntu-latest
     container:
-      ${{ inputs.container_image }}
+      ${{ inputs.custom_container }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -46,6 +46,10 @@ on:
       convert_notebooks:
         type: boolean
         description: "Convert notebooks to markdown files before building docs."
+      container_image:
+        type: string
+        default: "huggingface/transformers-doc-builder"
+        description: "Docker image to use for the build."
       # Debug purposes only!
       doc_builder_revision:
         type: string
@@ -57,7 +61,7 @@ jobs:
   build_pr_documentation:
     runs-on: ubuntu-latest
     container:
-      huggingface/transformers-doc-builder
+      ${{ inputs.container_image }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -46,7 +46,10 @@ on:
       convert_notebooks:
         type: boolean
         description: "Convert notebooks to markdown files before building docs."
-      container_image:
+      # Docker image to use for the build. Set custom_container="" if you don't need any.
+      # Default containers is "huggingface/transformers-doc-builder" which has all the necessary dependencies (torch,
+      # transformers, tensorflow, etc.) but is quite heavy to download.
+      custom_container:
         type: string
         default: "huggingface/transformers-doc-builder"
         description: "Docker image to use for the build."
@@ -61,7 +64,7 @@ jobs:
   build_pr_documentation:
     runs-on: ubuntu-latest
     container:
-      ${{ inputs.container_image }}
+      ${{ inputs.custom_container }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds a new options `custom_container` to build PR in the CI in a custom container. By default, workflow runs inside `"huggingface/transformers-doc-builder"` which is the container needed for `transformers` and that has all dependencies like torch, tensorflow, etc. However, it takes quite some time (>2min) to initialize the container in the CI given its size. In theory, most libraries don't need this container so we should be able to bypass this step and run directly on `ubuntu:latest`. 

This PR is related to https://github.com/huggingface/huggingface_hub/pull/2140 in which I tested the idea.

---

[As discussed on slack](https://huggingface.slack.com/archives/C04F8N7FQNL/p1711384899462349?thread_ts=1711041424.720769&cid=C04F8N7FQNL) (internal), plan is:
1. we merge https://github.com/huggingface/doc-builder/pull/487 in its current state
2. we test to disable custom_container (i.e. `custom_container: ""`) on several repos, including huggingface_hub (already done), datasets, diffusers, hub-docs, etc.
3. for the repos that **needs** the custom container, we set `custom_container: "huggingface/transformers-doc-builder"` in their CI. This should not change anything since it is the default value for now.
4. Once we fixed the repos in which we think transformers image is needed, we make a new PR on doc-builder to change the default value of custom_container to `"" `

This way we should be able to make the transition between "all of them use transformers image" to "most of them use a bare ubuntu" without a breaking change in the process.