### PR TITLE
fix(security): sanitize PR data interpolation in upload_pr_documentation workflow

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -100,34 +100,46 @@ jobs:
 
       - name: Set hub_docs_url
         id: hfhub-context
+        env:
+          HUB_BASE_PATH: ${{ inputs.hub_base_path }}
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          PR_NUMBER: ${{ steps.github-context.outputs.pr_number }}
         run: |
-          if [ -z "${{ inputs.hub_base_path }}" ]
+          if [ -z "$HUB_BASE_PATH" ]
           then
-            echo "hub_docs_url=https://moon-ci-docs.huggingface.co/docs/${{ inputs.package_name }}/pr_${{ steps.github-context.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "hub_docs_url=https://moon-ci-docs.huggingface.co/docs/${PACKAGE_NAME}/pr_${PR_NUMBER}" >> $GITHUB_OUTPUT
             echo "hub_base_path not provided, defaulting to https://moon-ci-docs.huggingface.co/docs"
           else
-            echo "hub_docs_url=${{ inputs.hub_base_path }}/${{ inputs.package_name }}/pr_${{ steps.github-context.outputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "hub_docs_url=${HUB_BASE_PATH}/${PACKAGE_NAME}/pr_${PR_NUMBER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Compose doc comment message
         id: doc-comment
+        env:
+          WARNINGS_EMITTED: ${{ steps.warning-context.outputs.warnings_emitted }}
+          HUB_DOCS_URL: ${{ steps.hfhub-context.outputs.hub_docs_url }}
         run: |
           warning_message=""
-          if [ "${{ steps.warning-context.outputs.warnings_emitted }}" = "true" ]; then
+          if [ "$WARNINGS_EMITTED" = "true" ]; then
             warning_message=" Some warnings were emitted during doc build; check the workflow logs for details."
           fi
 
           {
             echo "message<<EOF"
-            echo "The docs for this PR live [here](${{ steps.hfhub-context.outputs.hub_docs_url }}). All of your documentation changes will be reflected on that endpoint. The docs are available until 30 days after the last update.${warning_message}"
+            echo "The docs for this PR live [here](${HUB_DOCS_URL}). All of your documentation changes will be reflected on that endpoint. The docs are available until 30 days after the last update.${warning_message}"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
       - name: Push to repositories
         shell: bash
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+          REPO_OWNER: ${{ inputs.repo_owner }}
+          COMMIT_SHA: ${{ steps.github-context.outputs.commit_sha }}
+          HF_TOKEN: ${{ secrets.hf_token }}
         run: |
           cd build_dir
-          doc-builder push ${{ inputs.package_name }} --doc_build_repo_id "hf-doc-build/doc-build-dev" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ steps.github-context.outputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package_name }}/commit/${{ steps.github-context.outputs.commit_sha }}"
+          doc-builder push "$PACKAGE_NAME" --doc_build_repo_id "hf-doc-build/doc-build-dev" --token "$HF_TOKEN" --commit_msg "Updated with commit ${COMMIT_SHA} See: https://github.com/${REPO_OWNER}/${PACKAGE_NAME}/commit/${COMMIT_SHA}"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1  # v2
@@ -138,10 +150,13 @@ jobs:
 
       - name: Determine authentication method
         id: auth
+        env:
+          COMMENT_BOT_TOKEN: ${{ secrets.comment_bot_token }}
+          COMMENT_BOT_APP_ID: ${{ secrets.comment_bot_app_id }}
         run: |
-          if [[ -n "${{ secrets.comment_bot_token }}" ]]; then
+          if [[ -n "$COMMENT_BOT_TOKEN" ]]; then
             echo "method=comment_bot_token" >> $GITHUB_OUTPUT
-          elif [[ -n "${{ secrets.comment_bot_app_id }}" ]]; then
+          elif [[ -n "$COMMENT_BOT_APP_ID" ]]; then
             echo "method=github_app" >> $GITHUB_OUTPUT
           else
             echo "No authentication method provided"


### PR DESCRIPTION
Pass PR event data through env: instead of direct interpolation to prevent potential injection via crafted PR metadata. Ref: Wiz advisory wiz-adv-2026-043.

## Changes

All `run:` blocks in `upload_pr_documentation.yml` that previously used direct `${{ }}` expression interpolation now pass those values through `env:` blocks instead:

- **Set hub_docs_url**: `inputs.hub_base_path`, `inputs.package_name`, step output `pr_number`
- **Compose doc comment message**: step outputs `warnings_emitted`, `hub_docs_url`
- **Push to repositories**: `inputs.package_name`, `inputs.repo_owner`, step output `commit_sha`, `secrets.hf_token`
- **Determine authentication method**: `secrets.comment_bot_token`, `secrets.comment_bot_app_id`

This prevents shell injection if any of these values contain malicious content (e.g., backticks, `$(...)`, or newlines in crafted PR branch names or titles).