### PR TITLE
small fix: remove left over debug print

### DIFF
--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -170,7 +170,6 @@ def regex_closure(object_doc, regex):
 
 
 def get_signature_component_svelte(name, anchor, signature, object_doc, source_link=None, is_getset_desc=False):
-    print("some things svelte")
     """
     Returns the svelte `Docstring` component string.
 


### PR DESCRIPTION
Removes a print statement that seems like a left over debug print. This debug print spams logs on larger builds (like transformer's docs where more than 1000 lines are just "some things svelte").