### PR TITLE
Harden doc build ZIP extraction

### DIFF
--- a/src/doc_builder/archive_utils.py
+++ b/src/doc_builder/archive_utils.py
@@ -1,0 +1,30 @@
+import zipfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+
+def _has_unsafe_path_parts(filename: str) -> bool:
+    posix_path = PurePosixPath(filename)
+    windows_path = PureWindowsPath(filename)
+    return (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    )
+
+
+def _safe_zip_members(zip_ref: zipfile.ZipFile, destination: str | Path):
+    destination_path = Path(destination).resolve()
+    for member in zip_ref.infolist():
+        if _has_unsafe_path_parts(member.filename):
+            raise ValueError(f"Unsafe ZIP member path: {member.filename}")
+
+        target_path = (destination_path / member.filename).resolve()
+        if target_path != destination_path and destination_path not in target_path.parents:
+            raise ValueError(f"Unsafe ZIP member path: {member.filename}")
+
+        yield member
+
+
+def safe_extract_zip(zip_ref: zipfile.ZipFile, destination: str | Path) -> None:
+    zip_ref.extractall(destination, members=_safe_zip_members(zip_ref, destination))

--- a/src/doc_builder/commands/push.py
+++ b/src/doc_builder/commands/push.py
@@ -23,6 +23,8 @@ from time import sleep, time
 
 from huggingface_hub import HfApi, hf_hub_download
 
+from doc_builder.archive_utils import safe_extract_zip
+
 REPO_TYPE = "dataset"
 SEPARATOR = "/"
 
@@ -71,7 +73,7 @@ def merge_with_existing_docs(api, doc_build_repo_id, zip_file_path, path_docs_bu
             existing_docs_dir.mkdir(parents=True, exist_ok=True)
 
             with zipfile.ZipFile(existing_zip_path, "r") as zf:
-                zf.extractall(existing_docs_dir)
+                safe_extract_zip(zf, existing_docs_dir)
 
             # The zip structure is: library_name/version/language/...
             # e.g., transformers/main/en/..., transformers/main/ja/...

--- a/src/doc_builder/process_hf_docs.py
+++ b/src/doc_builder/process_hf_docs.py
@@ -29,6 +29,7 @@ import httpx
 from packaging import version as package_version
 from tqdm import tqdm
 
+from .archive_utils import safe_extract_zip
 from .build_embeddings import Chunk, split_markdown_by_headings
 
 HF_DATASET_REPO = "hf-doc-build/doc-build"
@@ -140,7 +141,7 @@ def download_and_extract_zip(library_name: str, output_dir: Path, zip_filename: 
         extract_path.mkdir(parents=True, exist_ok=True)
 
         with zipfile.ZipFile(zip_content) as zip_ref:
-            zip_ref.extractall(extract_path)
+            safe_extract_zip(zip_ref, extract_path)
 
         print(f"  Extracted to {extract_path}")
         return extract_path

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,42 @@
+import importlib.util
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+def load_archive_utils_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "src" / "doc_builder" / "archive_utils.py"
+    spec = importlib.util.spec_from_file_location("archive_utils", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("member_name", ["../escape.md", "/tmp/escape.md", "..\\escape.md", "C:\\tmp\\escape.md"])
+def test_safe_extract_zip_rejects_path_traversal(tmp_path, member_name):
+    archive_utils = load_archive_utils_module()
+    zip_path = tmp_path / "docs.zip"
+    with zipfile.ZipFile(zip_path, "w") as zip_ref:
+        zip_ref.writestr(member_name, "bad")
+
+    with zipfile.ZipFile(zip_path) as zip_ref:
+        with pytest.raises(ValueError, match="Unsafe ZIP member path"):
+            archive_utils.safe_extract_zip(zip_ref, tmp_path / "extract")
+
+    assert not (tmp_path / "escape.md").exists()
+
+
+def test_safe_extract_zip_allows_nested_docs(tmp_path):
+    archive_utils = load_archive_utils_module()
+    zip_path = tmp_path / "docs.zip"
+    with zipfile.ZipFile(zip_path, "w") as zip_ref:
+        zip_ref.writestr("transformers/main/en/index.md", "# Docs")
+
+    extract_path = tmp_path / "extract"
+    with zipfile.ZipFile(zip_path) as zip_ref:
+        archive_utils.safe_extract_zip(zip_ref, extract_path)
+
+    assert (extract_path / "transformers" / "main" / "en" / "index.md").read_text() == "# Docs"


### PR DESCRIPTION
## Summary
- add a shared safe ZIP extraction helper for doc artifacts
- reject absolute paths and parent traversal before extracting downloaded doc build ZIPs
- cover safe nested docs and unsafe POSIX/Windows-style member paths with focused tests

## Testing
- `PYTHONPATH=src uv run --no-project --with pytest pytest -q tests/test_archive_utils.py`
- `uv run --no-project --with ruff ruff check src/doc_builder/archive_utils.py src/doc_builder/commands/push.py src/doc_builder/process_hf_docs.py tests/test_archive_utils.py`
- `python3 -m py_compile src/doc_builder/archive_utils.py src/doc_builder/commands/push.py src/doc_builder/process_hf_docs.py tests/test_archive_utils.py`
- `git diff --check`