### PR TITLE
[Tip] Add icons

### DIFF
--- a/kit/src/lib/Tip.svelte
+++ b/kit/src/lib/Tip.svelte
@@ -13,5 +13,14 @@
 		? 'course-tip-orange'
 		: ''} bg-gradient-to-br dark:bg-gradient-to-r before:border-{color}-500 dark:before:border-{color}-800 from-{color}-50 dark:from-gray-900 to-white dark:to-gray-950 border border-{color}-50 text-{color}-700 dark:text-gray-400"
 >
-	<slot />
+	<div class="flex items-center gap-2">
+		{#if warning}
+			<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 -mt-0.5 flex-shrink-0"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+		{:else}
+			<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 -mt-0.5 flex-shrink-0"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+		{/if}
+		<div class="flex-1">
+			<slot />
+		</div>
+	</div>
 </div>


### PR DESCRIPTION
Adds a "warning" and "lightbulb" icon for the Warning/Tip component as shown below. This helps add some more context to the current Tip component. I can also explicitly add a "Warning" and "Tip" label to the component if we like :)

<img width="928" height="185" alt="Screenshot 2025-07-18 at 1 23 22 PM" src="https://github.com/user-attachments/assets/47819c9b-399c-423e-8f23-2c8b05b4cf87" />