### PR TITLE
Fix PR doc upload workflow

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: doc-build-artifact
+          path: ${{ github.workspace }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: huggingface/optimum-habana
           run-id: ${{github.event.workflow_run.id }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -49,6 +49,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: doc-build-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: huggingface/optimum-habana
           run-id: ${{github.event.workflow_run.id }}
 
       - run: |

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -49,15 +49,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: doc-build-artifact
-          path: ${{ github.workspace }}
+          path: ${{ github.workspace }}/build_dir
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: huggingface/optimum-habana
           run-id: ${{github.event.workflow_run.id }}
-
-      - run: |
-          mkdir build_dir
-          pwd && ls
-          unzip doc-build-artifact.zip -d build_dir
 
       - name: Display structure of downloaded files
         run: ls -l

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -55,6 +55,7 @@ jobs:
 
       - run: |
           mkdir build_dir
+          pwd && ls
           unzip doc-build-artifact.zip -d build_dir
 
       - name: Display structure of downloaded files

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -51,7 +51,6 @@ jobs:
           name: doc-build-artifact
           path: ${{ github.workspace }}/build_dir
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: huggingface/optimum-habana
           run-id: ${{github.event.workflow_run.id }}
 
       - name: Display structure of downloaded files

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -46,25 +46,10 @@ jobs:
           echo "current_work_dir=$(pwd)" >> $GITHUB_OUTPUT
 
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "doc-build-artifact"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{steps.setup-env.outputs.current_work_dir}}/doc-build-artifact.zip', Buffer.from(download.data));
+          name: doc-build-artifact
+          run-id: ${{github.event.workflow_run.id }}
 
       - run: |
           mkdir build_dir


### PR DESCRIPTION
`actions/upload-artifact@v3` recently had to be upgraded because it is now deprecated (see https://github.com/huggingface/doc-builder/pull/541).
However, the logic used to download the uploaded artifact does not work anymore with this upgrade. This PR fixes this issue and replaces the custom download logic with `actions/download-artifact@v4`.