### PR TITLE
Pass inferenceProvider as mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,43 +398,47 @@ The `InferenceSnippet` component is used to render an interactive interface for 
 
 Below is a description of the props that can be passed to this component:
 
-- **modelId** (string, required):  
-  The identifier of the AI model to be used for inference. This should be a valid model ID, such as `"deepseek-ai/DeepSeek-R1"`.
-
 - **pipeline** (string, required):  
   Specifies the type of pipeline to be used for inference. Common values include `"text-generation"`, `"text-classification"`, etc.
 
+- **providersMapping** (mapping of {modelId: string, providerModelId: string}, required):  
+  A mapping which keys are provider names and values are an object with `modelId` and `providerModelId`.
+  Example: `{"fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1", novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}}`
+
 - **conversational** (boolean, optional):  
   If set to `true`, the component will enable conversational mode, allowing for multi-turn interactions for `text-generation` models.
-
-- **providers** (array of strings, required):  
-  A list of provider names that support the specified model and pipeline. Example: `["fireworks-ai", "cerebras", "cohere", "hyperbolic"]`.
 
 #### Example Usage
 
 ```svelte
 <InferenceSnippet
-	modelId="deepseek-ai/DeepSeek-R1"
 	pipeline="text-generation"
 	conversational
-	providers={["fireworks-ai", "cerebras", "cohere", "hyperbolic"]}
+	providersMapping={{
+    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"},
+    novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}
+  }}
 />
 ```
 
 ```svelte
 <InferenceSnippet
-	modelId="deepseek-ai/DeepSeek-R1"
 	pipeline="text-generation"
 	conversational
-	providers={["fireworks-ai"]}
+	providers={{
+    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"}
+  }}
 />
 ```
 
 ```svelte
 <InferenceSnippet
-	modelId="black-forest-labs/FLUX.1-dev"
 	pipeline="text-to-image"
-	providers={["black-forest-labs", "replicate", "fal-ai"]}
+	providers={{
+    "black-forest-labs": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "flux-dev"},
+    "replicate": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "black-forest-labs/flux-dev"},
+    "fal-ai": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "fal-ai/flux/dev"},
+  }}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Below is a description of the props that can be passed to this component:
   Specifies the type of pipeline to be used for inference. Common values include `"text-generation"`, `"text-classification"`, etc.
 
 - **providersMapping** (mapping of {modelId: string, providerModelId: string}, required):  
-  A mapping which keys are provider names and values are an object with `modelId` and `providerModelId`.
+  A mapping which keys are provider names and values are objects with `modelId` and `providerModelId`.
   Example: `{"fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1", novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}}`
 
 - **conversational** (boolean, optional):  

--- a/kit/src/lib/InferenceSnippet/README.md
+++ b/kit/src/lib/InferenceSnippet/README.md
@@ -10,7 +10,7 @@ Below is a description of the props that can be passed to this component:
   Specifies the type of pipeline to be used for inference. Common values include `"text-generation"`, `"text-classification"`, etc.
 
 - **providersMapping** (mapping of {modelId: string, providerModelId: string}, required):  
-  A mapping which keys are provider names and values are an object with `modelId` and `providerModelId`.
+  A mapping which keys are provider names and values are objects with `modelId` and `providerModelId`.
   Example: `{"fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1", novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}}`
 
 - **conversational** (boolean, optional):  

--- a/kit/src/lib/InferenceSnippet/README.md
+++ b/kit/src/lib/InferenceSnippet/README.md
@@ -6,43 +6,47 @@ The `InferenceSnippet` component is used to render an interactive interface for 
 
 Below is a description of the props that can be passed to this component:
 
-- **modelId** (string, required):  
-  The identifier of the AI model to be used for inference. This should be a valid model ID, such as `"deepseek-ai/DeepSeek-R1"`.
-
 - **pipeline** (string, required):  
   Specifies the type of pipeline to be used for inference. Common values include `"text-generation"`, `"text-classification"`, etc.
 
+- **providersMapping** (mapping of {modelId: string, providerModelId: string}, required):  
+  A mapping which keys are provider names and values are an object with `modelId` and `providerModelId`.
+  Example: `{"fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1", novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}}`
+
 - **conversational** (boolean, optional):  
   If set to `true`, the component will enable conversational mode, allowing for multi-turn interactions for `text-generation` models.
-
-- **providers** (array of strings, required):  
-  A list of provider names that support the specified model and pipeline. Example: `["fireworks-ai", "cerebras", "cohere", "hyperbolic"]`.
 
 #### Example Usage
 
 ```svelte
 <InferenceSnippet
-	modelId="deepseek-ai/DeepSeek-R1"
 	pipeline="text-generation"
 	conversational
-	providers={["fireworks-ai", "cerebras", "cohere", "hyperbolic"]}
+	providersMapping={{
+    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"},
+    novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}
+  }}
 />
 ```
 
 ```svelte
 <InferenceSnippet
-	modelId="deepseek-ai/DeepSeek-R1"
 	pipeline="text-generation"
 	conversational
-	providers={["fireworks-ai"]}
+	providers={{
+    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"}
+  }}
 />
 ```
 
 ```svelte
 <InferenceSnippet
-	modelId="black-forest-labs/FLUX.1-dev"
 	pipeline="text-to-image"
-	providers={["black-forest-labs", "replicate", "fal-ai"]}
+	providers={{
+    "black-forest-labs": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "flux-dev"},
+    "replicate": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "black-forest-labs/flux-dev"},
+    "fal-ai": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "fal-ai/flux/dev"},
+  }}
 />
 ```
 


### PR DESCRIPTION
Follow-up after https://github.com/huggingface/doc-builder/pull/549 and https://github.com/huggingface/doc-builder/pull/552 on the Inference Snippet svelte component. 

The main change is to remove `modelId` and `providers` in favor of a `providersMapping`. The keys are provider names and values are objects with `modelId` and `providerModelId`. Goals are:
- we want to be able to highlight different models depending on the provider. Component will be use for e.g. the "chat completion" doc page. Since we can't guarantee that a single model will be available on all providers, we need to feature different models in order to show snippet for all providers.
- for each provider <> model id pair, there is a "providerModelId" mapping. For some providers, it is the same id but not for all. The provider model id is required to display correct snippets for cURL / raw requests snippets.  

#### Example Usage

```svelte
<InferenceSnippet
	pipeline="text-generation"
	conversational
	providersMapping={{
    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"},
    novita: {modelId: "deepseek-ai/DeepSeek-V3-0324", providerModelId: "deepseek/deepseek-v3-0324"}
  }}
/>
```

```svelte
<InferenceSnippet
	pipeline="text-generation"
	conversational
	providers={{
    "fireworks-ai": {modelId: "deepseek-ai/DeepSeek-R1", providerModelId: "accounts/fireworks/models/deepseek-r1"}
  }}
/>
```

```svelte
<InferenceSnippet
	pipeline="text-to-image"
	providers={{
    "black-forest-labs": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "flux-dev"},
    "replicate": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "black-forest-labs/flux-dev"},
    "fal-ai": {modelId: "black-forest-labs/FLUX.1-dev", providerModelId: "fal-ai/flux/dev"},
  }}
/>
```