### PR TITLE
Fix missing page argument in Chunk instantiations

### DIFF
--- a/src/doc_builder/build_embeddings.py
+++ b/src/doc_builder/build_embeddings.py
@@ -216,6 +216,7 @@ def create_autodoc_chunks(
                     source_page_title=get_page_title(page_info["page"]),
                     package_name=page_info["package_name"],
                     headings=headings,
+                    page=page_info["page"],
                 )
                 for od in object_docs
             ]
@@ -868,6 +869,7 @@ def add_gradio_docs(hf_ie_url: str, hf_ie_token: str, meilisearch_key: str):
             doc["source_page_title"],
             "gradio",
             [doc["source_page_title"]] + ([doc["heading1"]] if doc.get("heading1") else []),
+            doc["source_page_url"],  # use URL as page identifier for gradio docs
         )
         for doc in data
     ]


### PR DESCRIPTION
Fixes the `TypeError: Chunk.__new__() missing 1 required positional argument: 'page'` error.

## Changes
- Add `page` argument to object doc chunks (autodoc)
- Add `page` argument to gradio docs chunks

This is a follow-up fix to #719 which added the `page` field to the `Chunk` namedtuple but missed two instantiation sites.