### PR TITLE
feat: make >>> and ... REPL prompts unselectable in code blocks

### DIFF
--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -394,7 +394,7 @@ const _mdsvexPreprocess = mdsvex({
 						.join("\n");
 				}
 				return `
-	<CodeBlock
+	<CodeBlock 
 		code={\`${base64(code)}\`}
 		highlighted={\`${escape(highlighted)}\`}
 		wrap={${wrapCodeBlocks}}

--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -8,6 +8,18 @@ import path from "path";
 import cheerio from "cheerio";
 import { renderSvelteChars } from "../utils.js";
 
+// Wrap >>> and ... at the start of lines in hljs-meta spans so the CSS
+// `select-none` rule makes them unselectable when copying code.
+// highlight.js only does this natively for python-repl/pycon; for bash and
+// other languages the prompt appears as plain &gt;&gt;&gt; in the HTML.
+hljs.addPlugin({
+	"after:highlight": (result) => {
+		result.value = result.value
+			.replace(/^(&gt;&gt;&gt;[ \t])/gm, '<span class="hljs-meta">$1</span>')
+			.replace(/^(\.\.\.[ \t])/gm, '<span class="hljs-meta">$1</span>');
+	},
+});
+
 /**
  * inside `<code>` html elements, we need to replace `&amp;` with `&`
  * to correctly render escaped characters like `<`, `{`, etc.
@@ -382,7 +394,7 @@ const _mdsvexPreprocess = mdsvex({
 						.join("\n");
 				}
 				return `
-	<CodeBlock 
+	<CodeBlock
 		code={\`${base64(code)}\`}
 		highlighted={\`${escape(highlighted)}\`}
 		wrap={${wrapCodeBlocks}}

--- a/kit/src/app.css
+++ b/kit/src/app.css
@@ -287,6 +287,10 @@
 	@apply border border-gray-100;
 }
 
+.code-block .hljs-meta {
+	@apply select-none;
+}
+
 .prose.prose-doc > p > em {
 	@apply text-gray-500;
 }

--- a/kit/src/app.css
+++ b/kit/src/app.css
@@ -287,10 +287,6 @@
 	@apply border border-gray-100;
 }
 
-.code-block .hljs-meta {
-	@apply select-none;
-}
-
 .prose.prose-doc > p > em {
 	@apply text-gray-500;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: highlight.js only wraps `>>>` in `hljs-meta` for `python-repl`/`pycon`. For `bash` and other languages it emits plain `&gt;&gt;&gt;`, so the existing `.hljs-meta { select-none }` CSS had nothing to target (visible on pages like [jobs-quickstart](https://huggingface.co/docs/hub/jobs-quickstart)).
- Registers an `hljs.addPlugin` `after:highlight` hook that wraps `>>>` and `...` at line starts in `<span class="hljs-meta">` for all languages where hljs doesn't already do it.


https://huggingface.co/docs/hub/jobs-quickstart before

https://github.com/user-attachments/assets/de124db7-12c1-4f05-acd2-c227b685320d

https://huggingface.co/docs/hub/jobs-quickstart after

https://github.com/user-attachments/assets/2b95e930-933d-40fa-a3fa-c745477e28d3

🤖 Generated with [Claude Code](https://claude.com/claude-code)