### PR TITLE
bump `actions/upload-artifact` version

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -217,7 +217,7 @@ jobs:
           echo ${{ inputs.commit_sha }} > ./build_dir/commit_sha
           echo ${{ inputs.pr_number }} > ./build_dir/pr_number
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: doc-build-artifact
           path: build_dir/


### PR DESCRIPTION
`actions/upload-artifact@v3` is no longer working, see e.g. [this workflow](https://github.com/huggingface/transformers/actions/runs/12813495878/job/35727693015?pr=35709)