### PR TITLE
Fix args parsing when argument doesn't have a type

### DIFF
--- a/src/doc_builder/convert_rst_to_mdx.py
+++ b/src/doc_builder/convert_rst_to_mdx.py
@@ -401,7 +401,7 @@ def parse_rst_docstring(docstring):
                 if intro.lstrip().startswith(">"):
                     lines[idx] = intro.lstrip()
                 else:
-                    lines[idx] = re.sub(r"^\s*(\S+)(\s)", r"- **\1**\2", intro) + " --" + doc
+                    lines[idx] = re.sub(r"^\s*(\S+)(\s)?", r"- **\1**\2", intro) + " --" + doc
                 idx += 1
                 while idx < len(lines) and (is_empty_line(lines[idx]) or find_indent(lines[idx]) > param_indent):
                     idx += 1

--- a/tests/test_convert_rst_to_mdx.py
+++ b/tests/test_convert_rst_to_mdx.py
@@ -504,6 +504,9 @@ Args:
     a (:obj:`str` or :obj:`bool`): some parameter
     b (:obj:`str` or :obj:`bool`):
         Another parameter with the description below
+    c: another parameter with no type annotation
+    d:
+        Another parameter with no type annotation and a description below
 
 Raises:
     `pa.ArrowInvalidError`: if the arrow data casting fails
@@ -530,6 +533,9 @@ docstring
 - **a** (:obj:`str` or :obj:`bool`) -- some parameter
 - **b** (:obj:`str` or :obj:`bool`) --
         Another parameter with the description below
+- **c** -- another parameter with no type annotation
+- **d** --
+        Another parameter with no type annotation and a description below
 
 </parameters>
 


### PR DESCRIPTION
(testing things for timm)

Explanation:
1. docstring is parsed => parameters section is located from the `Args:` (or `Parameters:`) title
2. then, each arg section is detected. The logic detect new args from the indentation. The first line of an arg looks like this:
```
filter_bias_and_bn (*str*, _optional_):  If True, bias, norm layer parameters (...)
```

3. then, the arg first line is reformatted to
```
- **filter_bias_and_bn** (*str*, _optional_) -- If True, bias, norm layer parameters (...)
```
=> a regex splits the line around `":"`
=> another regex detects the arg name "`filter_bias_and_bn`" and adds the `** **` around it
=> finally, a string concatenation is applied to replace the `:` by a `--`
**This is the step that got modified in this PR.**

4. Later in the process, if an arg doesn't start with `- **(...)`, it is removed from the docstring, hence not appearing in the docs.

---
What this PR does is to update the regex from step 3. that adds `** **` with a substitution. The regex was `r"^\s*(\S+)(\s)"` which does not match when an argument has no extra information apart its name. This is for example the case for many `timm` docstrings that follow google style (-ish).

```
param_group_fn: Optional function to create custom parameter groups.
```
=> regex does not detect a new space => `- **(...)` is not added => the arg is removed from the docs
This PR allows for no extra space by adding a simple `?` to the regex :smile: 
