### PR TITLE
Add ruff to the list of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     "huggingface_hub",
     "pillow",
     "meilisearch==0.34.1",
+    "ruff",
 ]
 
 extras = {}


### PR DESCRIPTION
Add ruff to the list of dependencies.

Currently, an error is raised when running `doc-builder style`:
> No such file or directory: 'ruff'

Note that `doc-builder style` uses ruff unconditionally: https://github.com/huggingface/doc-builder/blob/2430c1ec91d04667414e2fa31ecfc36c153ea391/src/doc_builder/style_doc.py#L140-L147

However, `ruff` is not declared as a dependency.

See related issue downstream in `trl`:
- https://github.com/huggingface/trl/issues/5633