### PR TITLE
Update python version in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install Python dependencies
       run: pip install -e .[quality]
     - name: Run Quality check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install Python dependencies
       run: pip install -e .[quality]
     - name: Run Quality check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install Python dependencies
       run: |
         pip install -e ".[all]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install Python dependencies
       run: |
         pip install -e ".[all]"

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -88,14 +88,9 @@ def get_shortest_path(obj, package):
 
 def get_type_name(typ):
     """
-    Returns the name of the type passed, properly dealing with type annotions.
+    Returns the name of the type passed, properly dealing with type annotations.
     """
-    if hasattr(typ, "__qualname__"):
-        return typ.__qualname__
-    elif hasattr(typ, "__name__"):
-        return typ.__name__
-    name = str(typ)
-    return re.sub(r"typing.Union\[(\S+), NoneType\]", r"typing.Optional[\1]", name)
+    return re.sub(r"typing\.", "", str(typ))
 
 
 def format_signature(obj):

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -92,8 +92,8 @@ def get_type_name(typ):
     """
     if isinstance(typ, type):
         # If it's a class, use its name.
-        return getattr(typ, '__qualname__', None) or getattr(typ, '__name__', None) or str(typ)
-    return str(typ) # otherwise, trust its string representation
+        return getattr(typ, "__qualname__", None) or getattr(typ, "__name__", None) or str(typ)
+    return str(typ)  # otherwise, trust its string representation
 
 
 def format_signature(obj):

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -92,7 +92,7 @@ def get_type_name(typ):
     """
     if isinstance(typ, type):
         # If it's a class, use its name.
