### PR TITLE
Fix model not changing in inference snippet

### DIFF
--- a/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
+++ b/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
@@ -52,14 +52,12 @@
 	let selectedProvider = providers[0];
 	let streaming = false;
 
-	const model = {
-		id: providersMapping[selectedProvider]!.modelId,
-		pipeline_tag: pipeline,
-		tags: conversational ? ["conversational"] : [],
-	};
-
 	const availableSnippets = snippets.getInferenceSnippets(
-		model as ModelDataMinimal,
+		{
+			id: providersMapping[selectedProvider]!.modelId,
+			pipeline_tag: pipeline,
+			tags: conversational ? ["conversational"] : [],
+		} as ModelDataMinimal,
 		selectedProvider,
 		{
 			hfModelId: providersMapping[selectedProvider]!.modelId,
@@ -82,7 +80,11 @@
 
 	$: code = snippets
 		.getInferenceSnippets(
-			model as ModelDataMinimal,
+			{
+				id: providersMapping[selectedProvider]!.modelId,
+				pipeline_tag: pipeline,
+				tags: conversational ? ["conversational"] : [],
+			} as ModelDataMinimal,
 			selectedProvider,
 			{
 				hfModelId: providersMapping[selectedProvider]!.modelId,
@@ -287,7 +289,7 @@
 				</slot>
 				<slot slot="menu">
 					<div class="flex flex-col gap-y-2 p-2">
-						{#if model.tags.includes("conversational")}
+						{#if conversational}
 							<button
 								class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
 								on:click={() => (streaming = !streaming)}
@@ -340,7 +342,7 @@
 				</slot>
 				<slot slot="menu">
 					<div class="flex flex-col gap-y-2 p-2">
-						{#if model.tags.includes("conversational")}
+						{#if conversational}
 							<button
 								class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
 								on:click={() => (streaming = !streaming)}


### PR DESCRIPTION
Currently model ID is not correctly updated in the `<InferenceSnippet ...>` section of the docs. This is due to `model` being a constant in the underlying svelte component. This PR fixes it.

Example of broken code: `z-ai` does not serve `openai/gpt-oss-120b`.
<img width="962" height="621" alt="image" src="https://github.com/user-attachments/assets/eb3db140-9b72-4ec3-87cc-293820728934" />

It should be `GLM-4.6` instead. Screenshot below is with the update code from this PR

<img width="588" height="706" alt="image" src="https://github.com/user-attachments/assets/62011d08-13b7-496b-acf4-c0c5d8e19491" />

