### PR TITLE
Add peft as HF lib

### DIFF
--- a/src/doc_builder/external.py
+++ b/src/doc_builder/external.py
@@ -30,6 +30,7 @@ HUGGINFACE_LIBS = [
     "evaluate",
     "huggingface_hub",
     "optimum",
+    "peft",
     "tokenizers",
     "transformers",
     "trl",


### PR DESCRIPTION
Add peft as HF lib, so interlinks like
```python
[`~peft.PeftConfig`]
```
are properly rendered as links to: [PeftConfig](https://huggingface.co/docs/peft/en/package_reference/config#peft.PeftConfig)

As an example, see currently how it is rendered in TRL docs: https://huggingface.co/docs/trl/v0.23.0/en/sft_trainer#trl.SFTTrainer

<img width="226" height="30" alt="Screenshot from 2025-09-16 15-39-41" src="https://github.com/user-attachments/assets/e29bc087-fa5e-40a6-b993-f4b829238dab" />

contrary to, e.g., `~datasets.Dataset`:

<img width="154" height="26" alt="Screenshot from 2025-09-16 15-42-55" src="https://github.com/user-attachments/assets/c5bc1abc-b58c-49ed-9179-8ed28f0b828e" />

