### PR TITLE
Fix typo in 'Parameter' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is the package we use to build the documentation of our Hugging Face repos.
     + [Description](#description)
     + [Arguments](#arguments)
     + [Attributes](#attributes)
-    + [Parmeter typing and default value](#parmeter-typing-and-default-value)
+    + [Parameter typing and default value](#parameter-typing-and-default-value)
     + [Returns](#returns)
     + [Yields](#yields)
     + [Raises](#raises)
@@ -703,7 +703,7 @@ Syntax:
           ...
 ```
 
-### Parmeter typing and default value
+### Parameter typing and default value
 
 For optional arguments or arguments with defaults we follow the following syntax. Imagine we have a function with the
 following signature:


### PR DESCRIPTION
## Summary
Fixes a typo in the README.md documentation where "Parmeter" should be "Parameter" in the "Writing API documentation (Python)" section.

## Changes
- Fixed typo: "Parmeter typing and default value" → "Parameter typing and default value"

## Details
This is a minor documentation fix that corrects a spelling error in a subsection heading of the API documentation guidelines. The typo has been present in the table of contents and section heading for the parameter documentation section.

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change

## Checklist
- [x] Changes follow the code style guidelines
- [x] Documentation has been updated accordingly
- [x] No breaking changes introduced