### PR TITLE
Update GitHub Actions to use Node 20

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -26,7 +26,7 @@ jobs:
           ref: 16eb6d76bf987c7d8d877ce5152f2e29878eab37
 
       - name: Loading cache.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: ~/.cache/pip

--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           node-version: '20'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
       
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'huggingface/accelerate'
           path: accelerate

--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -10,7 +10,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -67,17 +67,17 @@ jobs:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
         
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: '${{ inputs.repo_owner }}/${{ inputs.package }}'
           path: ${{ inputs.package }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: inputs.notebook_folder != ''
         with:
           repository: 'huggingface/notebooks'

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -84,7 +84,7 @@ jobs:
           path: notebooks
           token: ${{ secrets.token }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json" 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -79,7 +79,7 @@ jobs:
           repository: '${{ inputs.repo_owner }}/${{ inputs.package }}'
           path: ${{ inputs.package }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -68,13 +68,13 @@ jobs:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
           ref: ${{ inputs.doc_builder_revision }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: '${{ inputs.repo_owner }}/${{ inputs.package }}'
           path: ${{ inputs.package }}

--- a/.github/workflows/delete_old_pr_documentations.yml
+++ b/.github/workflows/delete_old_pr_documentations.yml
@@ -11,7 +11,7 @@ jobs:
   delete_old_prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/lint-svelte-kit.yml
+++ b/.github/workflows/lint-svelte-kit.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint-svelte-kit.yml
+++ b/.github/workflows/lint-svelte-kit.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install dependencies
         run: npm install ci

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,7 +6,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install Python dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install Python dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -28,7 +28,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder


### PR DESCRIPTION
Currently, we get deprecation warnings when building our docs: https://github.com/huggingface/datasets/actions/runs/9547896244
```
build / build_main_documentation
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

This PR updates the required GitHub Actions to use Node 20.