### PR TITLE
Support building notebooks from .md files

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -291,8 +291,8 @@ def build_notebooks(doc_folder, notebook_dir, package=None, mapping=None, page_i
     if "package_name" not in page_info:
         page_info["package_name"] = package.__name__
 
-    mdx_files = list(doc_folder.glob("**/*.mdx"))
-    for file in tqdm(mdx_files, desc="Building the notebooks"):
+    md_mdx_files = list(doc_folder.glob("**/*.md")) + list(doc_folder.glob("**/*.mdx"))
+    for file in tqdm(md_mdx_files, desc="Building the notebooks"):
         with open(file, "r", encoding="utf-8") as f:
             if "[[open-in-colab]]" not in f.read():
                 continue


### PR DESCRIPTION
Support building notebooks from .md files.

Currently, to have notebooks built, we need to set the `.mdx` extension in our docs. This impacts rendering in GitHub and IDEs.