### PR TITLE
feat: sync PR docs to HF bucket instead of git dataset

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -244,10 +244,11 @@ jobs:
       - name: Sync to bucket
         env:
           HF_TOKEN: ${{ secrets.hf_token }}
+          PACKAGE_NAME: ${{ env.package_name }}
         run: |
           pip install -U huggingface_hub
           cd build_dir
-          hf sync "./${{ env.package_name }}" "hf://buckets/hf-doc-build/doc/${{ env.package_name }}"
+          hf sync "./$PACKAGE_NAME" "hf://buckets/hf-doc-build/doc/$PACKAGE_NAME"
           cd ..
 
           if [ -d "notebook_dir" ]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -234,11 +234,13 @@ jobs:
 
           cd ..
 
-      - name: Push to repositories
+      - name: Sync to bucket
+        env:
+          HF_TOKEN: ${{ secrets.hf_token }}
         run: |
-          source .venv/bin/activate
+          pip install -U huggingface_hub
           cd build_dir
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --upload_version_yml
+          hf sync "./${{ env.package_name }}" "hf://buckets/hf-doc-build/doc/${{ env.package_name }}"
           cd ..
 
           if [ -d "notebook_dir" ]

--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -234,6 +234,13 @@ jobs:
 
           cd ..
 
+      - name: Push to dataset (legacy, kept for rollback safety)
+        run: |
+          source .venv/bin/activate
+          cd build_dir
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --upload_version_yml
+          cd ..
+
       - name: Sync to bucket
         env:
           HF_TOKEN: ${{ secrets.hf_token }}

--- a/.github/workflows/delete_old_pr_documentations.yml
+++ b/.github/workflows/delete_old_pr_documentations.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+      - name: Install hf CLI
+        run: pip install -U huggingface_hub
       - run: deno run --allow-env --allow-net --allow-run --allow-read ./delete-old-prs.ts
         env:
           HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -130,16 +130,15 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-      - name: Push to repositories
+      - name: Sync to bucket
         shell: bash
         env:
           PACKAGE_NAME: ${{ inputs.package_name }}
-          REPO_OWNER: ${{ inputs.repo_owner }}
-          COMMIT_SHA: ${{ steps.github-context.outputs.commit_sha }}
           HF_TOKEN: ${{ secrets.hf_token }}
         run: |
           cd build_dir
-          doc-builder push "$PACKAGE_NAME" --doc_build_repo_id "hf-doc-build/doc-build-dev" --token "$HF_TOKEN" --commit_msg "Updated with commit ${COMMIT_SHA} See: https://github.com/${REPO_OWNER}/${PACKAGE_NAME}/commit/${COMMIT_SHA}"
+          pip install -U huggingface_hub
+          hf sync "./$PACKAGE_NAME" "hf://buckets/hf-doc-build/doc-dev/$PACKAGE_NAME"
 
       - name: Find doc comment
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1  # v2
@@ -162,7 +161,7 @@ jobs:
             echo "No authentication method provided"
             exit 1
           fi
-      
+
       - name: Create comment_bot token
         id: comment_bot_token
         if: steps.auth.outputs.method == 'github_app'

--- a/scripts/delete-old-prs.ts
+++ b/scripts/delete-old-prs.ts
@@ -1,52 +1,59 @@
 #!/usr/bin/env -S deno run --allow-env --allow-net --allow-run --allow-read
 // To format: npx prettier --write .
-import { commit, listFiles } from "npm:@huggingface/hub@0.15.1";
+//
+// Cleans up old PR documentation from the HF bucket.
+// Lists all pr_* directories across all packages and deletes those older than 30 days.
 
-const oneMonthAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+const BUCKET_ID = "hf-doc-build/doc-dev";
+const MAX_AGE_DAYS = 30;
 
-const allFiles = listFiles({
-	repo: { type: "dataset", name: "hf-doc-build/doc-build-dev" },
-	recursive: true,
-	expand: true,
-});
+const oneMonthAgo = new Date(Date.now() - MAX_AGE_DAYS * 24 * 3600 * 1000);
+const token = Deno.env.get("HF_ACCESS_TOKEN")!;
+const headers = { Authorization: `Bearer ${token}` };
 
-const filesToDelete: string[] = [];
+// Step 1: List all top-level packages in the bucket
+const packagesRes = await fetch(
+	`https://huggingface.co/api/repos/bucket/${BUCKET_ID}/tree?recursive=false`,
+	{ headers },
+);
+const packages: { path: string; type: string }[] = await packagesRes.json();
 
-let fileCount = 0;
-let filesWithoutDates = 0;
+let totalDeleted = 0;
+let totalKept = 0;
 
-for await (const file of allFiles) {
-	fileCount++;
-	
-	if (file.type !== "file" || !file.path.endsWith(".zip")) {
-		continue;
+for (const pkg of packages) {
+	if (pkg.type !== "directory") continue;
+
+	// Step 2: List pr_* directories inside each package
+	const entriesRes = await fetch(
+		`https://huggingface.co/api/repos/bucket/${BUCKET_ID}/tree?path_prefix=${pkg.path}/&recursive=false`,
+		{ headers },
+	);
+	const entries: { path: string; type: string; uploadedAt?: string }[] = await entriesRes.json();
+
+	for (const entry of entries) {
+		if (entry.type !== "directory" || !entry.path.includes("/pr_")) continue;
+
+		const uploadedAt = entry.uploadedAt ? new Date(entry.uploadedAt) : null;
+		if (!uploadedAt) continue;
+
+		if (uploadedAt < oneMonthAgo) {
+			console.log(`Deleting ${entry.path} (uploaded ${uploadedAt.toISOString()})`);
+			const proc = new Deno.Command("hf", {
+				args: ["buckets", "rm", `hf-doc-build/doc-dev/${entry.path}`, "--recursive", "-y"],
+				env: { HF_TOKEN: token },
+				stdout: "piped",
+				stderr: "piped",
+			});
+			const output = await proc.output();
+			if (!output.success) {
+				console.error(`Failed to delete ${entry.path}:`, new TextDecoder().decode(output.stderr));
+			}
+			totalDeleted++;
+		} else {
+			totalKept++;
+		}
 	}
-
-	const date = file.lastCommit?.date;
-
-	if (!date) {
-		filesWithoutDates++;
-		continue;
-	}
-
-	if (oneMonthAgo < new Date(date)) {
-		continue;
-	}
-
-	filesToDelete.push(file.path);
 }
 
-console.log({fileCount, filesWithoutDates});
-
-if (filesToDelete.length) {
-	console.log("deleting", filesToDelete.length, "files");
-	await commit({
-		repo: { type: "dataset", name: "hf-doc-build/doc-build-dev" },
-		credentials: { accessToken: Deno.env.get("HF_ACCESS_TOKEN") },
-		title: "Delete old docs",
-		operations: filesToDelete.map((file) => ({
-			operation: "delete",
-			path: file,
-		})),
-	});
-}
+console.log({ totalDeleted, totalKept });


### PR DESCRIPTION
## Summary

Replace `doc-builder push` (zip + git LFS upload to Hub dataset) with `hf sync` (direct sync to HF bucket) for PR documentation uploads.

## Changes

- `upload_pr_documentation.yml`: replace `doc-builder push` step with `hf sync` to bucket `hf-doc-build/doc-dev`

## Context

Part of the EFS → bucket migration for moon-ci-docs. The bucket is mounted via hf-mount CSI driver on the doc pods, replacing the shared EFS + git pull + unzip pipeline.

Companion PR: https://github.com/huggingface-internal/moon-landing/pull/17729
