### PR TITLE
Allow Import Paths of Arbitrary Length

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -39,9 +39,9 @@ def find_object_in_package(object_name, package):
         submodule = getattr(module, split, None)
         # `split` could be the name of a package if `package` is a namespace package, in which case it doesn't appear
         # as an attribute if the submodule was not imported before
-        if submodule is None and idx == 0:
+        if submodule is None:
             try:
-                importlib.import_module(f"{package.__name__}.{split}")
+                importlib.import_module(".".join([package.__name__] + path_splits[:idx+1]))
                 submodule = getattr(module, split, None)
             except ImportError:
                 pass


### PR DESCRIPTION
The `import_module` would be called only on a single level up from a submodule
- i.e., <submodule>.<submodule> will work, and 
- and <package>.<submodule>.<submodule> will work
- but <submodule>.<submodule>.<submodule> *will not work*

For example this will work
```python
utils.extract_model_from_parallel
utils.save
utils.wait_for_everyone
utils.set_seed
utils.synchronize_rng_state
utils.install_xla 
utils.load_checkpoint_in_model
utils.load_and_quantize_model
utils.DeepSpeedPlugin
utils.DeepSpeedPlugin.deepspeed_config_process
accelerate.DeepSpeedPlugin.deepspeed_config_process
```

Also this will work, because it starts from `accelerate`
```python
accelerate.DeepSpeedPlugin.deepspeed_config_process
```

But this **will not work**
```python
utils.deepspeed.DummyOptim
```

This PR will allow the last example to work
