### PR TITLE
Fix autodoc parameter hrefs

### DIFF
--- a/kit/preprocessors/hashInCode.js
+++ b/kit/preprocessors/hashInCode.js
@@ -6,11 +6,16 @@ export const hashInCodePreprocess = {
 	markup: async ({ content }) => {
 		const REGEX_CODE_BLOCK = /```.*?```/gs;
 		const REGEX_INLINE_CODE = /`.*?`/g;
+		const REGEX_INLINE_EXCEPTION = /(?!.*HF_DOC_BODY_START)`.*?`(?<!HF_DOC_BODY_END.*)/gs;
 		content = await replaceAsync(content, REGEX_CODE_BLOCK, async (codeContent) => {
 			return codeContent.replaceAll("#", "&amp;num;");
 		});
 		content = await replaceAsync(content, REGEX_INLINE_CODE, async (codeContent) => {
 			return codeContent.replaceAll("#", "&amp;num;");
+		});
+		// Exception: we don't want to replace `#` in code blocks that are part of the doc body, as they may be hrefs
+		content = await replaceAsync(content, REGEX_INLINE_EXCEPTION, async (codeContent) => {
+			return codeContent.replaceAll("&amp;num;", "#");
 		});
 		return { code: content };
 	},


### PR DESCRIPTION
## TL;DR 

fixes hrefs for class parameters 🤗 

_______________________________________________ 

### Problem

Currently, hrefs for individual parameters are broken on ALL classes across ALL libraries.

Examples (try to click on individual parameters of the classes):
- (transformers) https://huggingface.co/docs/transformers/v4.43.2/en/main_classes/text_generation#transformers.GenerationConfig
- (accelerate) https://huggingface.co/docs/accelerate/v0.33.0/en/package_reference/accelerator

We can see in the pages' source code that the hrefs are sketchy
<img width="409" alt="Screenshot 2024-07-26 at 10 27 11" src="https://github.com/user-attachments/assets/ad017811-21b4-482f-9242-d3505a060adf">

Diving deeper in the doc builder, we can see that:
1. The creation of the mdx files is correct
2. The issue can be solved if we comment out [the lines](https://github.com/huggingface/doc-builder/blob/fcea09086f6dec68ef9ce419f164c6c33e8fb5f4/kit/preprocessors/hashInCode.js#L12) that replace `#` by their htlm equivalent on inline code blocks

### Solution

The `#` conversion exists to prevent bad formatting in some cases, so it can't simply be removed -- see #504 

The solution adopted consists in detecting inline code blocks inside the autodoc section, which contain the href anchor, and preserving the `#` there. The solution in the PR consists in reverting the conversion -- in my quick experiments, a complete regex that skipped the conversion in autodoc blocks was much much slower.

Example of an href after these changes:
<img width="431" alt="Screenshot 2024-07-26 at 10 37 01" src="https://github.com/user-attachments/assets/78917a2c-5a51-46d0-ad2e-4f05b786751e">

Same href in a [previously working version](https://huggingface.co/docs/transformers/v4.40.2/en/main_classes/text_generation):
<img width="483" alt="Screenshot 2024-07-26 at 10 36 29" src="https://github.com/user-attachments/assets/1fa9f474-148a-40ef-9995-b58e9fb81d00">
