### PR TITLE
[fix] overwrite defined python object link

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -233,7 +233,9 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
             page_name = str(file.with_suffix("").relative_to(doc_folder))
             for anchor in new_anchors:
                 if isinstance(anchor, tuple):
-                    anchor_mapping.update({a: f"{page_name}#{anchor[0]}" for a in anchor[1:]})
+                    anchor_mapping.update(
+                        {a: f"{page_name}#{anchor[0]}" for a in anchor[1:] if a not in anchor_mapping}
+                    )
                     anchor = anchor[0]
                 anchor_mapping[anchor] = page_name
 


### PR DESCRIPTION
Fixes an issue reported by @NielsRogge 

> Hi, when clicking on "generate()" (the PyTorch one) here: https://huggingface.co/docs/transformers/en/main_classes/text_generation, it links to https://huggingface.co/docs/transformers/v4.38.2/en/model_doc/phi#transformers.PhiForCausalLM.generate, for some reason. It should normally link to https://huggingface.co/docs/transformers/en/main_classes/text_generation#transformers.GenerationMixin.generate.
The code is defined correctly: https://github.com/huggingface/transformers/blob/main/docs/source/en/main_classes/text_generation.md