### PR TITLE
[fix] ntoebook png image output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-install_requires = ["black", "GitPython", "tqdm", "pyyaml", "packaging", "nbformat", "huggingface_hub"]
+install_requires = ["black", "GitPython", "tqdm", "pyyaml", "packaging", "nbformat", "huggingface_hub", "pillow"]
 
 extras = {}
 


### PR DESCRIPTION
Follow up to https://github.com/huggingface/doc-builder/pull/492

There was svelte parser error when the image output was `png`. Therefore, converting `png` output to `jpeg` before creating svelte/html img element