### PR TITLE
LLMs txt

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -383,7 +383,7 @@ def build_doc(
     if not watch_mode:
         toctree_renamings(output_dir)
 
-    return source_files_mapping
+    return source_files_mapping, output_dir
 
 
 def toctree_renamings(output_dir):

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -29,6 +29,7 @@ from doc_builder.utils import (
     markdownify_file_route,
     read_doc_config,
     sveltify_file_route,
+    write_llms_feeds,
     write_markdown_route_file,
 )
 
@@ -184,11 +185,15 @@ def build_command(args):
             shutil.rmtree(output_path)
             shutil.copytree(tmp_dir / "kit" / "build", output_path)
             # copy markdown routes alongside the generated html output
+            markdown_data = []
             for markdown_file, relative_path in markdown_exports:
                 markdown_source = Path(markdown_file)
                 markdown_dest = output_path / relative_path
                 markdown_dest.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(markdown_source, markdown_dest)
+                with open(markdown_source, encoding="utf-8") as f:
+                    markdown_data.append((relative_path, f.read()))
+            write_llms_feeds(output_path, markdown_data)
             # Move the objects.inv file back
             if not args.not_python_module:
                 shutil.move(tmp_dir / "objects.inv", output_path / "objects.inv")

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -193,7 +193,13 @@ def build_command(args):
                 shutil.copy(markdown_source, markdown_dest)
                 with open(markdown_source, encoding="utf-8") as f:
                     markdown_data.append((relative_path, f.read()))
-            write_llms_feeds(output_path, markdown_data)
+            write_llms_feeds(
+                output_path,
+                markdown_data,
+                package_name=args.library_name,
+                version=version,
+                language=args.language,
+            )
             # Move the objects.inv file back
             if not args.not_python_module:
                 shutil.move(tmp_dir / "objects.inv", output_path / "objects.inv")

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -199,6 +199,7 @@ def build_command(args):
                 package_name=args.library_name,
                 version=version,
                 language=args.language,
+                is_python_module=not args.not_python_module,
             )
             # Move the objects.inv file back
             if not args.not_python_module:

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -26,8 +26,10 @@ from doc_builder.utils import (
     get_default_branch_name,
     get_doc_config,
     locate_kit_folder,
+    markdownify_file_route,
     read_doc_config,
     sveltify_file_route,
+    write_markdown_route_file,
 )
 
 
@@ -138,10 +140,12 @@ def build_command(args):
             # make mdx file paths comply with the sveltekit 1.0 routing mechanism
             # see more: https://learn.svelte.dev/tutorial/pages
             for mdx_file_path in svelte_kit_routes_dir.rglob("*.mdx"):
-                new_path = sveltify_file_route(mdx_file_path)
-                parent_path = os.path.dirname(new_path)
+                new_page_svelte = sveltify_file_route(mdx_file_path)
+                new_markdown = markdownify_file_route(mdx_file_path)
+                write_markdown_route_file(mdx_file_path, new_markdown)
+                parent_path = os.path.dirname(new_page_svelte)
                 os.makedirs(parent_path, exist_ok=True)
-                shutil.move(mdx_file_path, new_path)
+                shutil.move(mdx_file_path, new_page_svelte)
 
             # Move the objects.inv file at the root
             if not args.not_python_module:

--- a/src/doc_builder/commands/build.py
+++ b/src/doc_builder/commands/build.py
@@ -139,10 +139,12 @@ def build_command(args):
                     shutil.copy(f, dest)
             # make mdx file paths comply with the sveltekit 1.0 routing mechanism
             # see more: https://learn.svelte.dev/tutorial/pages
+            markdown_exports = []
             for mdx_file_path in svelte_kit_routes_dir.rglob("*.mdx"):
                 new_page_svelte = sveltify_file_route(mdx_file_path)
                 new_markdown = markdownify_file_route(mdx_file_path)
                 write_markdown_route_file(mdx_file_path, new_markdown)
+                markdown_exports.append((new_markdown, os.path.relpath(new_markdown, svelte_kit_routes_dir)))
                 parent_path = os.path.dirname(new_page_svelte)
                 os.makedirs(parent_path, exist_ok=True)
                 shutil.move(mdx_file_path, new_page_svelte)
@@ -181,6 +183,12 @@ def build_command(args):
             # Copy result back in the build_dir.
             shutil.rmtree(output_path)
             shutil.copytree(tmp_dir / "kit" / "build", output_path)
