### PR TITLE
Pin ubuntu-22.04 for build_pr_documentation.yml

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -25,12 +25,7 @@ jobs:
           path: accelerate
           ref: 16eb6d76bf987c7d8d877ce5152f2e29878eab37
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Loading cache
+      - name: Loading cache.
         uses: actions/cache@v4
         id: cache
         with:
@@ -39,11 +34,6 @@ jobs:
           restore-keys: |
             v1-test_build_doc-${{ hashFiles('setup.py') }}
             v1-test_build_doc
-
-      - name: Create and activate virtual environment
-        run: |
-          python -m venv venv
-          source venv/bin/activate
 
       - name: Setup environment
         run: |
@@ -54,7 +44,7 @@ jobs:
           cd accelerate
           pip install .[dev]
           cd ..
-        
+          
       - name: Make documentation
         run: |
           cd doc-builder &&

--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -25,7 +25,12 @@ jobs:
           path: accelerate
           ref: 16eb6d76bf987c7d8d877ce5152f2e29878eab37
 
-      - name: Loading cache.
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Loading cache
         uses: actions/cache@v4
         id: cache
         with:
@@ -34,6 +39,11 @@ jobs:
           restore-keys: |
             v1-test_build_doc-${{ hashFiles('setup.py') }}
             v1-test_build_doc
+
+      - name: Create and activate virtual environment
+        run: |
+          python -m venv venv
+          source venv/bin/activate
 
       - name: Setup environment
         run: |

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -148,7 +148,7 @@ jobs:
       # Use venv in both cases
       - name: Install uv
         run: |
-          pip install -U uv --break-system-packages
+          pip install -U uv
           uv venv
 
       - name: Setup environment

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -148,7 +148,7 @@ jobs:
       # Use venv in both cases
       - name: Install uv
         run: |
-          pip install -U uv
+          pip install -U uv --break-system-packages
           uv venv
 
       - name: Setup environment

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -84,11 +84,6 @@ jobs:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
       - name: Export ROOT_APT_GET ('apt-get' or 'sudo apt-get')
         # Use `sudo` only if running on the base runner.
         # When using a container, `sudo` is not needed (and not installed)
@@ -145,11 +140,6 @@ jobs:
         if: inputs.install_rust
         with:
           toolchain: stable
-
-      - name: Create and activate virtual environment
-        run: |
-          python -m venv venv
-          source venv/bin/activate
 
       # Use venv in both cases
       - name: Install uv

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   build_pr_documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       ${{ inputs.custom_container }}
     env:

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -154,7 +154,7 @@ jobs:
       # Use venv in both cases
       - name: Install uv
         run: |
-          pip install -U uv --break-system-packages
+          pip install -U uv
           uv venv
 
       - name: Setup environment

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -39,9 +39,9 @@ jobs:
         shell: bash
         id: setup-env
         run: |
-          pip install black --break-system-packages
+          pip install black
           cd doc-builder
-          pip install . --break-system-packages
+          pip install .
           cd ..
           echo "current_work_dir=$(pwd)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Follow up to #528 #529 #530

### Description

`ubuntu-latest` is now `ubuntu-24.04` and it is breaking stuff.

#528 #529 #530 handled `uv` install error described [here](https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana).

However, more errors are happening. Such as:
> python: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found

Therefore, for now, pinning `ubuntu-22.04`