### PR TITLE
Fix venv not sourced when pushing docs

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -187,6 +187,7 @@ jobs:
       - name: Run pre-command
         shell: bash
         run: |
+          source .venv/bin/activate
           if [ ! -z "${{ inputs.pre_command }}" ]
           then
             bash -c "${{ inputs.pre_command }}"
@@ -235,6 +236,7 @@ jobs:
 
       - name: Push to repositories
         run: |
+          source .venv/bin/activate
           cd build_dir
           doc-builder push ${{ env.package_name }} --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --upload_version_yml
           cd ..

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Run pre-command
         shell: bash
         run: |
+          source .venv/bin/activate
           if [ ! -z "${{ inputs.pre_command }}" ]
           then
             bash -c "${{ inputs.pre_command }}"


### PR DESCRIPTION
Fix bug introduced in https://github.com/huggingface/doc-builder/pull/488.
Problem comes from that the venv is not properly activated in some cases. See failed CI in [computer vision course](https://github.com/johko/computer-vision-course): https://github.com/johko/computer-vision-course/actions/runs/8895303169/job/24425352840. This PR should fix it.

cc @mishig25 @coyotte508 @merveenoyan 