### PR TITLE
feat: add scripts for Meilisearch index management

### DIFF
--- a/migrations/clear_meili_index.py
+++ b/migrations/clear_meili_index.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Script to delete all documents from a Meilisearch index without deleting the index itself.
+
+Usage:
+    uv run python migrations/clear_meili_index.py --meilisearch_key <your_key>          # clears main index
+    uv run python migrations/clear_meili_index.py --meilisearch_key <your_key> --temp   # clears temp index
+"""
+
+import argparse
+
+import meilisearch
+
+from doc_builder.build_embeddings import MEILI_INDEX, MEILI_INDEX_TEMP
+from doc_builder.meilisearch_helper import clear_embedding_db
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Delete all documents from a Meilisearch index")
+    parser.add_argument("--meilisearch_key", type=str, required=True, help="Meilisearch API key")
+    parser.add_argument("--temp", action="store_true", help="Clear the temp index instead of the main index")
+    args = parser.parse_args()
+
+    index_name = MEILI_INDEX_TEMP if args.temp else MEILI_INDEX
+
+    client = meilisearch.Client("https://edge.meilisearch.com", args.meilisearch_key)
+    clear_embedding_db(client, index_name)
+    print(f"[meilisearch] successfully cleared all documents from {index_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/create_meili_index.py
+++ b/migrations/create_meili_index.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Script to create a Meilisearch index for docs semantic search.
+
+Usage:
+    uv run python migrations/create_meili_index.py --meilisearch_key <your_key>          # creates main index
+    uv run python migrations/create_meili_index.py --meilisearch_key <your_key> --temp   # creates temp index
+"""
+
+import argparse
+
+import meilisearch
+
+from doc_builder.build_embeddings import MEILI_INDEX, MEILI_INDEX_TEMP
+from doc_builder.meilisearch_helper import create_embedding_db, update_db_settings
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a Meilisearch index for docs semantic search")
+    parser.add_argument("--meilisearch_key", type=str, required=True, help="Meilisearch API key")
+    parser.add_argument("--temp", action="store_true", help="Create the temp index instead of the main index")
+    args = parser.parse_args()
+
+    index_name = MEILI_INDEX_TEMP if args.temp else MEILI_INDEX
+
+    client = meilisearch.Client("https://edge.meilisearch.com", args.meilisearch_key)
+    create_embedding_db(client, index_name)
+    update_db_settings(client, index_name)
+    print(f"[meilisearch] successfully created {index_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/doc_builder/meilisearch_helper.py
+++ b/src/doc_builder/meilisearch_helper.py
@@ -168,6 +168,14 @@ def delete_embedding_db(client: Client, index_name: str):
     return client, task_info
 
 
+@wait_for_task_completion
+def clear_embedding_db(client: Client, index_name: str):
+    """Delete all documents from an index without deleting the index itself."""
+    index = client.index(index_name)
+    task_info = index.delete_all_documents()
+    return client, task_info
+
+
 def sanitize_for_id(text):
     """
     Sanitize text to only contain valid Meilisearch ID characters.


### PR DESCRIPTION
- Introduced `clear_meili_index.py` to delete all documents from a Meilisearch index without removing the index.
- Added `create_meili_index.py` to create a Meilisearch index for document semantic search.
- Updated `meilisearch_helper.py` with a new function `clear_embedding_db` for clearing index documents.