### PR TITLE
fix(kit): don't crash prerender when a provider/task has no snippet

### DIFF
--- a/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
+++ b/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
@@ -81,7 +81,7 @@
 			[...new Set(availableSnippets.filter((s) => s.language === lang).map((s) => s.client))],
 		])
 	);
-	$: clients = clientsByLanguage[selectedLanguage];
+	$: clients = clientsByLanguage[selectedLanguage] ?? [];
 	$: selectedClient = clients?.[0];
 
 	$: code = snippets


### PR DESCRIPTION
## Problem

`InferenceSnippet.svelte` crashes the doc build when an `<InferenceSnippet>` is rendered for a `(provider, task)` combo that the kit's bundled `@huggingface/inference` has no helper for.

`snippets.getInferenceSnippets(...)` **catches** the `InferenceClientInputError` internally and returns `[]` (it just logs `Failed to get provider helper for …`). With no snippets:

```
const languages = [...]            // []
let selectedLanguage = languages[0]; // undefined
const clientsByLanguage = {...};     // {}
$: clients = clientsByLanguage[selectedLanguage];  // undefined
...
{#if clients.length > 1}             // 💥 Cannot read properties of undefined (reading 'length')
```

That uncaught `TypeError` becomes a SvelteKit `500` during prerender and fails the entire build.

This is reachable whenever the `@huggingface/inference` version used to **generate** the docs is ahead of the version the kit uses to **render** them. Real example: `together` + `automatic-speech-recognition` was added to inference in `4.13.16`; docs generated with `4.13.18` include that section, but the kit pins `4.13.15`, so the render throws and the build dies.

## Fix

Default `clients` to `[]`:

```diff
- 	$: clients = clientsByLanguage[selectedLanguage];
+ 	$: clients = clientsByLanguage[selectedLanguage] ?? [];
```

The component now renders nothing for an unsupported combo instead of crashing the prerender — making the build resilient to any generator↔renderer version skew.

## Verification

Reproduced the exact CI crash condition locally — docs containing the `together`/ASR section, kit resolving the crashing `@huggingface/inference@4.13.15`:

- **Without** this change: `TypeError: Cannot read properties of undefined (reading 'length')` → `Error: 500 /providers/together` → build exit 1.
- **With** this change: build exit **0**, `providers/together` prerenders successfully, no `TypeError`. The `Failed to get provider helper …` line is still logged (harmless — the snippet just renders empty).

## Note

This is the minimal, structural safety net. Separately, bumping the kit's `@huggingface/inference` (currently `^4.13.15`, lockfile-pinned to `4.13.15`) to a current release would make such sections render their snippet rather than degrade to empty — but that also pulls `@huggingface/tasks` `^0.20.12` → `^0.21.x`, so it's left as a separate maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)