### PR TITLE
Simplify DocNotebookDropdown positioning with float CSS

### DIFF
--- a/kit/src/lib/DocNotebookDropdown.svelte
+++ b/kit/src/lib/DocNotebookDropdown.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import { onMount, tick } from "svelte";
-
 	import Dropdown from "./Dropdown.svelte";
 	import DropdownEntry from "./DropdownEntry.svelte";
 
 	export let options: { label: string; value: string }[] = [];
 	export let classNames = "";
-	let dropdownEl: HTMLDivElement;
+	export let containerStyle = "";
 
 	const googleColabOptions = options.filter((o) => o.value.includes("colab.research.google.com"));
 	const awsStudioOptions = options.filter((o) => o.value.includes("studiolab.sagemaker.aws"));
@@ -14,42 +12,9 @@
 	function onClick(url: string) {
 		window.open(url);
 	}
-
-	function onResize() {
-		// avoid DocNotebookDropdown overlapping with doc titles (i.e. h1 elements) on smaller screens because of absolute positioning
-		const h1El = document.querySelector(".prose-doc h1");
-		const h1SpanEl = document.querySelector(".prose-doc h1 > span");
-		if (h1El && h1SpanEl) {
-			const { width: h1Widht } = h1El.getBoundingClientRect();
-			const { width: spanWidth } = h1SpanEl.getBoundingClientRect();
-			// correct calculation of dropdownEl's width; othwrwise, the width can count in negative (empty) spaces
-			let dropdownWidth = 0;
-			for (let i = 0; i < dropdownEl.children.length; i++) {
-				const child = dropdownEl.children.item(i);
-				if (child) {
-					dropdownWidth += child.clientWidth;
-				}
-			}
-			const bufferMargin = 20;
-			if (h1Widht - spanWidth < dropdownWidth + bufferMargin) {
-				dropdownEl.classList.remove("absolute");
-			} else {
-				dropdownEl.classList.add("absolute");
-			}
-		}
-	}
-
-	onMount(() => {
-		(async () => {
-			await tick();
-			onResize();
-		})();
-	});
 </script>
 
-<svelte:window on:resize={onResize} />
-
-<div class="flex space-x-1 {classNames}" bind:this={dropdownEl}>
+<div class="flex space-x-1 {classNames}" style={containerStyle}>
 	<slot name="alwaysVisible" />
 	{#if googleColabOptions.length === 1}
 		<a href={googleColabOptions[0].value} target="_blank">

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -28,9 +28,10 @@ class BuildDocTester(unittest.TestCase):
         self.assertEqual(_re_list_item.search("   - forward").groups(), ("forward",))
 
     def test_resolve_open_in_colab(self):
-        expected = """
-<DocNotebookDropdown
-  classNames="absolute z-10 right-0 top-0"
+        # Test with heading - should place component before the heading
+        input_with_heading = "[[open-in-colab]]\n\n# Quick tour\n\nSome content here."
+        expected_with_heading = """<DocNotebookDropdown
+  containerStyle="float: right; margin-left: 10px; display: inline-flex; position: relative; z-index: 10;"
   options={[
     {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/quicktour.ipynb"},
     {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
@@ -39,8 +40,35 @@ class BuildDocTester(unittest.TestCase):
     {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
     {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/tensorflow/quicktour.ipynb"},
 ]} />
-"""
+
+# Quick tour
+
+Some content here."""
         self.assertEqual(
-            resolve_open_in_colab("\n[[open-in-colab]]\n", {"package_name": "transformers", "page": "quicktour.html"}),
-            expected,
+            resolve_open_in_colab(input_with_heading, {"package_name": "transformers", "page": "quicktour.html"}),
+            expected_with_heading,
+        )
+
+        # Test with CopyLLMTxtMenu present - should place component after CopyLLMTxtMenu
+        # (so CopyLLMTxtMenu appears rightmost when floated)
+        input_with_copy_menu = '[[open-in-colab]]\n\n<CopyLLMTxtMenu containerStyle="float: right;"></CopyLLMTxtMenu>\n\n# Quick tour\n\nContent.'
+        expected_with_copy_menu = """<CopyLLMTxtMenu containerStyle="float: right;"></CopyLLMTxtMenu>
+
+<DocNotebookDropdown
+  containerStyle="float: right; margin-left: 10px; display: inline-flex; position: relative; z-index: 10;"
+  options={[
+    {label: "Mixed", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/transformers_doc/en/tensorflow/quicktour.ipynb"},
+    {label: "Mixed", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/quicktour.ipynb"},
+    {label: "PyTorch", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/pytorch/quicktour.ipynb"},
+    {label: "TensorFlow", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/main/transformers_doc/en/tensorflow/quicktour.ipynb"},
+]} />
+
+# Quick tour
+
+Content."""
+        self.assertEqual(
+            resolve_open_in_colab(input_with_copy_menu, {"package_name": "transformers", "page": "quicktour.html"}),
+            expected_with_copy_menu,
         )


### PR DESCRIPTION
Here's a suggested GitHub commit message:

## **Commit Title:**
```
Simplify DocNotebookDropdown positioning with float CSS
```

## **Commit Description:**

```
Replace complex JavaScript positioning logic with simple float CSS for [[open-in-colab]] buttons

### Changes:

**Backend (Python):**
- Updated `resolve_open_in_colab()` in `build_doc.py` to place DocNotebookDropdown 
  after CopyLLMTxtMenu for correct float ordering
- Changed from `classNames="absolute z-10 right-0 top-0"` to 
  `containerStyle="float: right; margin-left: 10px; display: inline-flex; position: relative; z-index: 10;"`
- Updated tests to reflect new placement behavior

**Frontend (Svelte):**
- Added `containerStyle` prop to `DocNotebookDropdown.svelte`
- Removed complex `onResize()` function (~30 lines) that prevented heading overlap
- Removed `onMount`, `tick`, and resize event listeners
- Simplified component to use CSS float positioning

### Benefits:

✅ Consistent with `CopyLLMTxtMenu` pattern
✅ Both buttons float on heading line (not separate line)
✅ Correct visual order: [...Open in Colab] [📋 Copy page]
✅ ~30 lines less complex JavaScript code
✅ More maintainable and reliable positioning

### Migration:

No breaking changes - existing [[open-in-colab]] markers work as before,
just with improved positioning.
```

**Alternative shorter version if you prefer:**

```
Simplify [[open-in-colab]] button positioning

Replace absolute positioning + JS resize logic with simple float CSS.
Buttons now correctly float on heading line with CopyLLMTxtMenu.

- Add containerStyle prop to DocNotebookDropdown.svelte
- Remove ~30 lines of complex resize JavaScript
- Update resolve_open_in_colab() to place after CopyLLMTxtMenu
- Update tests for new placement behavior
```