### PR TITLE
fix(ci): sync to bucket before zip-push to preserve extracted files

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -234,13 +234,6 @@ jobs:
 
           cd ..
 
-      - name: Push to dataset (legacy, kept for rollback safety)
-        run: |
-          source .venv/bin/activate
-          cd build_dir
-          doc-builder push ${{ env.package_name }} --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --upload_version_yml
-          cd ..
-
       - name: Sync to bucket
         env:
           HF_TOKEN: ${{ secrets.hf_token }}
@@ -251,6 +244,15 @@ jobs:
           hf sync "./$PACKAGE_NAME" "hf://buckets/hf-doc-build/doc/$PACKAGE_NAME"
           cd ..
 
+      - name: Push to dataset (legacy, kept for rollback safety)
+        run: |
+          source .venv/bin/activate
+          cd build_dir
+          doc-builder push ${{ env.package_name }} --doc_build_repo_id "hf-doc-build/doc-build" --token "${{ secrets.hf_token }}" --commit_msg "Updated with commit ${{ inputs.commit_sha }} See: https://github.com/${{ inputs.repo_owner }}/${{ inputs.package }}/commit/${{ inputs.commit_sha }}" --n_retries 5 --upload_version_yml
+          cd ..
+
+      - name: Commit notebooks
+        run: |
           if [ -d "notebook_dir" ]
           then
             cd notebooks


### PR DESCRIPTION
## Summary

- Move the `Sync to bucket` step before `Push to dataset (legacy)` so the bucket receives the full extracted tree (`./<package>/main/**`), not just `main.zip` and `_versions.yml`.
- Split the notebooks commit logic into its own step (previously nested inside `Sync to bucket`).

## Why

The `doc-builder push` step replaces the build output with a zip (`main.zip`) and `_versions.yml`, so the subsequent `hf sync` only sees those 2 files. As a result, for all doc packages now served from `hf-doc-build/doc` via the bucket-backed deploy (moon-landing `prod-hub-doc`), the `main/` directory in the bucket has not been refreshed on merges since the migration.

Concretely: https://github.com/huggingface/hub-docs/pull/2400 merged at 2026-04-17 11:55 UTC, workflow ran successfully, the bucket sync step reported `Uploads: 2` (the zip + versions), but the individual `.html` / `.md` under `hub/main/en/` were never uploaded. Prod still serves the pre-migration content.

By running the bucket sync first, the full extracted tree is uploaded, and the legacy zip push still runs afterwards so the Dataset-based rollback path stays intact.
