### PR TITLE
Use python virtual env for gh CI

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -25,7 +25,12 @@ jobs:
           path: accelerate
           ref: 16eb6d76bf987c7d8d877ce5152f2e29878eab37
 
-      - name: Loading cache.
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Loading cache
         uses: actions/cache@v4
         id: cache
         with:
@@ -34,6 +39,11 @@ jobs:
           restore-keys: |
             v1-test_build_doc-${{ hashFiles('setup.py') }}
             v1-test_build_doc
+
+      - name: Create and activate virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
 
       - name: Setup environment
         run: |
@@ -44,7 +54,7 @@ jobs:
           cd accelerate
           pip install .[dev]
           cd ..
-          
+        
       - name: Make documentation
         run: |
           cd doc-builder &&

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -84,6 +84,11 @@ jobs:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Export ROOT_APT_GET ('apt-get' or 'sudo apt-get')
         # Use `sudo` only if running on the base runner.
         # When using a container, `sudo` is not needed (and not installed)
@@ -140,6 +145,11 @@ jobs:
         if: inputs.install_rust
         with:
           toolchain: stable
+
+      - name: Create and activate virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
 
       # Use venv in both cases
       - name: Install uv


### PR DESCRIPTION
In hf docs github CI, we are facing a same issue described [here](https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana).