### PR TITLE
Escape hash in code/codeblocks

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           repository: 'huggingface/accelerate'
           path: accelerate
+          ref: 16eb6d76bf987c7d8d877ce5152f2e29878eab37
 
       - name: Loading cache.
         uses: actions/cache@v2

--- a/kit/preprocessors/hashInCode.js
+++ b/kit/preprocessors/hashInCode.js
@@ -1,0 +1,17 @@
+import { replaceAsync } from "./utils.js";
+
+// Preprocessor that converts `#` char inside code/codeblocks into its html5 entity `&amp;num;`
+// otherwise, an extra new space was being rendered
+export const hashInCodePreprocess = {
+	markup: async ({ content }) => {
+		const REGEX_CODE_BLOCK = /```.*?```/sg;
+		const REGEX_INLINE_CODE = /`.*?`/sg;
+		content = await replaceAsync(content, REGEX_CODE_BLOCK, async (codeContent) => {
+			return codeContent.replaceAll("#", "&amp;num;");
+		});
+		content = await replaceAsync(content, REGEX_INLINE_CODE, async (codeContent) => {
+			return codeContent.replaceAll("#", "&amp;num;");
+		});
+		return { code: content };
+	},
+};

--- a/kit/preprocessors/hashInCode.js
+++ b/kit/preprocessors/hashInCode.js
@@ -4,8 +4,8 @@ import { replaceAsync } from "./utils.js";
 // otherwise, an extra new space was being rendered
 export const hashInCodePreprocess = {
 	markup: async ({ content }) => {
-		const REGEX_CODE_BLOCK = /```.*?```/sg;
-		const REGEX_INLINE_CODE = /`.*?`/sg;
+		const REGEX_CODE_BLOCK = /```.*?```/gs;
+		const REGEX_INLINE_CODE = /`.*?`/gs;
 		content = await replaceAsync(content, REGEX_CODE_BLOCK, async (codeContent) => {
 			return codeContent.replaceAll("#", "&amp;num;");
 		});

--- a/kit/preprocessors/index.js
+++ b/kit/preprocessors/index.js
@@ -4,3 +4,4 @@ export { inferenceSnippetPreprocess } from "./inferenceSnippet.js";
 export { tokenizersLangPreprocess } from "./tokenizersLang.js";
 export { mdsvexPreprocess } from "./mdsvex/index.js";
 export { hfOptionsPreprocess } from "./hfOptions.js";
+export { hashInCodePreprocess } from "./hashInCode.js";

--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -6,6 +6,7 @@ import htmlTags from "html-tags";
 import { readdir } from "fs/promises";
 import path from "path";
 import cheerio from "cheerio";
+import { renderSvelteChars } from "../utils.js";
 
 /**
  * inside `<code>` html elements, we need to replace `&amp;` with `&`
@@ -42,15 +43,6 @@ export const mdsvexPreprocess = {
 		return { code: content };
 	},
 };
-
-/**
- * Render escaped characters like `<`, `{`.
- * used for Doc
- * @param {string} code
- */
-function renderSvelteChars(code) {
-	return code.replace(/&amp;lcub;/g, "{").replace(/&amp;lt;/g, "<");
-}
 
 /**
  * Latex support in mdsvex

--- a/kit/preprocessors/utils.js
+++ b/kit/preprocessors/utils.js
@@ -29,7 +29,10 @@ export async function replaceAsync(string, searchValue, replacer) {
  * @param {string} code
  */
 export function renderSvelteChars(code) {
-	return code.replace(/&amp;lcub;/g, "{").replace(/&amp;lt;/g, "<").replace(/&amp;num;/g, "#");
+	return code
+		.replace(/&amp;lcub;/g, "{")
+		.replace(/&amp;lt;/g, "<")
+		.replace(/&amp;num;/g, "#");
 }
 
 /**

--- a/kit/preprocessors/utils.js
+++ b/kit/preprocessors/utils.js
@@ -24,12 +24,12 @@ export async function replaceAsync(string, searchValue, replacer) {
 }
 
 /**
- * Render escaped characters like `<`, `{`.
+ * Render escaped characters like `<`, `{`, '#'.
  * used for Doc
  * @param {string} code
  */
 export function renderSvelteChars(code) {
-	return code.replace(/&amp;lcub;/g, "{").replace(/&amp;lt;/g, "<");
+	return code.replace(/&amp;lcub;/g, "{").replace(/&amp;lt;/g, "<").replace(/&amp;num;/g, "#");
 }
 
 /**

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -8,6 +8,7 @@ import {
 	inferenceSnippetPreprocess,
 	tokenizersLangPreprocess,
 	hfOptionsPreprocess,
+	hashInCodePreprocess,
 } from "./preprocessors/index.js";
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -15,6 +16,7 @@ const config = {
 	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
 	// for more information about preprocessors
 	preprocess: [
+		hashInCodePreprocess,
 		docstringPreprocess,
 		frameworkcontentPreprocess,
 		inferenceSnippetPreprocess,


### PR DESCRIPTION
## Description 

Escape `#` char inside code/codeblocks into its html5 entity `&amp;num;`. Otherwise, an extra new space was being rendered. Discovered after checking the renderings from https://github.com/huggingface/chat-ui/pull/1155


| main    | this branch/pr |
| -------- | ------- |
| ![image](https://github.com/huggingface/doc-builder/assets/11827707/630ff31e-3758-41b7-886b-0311604278d4)  | ![image](https://github.com/huggingface/doc-builder/assets/11827707/7422b91e-415c-453c-b087-5922210862fb)   |