### PR TITLE
Bump infererence.js + adapt code

### DIFF
--- a/kit/package-lock.json
+++ b/kit/package-lock.json
@@ -8,8 +8,8 @@
 			"name": "kit",
 			"version": "0.0.1",
 			"devDependencies": {
-				"@huggingface/inference": "^3.6.2",
-				"@huggingface/tasks": "^0.18.4",
+				"@huggingface/inference": "^3.8.1",
+				"@huggingface/tasks": "^0.18.8",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-static": "^2.0.3",
 				"@sveltejs/kit": "^1.20.4",
@@ -497,35 +497,32 @@
 			}
 		},
 		"node_modules/@huggingface/inference": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-3.6.2.tgz",
-			"integrity": "sha512-FkJr8dOP8yFTxGFi+X/ylwG3qoCq/s8WI2A4Jg13RBX3voJWrzadpHLD/99EKZU7r35X4Mm6tKUev7dR2B/cTg==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-3.8.1.tgz",
+			"integrity": "sha512-Kq+EvWAAWOa0oWrVrHZZzRmiqw0edr6UUCM6+ZvvHUDbcokc33aUqr8djsUSf6iNDnpBobdswYAJ+hwGo//i3A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@huggingface/jinja": "^0.3.3",
-				"@huggingface/tasks": "^0.18.4"
+				"@huggingface/jinja": "^0.3.4",
+				"@huggingface/tasks": "^0.18.8"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@huggingface/jinja": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.3.3.tgz",
-			"integrity": "sha512-vQQr2JyWvVFba3Lj9es4q9vCl1sAc74fdgnEMoX8qHrXtswap9ge9uO3ONDzQB0cQ0PUyaKY2N6HaVbTBvSXvw==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.3.4.tgz",
+			"integrity": "sha512-kFFQWJiWwvxezKQnvH1X7GjsECcMljFx+UZK9hx6P26aVHwwidJVTB0ptLfRVZQvVkOGHoMmTGvo4nT0X9hHOA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@huggingface/tasks": {
-			"version": "0.18.4",
-			"resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.18.4.tgz",
-			"integrity": "sha512-kZ8G2b6JSdVCn48VpmB2Kcb9ae16HmDRf4RWEQJMgbF98DFTt4y69fTcvQ1vi/qALRWL57pDpbzIlwWlVhY3aQ==",
-			"dev": true,
-			"license": "MIT"
+			"version": "0.18.8",
+			"resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.18.8.tgz",
+			"integrity": "sha512-sgrONypSZDOwUKpvBxfzO/cfKU5lKhErG1souoyE7G7QAH+dQDshMFL8h7phTkbu3GR5+f4koAD8tWk0LSDc3w==",
+			"dev": true
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.11",

--- a/kit/package.json
+++ b/kit/package.json
@@ -14,8 +14,8 @@
 		"update-inference-providers": "npm ci && npm i @huggingface/inference@latest && npm i @huggingface/tasks@latest"
 	},
 	"devDependencies": {
-		"@huggingface/inference": "^3.6.2",
-		"@huggingface/tasks": "^0.18.4",
+		"@huggingface/inference": "^3.8.1",
+		"@huggingface/tasks": "^0.18.8",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.3",
 		"@sveltejs/kit": "^1.20.4",

--- a/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
+++ b/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
@@ -64,7 +64,7 @@
 			providerId: providersMapping[selectedProvider]!.providerModelId,
 			status: "live",
 			task: pipeline,
-		},
+		}
 	);
 	const languages = [...new Set(availableSnippets.map((s) => s.language))];
 	let selectedLanguage = languages[0];

--- a/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
+++ b/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
@@ -59,7 +59,12 @@
 		model as ModelDataMinimal,
 		accessToken,
 		selectedProvider,
-		providersMapping[selectedProvider]!.providerModelId
+		{
+			hfModelId: providersMapping[selectedProvider]!.modelId,
+			providerId: providersMapping[selectedProvider]!.providerModelId,
+			status: "live",
+			task: pipeline,
+		},
 	);
 	const languages = [...new Set(availableSnippets.map((s) => s.language))];
 	let selectedLanguage = languages[0];
@@ -77,7 +82,12 @@
 			model as ModelDataMinimal,
 			accessToken,
 			selectedProvider,
-			providersMapping[selectedProvider]!.providerModelId,
+			{
+				hfModelId: providersMapping[selectedProvider]!.modelId,
+				providerId: providersMapping[selectedProvider]!.providerModelId,
+				status: "live",
+				task: pipeline,
+			},
 			{
 				streaming,
 			}


### PR DESCRIPTION
Following-up on recent breaking change introduced in https://github.com/huggingface/huggingface.js/pull/1347#discussion_r2044512924. `getInferenceSnippets` now takes a `inferenceProviderMapping?: InferenceProviderModelMapping,` instead of `providerModelId?: string,` previously. Nothing else changes in the generated snippets though.