### PR TITLE
refactor: update gradio docs addition in populate_search_engine workflow

### DIFF
--- a/.github/workflows/populate_search_engine.yml
+++ b/.github/workflows/populate_search_engine.yml
@@ -55,9 +55,10 @@ jobs:
 
       - name: Add gradio docs to meilisearch
         env:
+          HF_IE_URL: ${{ secrets.HF_IE_URL }}
           HF_IE_TOKEN: ${{ secrets.HF_IE_TOKEN }}
           MEILISEARCH_KEY: ${{ secrets.MEILISEARCH_KEY }}
-        run: uv run doc-builder add-gradio-docs --hf_ie_name docs-embed-bge-base-en-v1-5 --hf_ie_namespace huggingface
+        run: uv run doc-builder add-gradio-docs
   
   cleanup-job:
     needs: [process-docs, gradio-job]


### PR DESCRIPTION
- Added HF_IE_URL as an environment variable for the gradio docs addition step.
- Simplified the command-line arguments in the workflow for better clarity.