### PR TITLE
Customize Success Feedback for Single-Option Questions

### DIFF
--- a/kit/src/lib/Question.svelte
+++ b/kit/src/lib/Question.svelte
@@ -51,6 +51,12 @@
 		// after the decimal.
 		return `${prefix}${Math.random().toString(36).substr(2, 9)}`;
 	}
+
+	function isSingleOption() {
+		// return whether there's single answer to the question or not
+ 		return choices.filter(c => c.correct).length === 1;
+	}
+
 </script>
 
 <div>
@@ -91,6 +97,8 @@
 						<span class="text-red-900 dark:text-red-200">
 							You didn't select all the correct answers, there's more!
 						</span>
+					{:else if isSingleOption()}
+  						<span class="text-green-900 dark:text-green-200"> You got it right! </span>
 					{:else}
 						<span class="text-green-900 dark:text-green-200"> You got all the answers! </span>
 					{/if}


### PR DESCRIPTION
This PR improves the user experience by customizing the success message based on the type of question and [#484](https://github.com/huggingface/agents-course/issues/484#issuecomment-2891532265):

- For single-answer questions: displays "You got it right!"
- For multi-answer questions: retains "You got all the answers!"

The changes are minimal and should work as intended. However, this PR still needs to be tested. I attempted to run it locally, but encountered errors — details are reported in #562.