+            # copy markdown routes alongside the generated html output
+            for markdown_file, relative_path in markdown_exports:
+                markdown_source = Path(markdown_file)
+                markdown_dest = output_path / relative_path
+                markdown_dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(markdown_source, markdown_dest)
             # Move the objects.inv file back
             if not args.not_python_module:
                 shutil.move(tmp_dir / "objects.inv", output_path / "objects.inv")

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -110,7 +110,7 @@ if is_watchdog_available():
                         src = Path(tmp_out_dir) / Path(src_path).name
                         svelte_dest = sveltify_file_route(self.kit_routes_folder / relative_path)
                         markdown_dest = markdownify_file_route(self.kit_routes_folder / relative_path)
-                        content = write_markdown_route_file(src, markdown_dest)
+                        write_markdown_route_file(src, markdown_dest)
                         parent_path = Path(svelte_dest).parent
                         parent_path.mkdir(parents=True, exist_ok=True)
                         shutil.move(src, svelte_dest)

--- a/src/doc_builder/commands/preview.py
+++ b/src/doc_builder/commands/preview.py
@@ -224,7 +224,14 @@ def preview_command(args):
             os.makedirs(parent_path, exist_ok=True)
             shutil.move(mdx_file_path, new_page_svelte)
 
-        write_llms_feeds(kit_routes_folder, markdown_exports)
+        write_llms_feeds(
+            kit_routes_folder,
+            markdown_exports,
+            package_name=args.library_name,
+            version=args.version,
+            language=args.language,
+            is_python_module=not args.not_python_module,
+        )
 
         # Node
         env = os.environ.copy()

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -18,8 +18,9 @@ import os
 import re
 import shutil
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional
 from urllib.parse import quote
 
 import yaml
@@ -237,8 +238,8 @@ def write_markdown_route_file(source_file, destination_file):
     return content
 
 
-def _collect_markdown_from_output(output_dir: Path) -> List[Tuple[str, str]]:
-    markdown_items: List[Tuple[str, str]] = []
+def _collect_markdown_from_output(output_dir: Path) -> list[tuple[str, str]]:
+    markdown_items: list[tuple[str, str]] = []
     for mdx_file in sorted(output_dir.glob("**/*.mdx")):
         relative_path = mdx_file.relative_to(output_dir).with_suffix(".md").as_posix()
         with open(mdx_file, encoding="utf-8") as f:
@@ -249,7 +250,7 @@ def _collect_markdown_from_output(output_dir: Path) -> List[Tuple[str, str]]:
 
 def write_llms_feeds(
     output_dir: Path,
-    markdown_items: Optional[Sequence[Tuple[str, str]]] = None,
+    markdown_items: Optional[Sequence[tuple[str, str]]] = None,
     base_url: Optional[str] = None,
     package_name: Optional[str] = None,
     version: Optional[str] = None,
@@ -316,8 +317,8 @@ def write_llms_feeds(
                 return line.lstrip("#").strip() or fallback
         return fallback
 
-    bullet_lines: List[str] = []
-    sections: List[str] = []
+    bullet_lines: list[str] = []
+    sections: list[str] = []
 
     for relative_path, markdown_text in markdown_items:
         url = build_url(relative_path)

--- a/src/doc_builder/utils.py
+++ b/src/doc_builder/utils.py
@@ -210,7 +210,12 @@ def write_markdown_route_file(source_file, destination_file):
         content = f.read()
 
     content = _SCRIPT_BLOCK_RE.sub("", content, count=1)
-    content = content.lstrip()
+
+    heading_match = re.search(r"^#", content, flags=re.MULTILINE)
+    if heading_match:
+        content = content[heading_match.start() :]
+    else:
+        content = content.lstrip()
 
     destination_path = Path(destination_file)
     destination_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Generate Markdown companions for every Svelte route, trimming leading Svelte blocks/metadata so pages start at the first `#` heading.
- Preserve `+page.svelte` routes while copying `.md` versions into the final HTML build output and preview workspace.
- Emit `llms.txt` and `llms-full.txt` feeds at each doc root using canonical Hugging Face URLs (switching to `huggingface.co/learn` for courses/cookbook docs, omitting `en` and version where appropriate).  
  Mirrors Mintlify’s public format:  
  ```
  # Mintlify

  ## Docs

  - [Editor permissions](https://mintlify.com/docs/advanced/dashboard/permissions.md)
  ...
  ```

## Details
- Added `convert_mdx_to_markdown_text`, Markdown collectors, and `write_llms_feeds` helpers to reuse cleaned content.
- Updated build/preview flows to capture Markdown output, keep Svelte routes, and regenerate feeds incrementally during watch mode.
- Normalised URL construction so non-Python modules drop version segments, default language doesn’t append `en`, and course-like packages point to the learn subdomain.
- Refined linted code paths (removed unused vars, replaced deprecated `typing` aliases).