### PR TITLE
fix(ci): set default shell to bash in build workflow jobs

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -63,6 +63,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       ${{ inputs.custom_container }}
+    defaults:
+      run:
+        shell: bash
     env:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -68,6 +68,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       ${{ inputs.custom_container }}
+    defaults:
+      run:
+        shell: bash
     env:
       UV_HTTP_TIMEOUT: 900 # max 15min to install deps (shouldn't take more than 5min)
 


### PR DESCRIPTION
After #780 split the push step, `source .venv/bin/activate` in "Push to dataset (legacy)" falls back to dash and fails with `source: not found` in custom_container jobs. Setting `defaults.run.shell: bash` at job level fixes this and prevents the same issue in "Convert notebooks" (same latent pattern). Applied to both build workflows.