-        return getattr(typ, '__qualname__', None) or getattr(typ, '__name__', None)
+        return getattr(typ, '__qualname__', None) or getattr(typ, '__name__', None) or str(typ)
     return str(typ) # otherwise, trust its string representation
 
 

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -66,7 +66,7 @@ def get_shortest_path(obj, package):
     package.
     """
     if isinstance(obj, property):
-        # Propreties have no __module__ or __name__ attributes, but their getter function does.
+        # Properties have no __module__ or __name__ attributes, but their getter function does.
         obj = obj.fget
 
     if not hasattr(obj, "__module__") or obj.__module__ is None:

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -90,7 +90,10 @@ def get_type_name(typ):
     """
     Returns the name of the type passed, properly dealing with type annotations.
     """
-    return str(typ)  # previous implementation was more complex, but this is enough for python 3.9+
+    if isinstance(typ, type):
+        # If it's a class, use its name.
+        return getattr(typ, '__qualname__', None) or getattr(typ, '__name__', None)
+    return str(typ) # otherwise, trust its string representation
 
 
 def format_signature(obj):

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -90,7 +90,7 @@ def get_type_name(typ):
     """
     Returns the name of the type passed, properly dealing with type annotations.
     """
-    return re.sub(r"typing\.", "", str(typ))
+    return str(typ)  # previous implementation was more complex, but this is enough for python 3.9+
 
 
 def format_signature(obj):

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -183,7 +183,7 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_type_name(Optional[str]), "typing.Optional[str]")
         self.assertEqual(get_type_name(Union[bool, int]), "typing.Union[bool, int]")
         self.assertEqual(get_type_name(List[Optional[str]]), "typing.List[typing.Optional[str]]")
-        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "typing.List[typing.Union[str, int]]")
+        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "typing.List[typing.Union[str, int, NoneType]]")
 
     def test_format_signature(self):
         self.assertEqual(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -179,10 +179,10 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_type_name(str), "str")
         self.assertEqual(get_type_name(BertModel), "BertModel")
         # Objects from typing which are the most annoying
-        self.assertEqual(get_type_name(List[str]), "typing.List[str]")
-        self.assertEqual(get_type_name(Optional[str]), "typing.Optional[str]")
-        self.assertEqual(get_type_name(Union[bool, int]), "typing.Union[bool, int]")
-        self.assertEqual(get_type_name(List[Optional[str]]), "typing.List[typing.Optional[str]]")
+        self.assertEqual(get_type_name(List[str]), "List[str]")
+        self.assertEqual(get_type_name(Optional[str]), "Optional[str]")
+        self.assertEqual(get_type_name(Union[bool, int]), "Union[bool, int]")
+        self.assertEqual(get_type_name(List[Optional[str]]), "List[Optional[str]]")
 
     def test_format_signature(self):
         self.assertEqual(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -39,6 +39,7 @@ from doc_builder.autodoc import (
 from transformers import BertModel, BertTokenizer, BertTokenizerFast, TrainingArguments
 from transformers.utils import PushToHubMixin
 
+
 # This is dynamic since the Transformers/timm libraries are not frozen.
 TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 TEST_LINE_NUMBER2 = inspect.getsourcelines(transformers.pipeline)[1]

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -183,6 +183,7 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_type_name(Optional[str]), "Optional[str]")
         self.assertEqual(get_type_name(Union[bool, int]), "Union[bool, int]")
         self.assertEqual(get_type_name(List[Optional[str]]), "List[Optional[str]]")
+        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "List[Union[str, int]]")
 
     def test_format_signature(self):
         self.assertEqual(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -39,6 +39,7 @@ from doc_builder.autodoc import (
 from transformers import BertModel, BertTokenizer, BertTokenizerFast, TrainingArguments
 from transformers.utils import PushToHubMixin
 
+
 # This is dynamic since the Transformers/timm libraries are not frozen.
 TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 TEST_LINE_NUMBER2 = inspect.getsourcelines(transformers.pipeline)[1]
@@ -182,7 +183,9 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_type_name(Optional[str]), "typing.Optional[str]")
         self.assertEqual(get_type_name(Union[bool, int]), "typing.Union[bool, int]")
         self.assertEqual(get_type_name(List[Optional[str]]), "typing.List[typing.Optional[str]]")
-        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "typing.List[typing.Union[str, int, NoneType]]")
+        self.assertEqual(
+            get_type_name(List[Optional[Union[str, int, None]]]), "typing.List[typing.Union[str, int, NoneType]]"
+        )
 
     def test_format_signature(self):
         self.assertEqual(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -39,7 +39,6 @@ from doc_builder.autodoc import (
 from transformers import BertModel, BertTokenizer, BertTokenizerFast, TrainingArguments
 from transformers.utils import PushToHubMixin
 
-
 # This is dynamic since the Transformers/timm libraries are not frozen.
 TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 TEST_LINE_NUMBER2 = inspect.getsourcelines(transformers.pipeline)[1]
@@ -172,7 +171,7 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_shortest_path(PushToHubMixin, transformers), "transformers.utils.PushToHubMixin")
         self.assertEqual(
             get_shortest_path(TrainingArguments.__init__, transformers),
-            "transformers.training_args.__create_fn__.<locals>.__init__",
+            "transformers.TrainingArguments.__init__",
         )
 
     def test_get_type_name(self):

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -179,11 +179,11 @@ class AutodocTester(unittest.TestCase):
         self.assertEqual(get_type_name(str), "str")
         self.assertEqual(get_type_name(BertModel), "BertModel")
         # Objects from typing which are the most annoying
-        self.assertEqual(get_type_name(List[str]), "List[str]")
-        self.assertEqual(get_type_name(Optional[str]), "Optional[str]")
-        self.assertEqual(get_type_name(Union[bool, int]), "Union[bool, int]")
-        self.assertEqual(get_type_name(List[Optional[str]]), "List[Optional[str]]")
-        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "List[Union[str, int]]")
+        self.assertEqual(get_type_name(List[str]), "typing.List[str]")
+        self.assertEqual(get_type_name(Optional[str]), "typing.Optional[str]")
+        self.assertEqual(get_type_name(Union[bool, int]), "typing.Union[bool, int]")
+        self.assertEqual(get_type_name(List[Optional[str]]), "typing.List[typing.Optional[str]]")
+        self.assertEqual(get_type_name(List[Optional[Union[str, int, None]]]), "typing.List[typing.Union[str, int]]")
 
     def test_format_signature(self):
         self.assertEqual(

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -39,7 +39,6 @@ from doc_builder.autodoc import (
 from transformers import BertModel, BertTokenizer, BertTokenizerFast, TrainingArguments
 from transformers.utils import PushToHubMixin
 
-
 # This is dynamic since the Transformers/timm libraries are not frozen.
 TEST_LINE_NUMBER = inspect.getsourcelines(transformers.utils.ModelOutput)[1]
 TEST_LINE_NUMBER2 = inspect.getsourcelines(transformers.pipeline)[1]


### PR DESCRIPTION
should fix the CI

Sets python3.10 as Python version in CI

This PR also simplifies `get_type_name` logic. From 3.9 onwards, `typing` resolves types by itself in a much cleaver way than before. Typically, `typing.Optional[Union[str, None]]]` is automatically converted to `typing.Optional[str]`. So let's use this instead of a custom regex. I've added a test to confirm everything works as before. `get_type_name` is now trivial but let's keep it so that it can be tested independently.