### PR TITLE
Update on Github btn

### DIFF
--- a/kit/src/lib/EditOnGithub.svelte
+++ b/kit/src/lib/EditOnGithub.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	export let source: string = "";
+</script>
+
+<a
+	class="!text-gray-400 !no-underline text-sm flex items-center not-prose mt-4"
+	href={source}
+	target="_blank"
+>
+	<span>&lt;</span>
+	<span>&gt;</span>
+	<span><span class="underline ml-1.5">Update</span> on GitHub</span>
+</a>

--- a/src/doc_builder/convert_md_to_mdx.py
+++ b/src/doc_builder/convert_md_to_mdx.py
@@ -54,6 +54,7 @@ import PipelineTag from "$lib/PipelineTag.svelte";
 import Heading from "$lib/Heading.svelte";
 import HfOptions from "$lib/HfOptions.svelte";
 import HfOption from "$lib/HfOption.svelte";
+import EditOnGithub from "$lib/EditOnGithub.svelte";
 let fw: "pt" | "tf" = "pt";
 onMount(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -70,6 +71,7 @@ HF_DOC_BODY_START
 
 """
         + process_md(md_text, page_info)
+        + edit_on_github(page_info)
         + """
 
 <!--HF DOCBUILD BODY END-->
@@ -78,6 +80,24 @@ HF_DOC_BODY_END
 
 """
     )
+
+
+def edit_on_github(page_info):
+    """
+    Svelte component string that adds "Update on Github" btn.
+    """
+    if "path" not in page_info or "repo_name" not in page_info:
+        return ""
+    path = str(page_info["path"])
+    package_name = page_info["repo_name"]
+    idx = path.find(package_name)
+    if idx == -1:
+        return ""
+    relative_path = path[idx + len(package_name) :]
+    if relative_path.startswith("/"):
+        relative_path = relative_path[1:]
+    source = f'https://github.com/{page_info["repo_owner"]}/{page_info["repo_name"]}/blob/main/{relative_path}'
+    return f'\n\n<EditOnGithub source="{source}" />\n\n'
 
 
 def convert_img_links(text, page_info):

--- a/tests/test_convert_md_to_mdx.py
+++ b/tests/test_convert_md_to_mdx.py
@@ -56,6 +56,7 @@ import PipelineTag from "$lib/PipelineTag.svelte";
 import Heading from "$lib/Heading.svelte";
 import HfOptions from "$lib/HfOptions.svelte";
 import HfOption from "$lib/HfOption.svelte";
+import EditOnGithub from "$lib/EditOnGithub.svelte";
 let fw: "pt" | "tf" = "pt";
 onMount(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -77,7 +78,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit
 HF_DOC_BODY_END
 
 """
-        print(convert_md_to_mdx(md_text, page_info))
         self.assertEqual(convert_md_to_mdx(md_text, page_info), expected_conversion)
 
     def test_convert_img_links(self):


### PR DESCRIPTION
Now on the bottom of every page, there is a btn to update the page source on github

<img width="201" alt="image" src="https://github.com/huggingface/doc-builder/assets/11827707/75c5a623-b4c9-49f1-a90a-1d290f431e41">
