### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/accelerate_doc.yml
+++ b/.github/workflows/accelerate_doc.yml
@@ -11,16 +11,16 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
       
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'huggingface/accelerate'
           path: accelerate

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -67,24 +67,24 @@ jobs:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: '${{ inputs.repo_owner }}/${{ inputs.package }}'
           path: ${{ inputs.package }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: inputs.notebook_folder != ''
         with:
           repository: 'huggingface/notebooks'
           path: notebooks
           token: ${{ secrets.token }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -68,13 +68,13 @@ jobs:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
           ref: ${{ inputs.doc_builder_revision }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: '${{ inputs.repo_owner }}/${{ inputs.package }}'
           path: ${{ inputs.package }}
@@ -86,7 +86,7 @@ jobs:
          git fetch https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}.git refs/pull/${{ inputs.pr_number }}/merge:refs/remotes/pull/${{ inputs.pr_number }}/merge
          git checkout refs/remotes/pull/${{ inputs.pr_number }}/merge
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache-dependency-path: "kit/package-lock.json"
@@ -224,7 +224,7 @@ jobs:
           echo ${{ inputs.commit_sha }} > ./build_dir/commit_sha
           echo ${{ inputs.pr_number }} > ./build_dir/pr_number
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: doc-build-artifact
           path: build_dir/

--- a/.github/workflows/bump-huggingface-js-packages.yml
+++ b/.github/workflows/bump-huggingface-js-packages.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/delete_old_pr_documentations.yml
+++ b/.github/workflows/delete_old_pr_documentations.yml
@@ -12,7 +12,7 @@ jobs:
   delete_old_prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/lint-svelte-kit.yml
+++ b/.github/workflows/lint-svelte-kit.yml
@@ -14,9 +14,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/populate_search_engine.yml
+++ b/.github/workflows/populate_search_engine.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 360  # Set timeout to 6 hours
     steps:
       - name: Checkout doc-builder
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout doc-builder
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -66,7 +66,7 @@ jobs:
   #   if: always() # This ensures that the cleanup job runs regardless of the result
   #   steps:
   #     - name: Checkout doc-builder
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Install uv
   #       uses: astral-sh/setup-uv@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,7 +6,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -32,7 +32,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: 'huggingface/doc-builder'
           path: doc-builder
@@ -50,7 +50,7 @@ jobs:
           echo "current_work_dir=$(pwd)" >> $GITHUB_OUTPUT
 
       - name: 'Download artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: doc-build-artifact
           path: ${{ github.workspace }}/build_dir


### PR DESCRIPTION
## Summary
This PR upgrades GitHub Actions to their latest versions for Node.js 24 compatibility and security updates.

## Changes

| Action | Old Version(s) | New Version | Files |
|--------|---------------|-------------|-------|
| actions/checkout | v3, v4 | v6 | accelerate_doc.yml, build_main_documentation.yml, build_pr_documentation.yml, bump-huggingface-js-packages.yml, delete_old_pr_documentations.yml, lint-svelte-kit.yml, populate_search_engine.yml, quality.yml, test.yml, upload_pr_documentation.yml |
| actions/download-artifact | v4 | v7 | upload_pr_documentation.yml |
| actions/setup-node | v3, v4 | v6 | accelerate_doc.yml, build_main_documentation.yml, build_pr_documentation.yml, bump-huggingface-js-packages.yml, lint-svelte-kit.yml |
| actions/upload-artifact | v4 | v6 | build_pr_documentation.yml |

## Why these changes?
- Keeps actions up to date with latest stable releases
- Updated actions include security fixes and new features

## Testing
These changes only update action versions and don't modify workflow logic.
