### PR TITLE
Parallel mdx building

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -263,7 +263,7 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
     source_files_mapping = {}
 
     if "package_name" not in page_info:
-        page_info["package_name"] = package.__name__ if package else None
+        page_info["package_name"] = package.__name__
 
     all_files = list(doc_folder.glob("**/*"))
     all_errors = []

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -163,13 +163,13 @@ def _process_single_mdx_file(file_info: tuple) -> dict:
 
     Args:
         file_info (tuple):
-            Tuple containing file information (file_path, doc_folder, output_dir, page_info, version_tag_suffix,
-            package_name).
+            Tuple containing file information (file_path, doc_folder, output_dir, page_info, version_tag_suffix).
 
     Returns:
         dict: Dictionary containing the processed results for this file (file, new_anchors, errors, source_files).
     """
-    file_path, doc_folder, output_dir, page_info, version_tag_suffix, package_name = file_info
+    file_path, doc_folder, output_dir, page_info, version_tag_suffix = file_info
+    package_name = page_info["package_name"]
 
     file_path = Path(file_path)
     doc_folder = Path(doc_folder)
@@ -244,7 +244,7 @@ def _process_single_mdx_file(file_info: tuple) -> dict:
 
 def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suffix):
     """
-    Build the MDX files for a given package.
+    Build the MDX files for a given package. Uses multiprocessing to process files in parallel.
 
     Args:
         package (`types.ModuleType`): The package where to look for objects to document.
@@ -269,11 +269,7 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
     all_errors = []
 
     # Prepare arguments for multiprocessing
-    package_name = package.__name__ if package else None
-    file_args = [
-        (str(file), str(doc_folder), str(output_dir), page_info, version_tag_suffix, package_name)
-        for file in all_files
-    ]
+    file_args = [(str(file), str(doc_folder), str(output_dir), page_info, version_tag_suffix) for file in all_files]
 
     # Use multiprocessing to process files in parallel
     with Pool() as pool:

--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -277,11 +277,9 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
 
     # Use multiprocessing to process files in parallel
     with Pool() as pool:
-        results = list(tqdm(
-            pool.imap(_process_single_mdx_file, file_args),
-            total=len(file_args),
-            desc="Building the MDX files"
-        ))
+        results = list(
+            tqdm(pool.imap(_process_single_mdx_file, file_args), total=len(file_args), desc="Building the MDX files")
+        )
 
     # Process results and collect mappings
     for result in results:


### PR DESCRIPTION
Speeds up the doc builder in the MDX building part by parallelizing the (embarrassingly parallel) loop.

Example of CI run from a PR in `transformers`: [link](https://github.com/huggingface/transformers/actions/runs/16144936462/job/45561147082?pr=39265) (total time = 13:00)
Same, but with this PR: [link](https://github.com/huggingface/transformers/actions/runs/16146845377/job/45567878075?pr=39278) (total time = 11:22, i.e. 15% speedup, [docs preview](https://moon-ci-docs.huggingface.co/docs/transformers/pr_39278/en/index))

To tackle the slow build time, the next part to look at is the JS part, invoked after the `print("Building HTML files. This will take a while :-)")` statement.

🤖 Made with AI 🤖 