### PR TITLE
Autodoc  __getattribute__  fix

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -428,7 +428,7 @@ def find_documented_methods(clas):
         a: m for a, m in public_methods.items() if getattr(m, "__doc__", None) is not None and len(m.__doc__) > 0
     }
 
-    superclasses = clas.mro()[1:]
+    superclasses = clas.__mro__[1:]
     for superclass in superclasses:
         superclass_methods = {a: getattr(superclass, a) for a in documented_methods.keys() if hasattr(superclass, a)}
         documented_methods = {


### PR DESCRIPTION
Autodoc calls `mro` on the target class triggering `__getattribute__()`.  This could throw an exception breaking the build of documentation, such as when building the documentation for `transformers` on Mac OS:  [transformers/issues/32203](https://github.com/huggingface/transformers/issues/32203).

This PR fixes this issue by using mro cached in `__mro__` instead of `mro()`. This shouldn't be a breaking change from what I understand of `mro()` and `__mro__` but I'm not 100% confident.