### PR TITLE
Fix Svelte 5 compile break on raw-HTML tables (<table><tr> without <tbody>)

### DIFF
--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -34,6 +34,20 @@ function renderCode(code) {
 	);
 }
 
+/**
+ * Svelte 5 raises a compile error (`node_invalid_placement`) when `<tr>` is a
+ * direct child of `<table>`, because browsers auto-insert `<tbody>` during
+ * parsing, which would break hydration. Raw-HTML tables in doc markdown
+ * commonly omit `<tbody>` (e.g. `<table><tr>...`), so add it explicitly —
+ * the resulting DOM is identical to what browsers produced for the old output.
+ * @param {string} code
+ */
+function wrapTableRowsInTbody(code) {
+	return code
+		.replace(/(<table\b[^>]*>)(\s*)(<tr\b)/g, "$1$2<tbody>$3")
+		.replace(/(<\/tr>)(\s*)(<\/table>)/g, "$1</tbody>$2$3");
+}
+
 function addFullWidthClassToTables(code) {
 	return code.replace(/<table\b([^>]*)>/g, (match, attrs) => {
 		if (attrs.includes('class="')) {
@@ -68,6 +82,7 @@ export const mdsvexPreprocess = {
 			const processed = await _mdsvexPreprocess.markup({ content, filename });
 			processed.code = renderKatex(processed.code, markedKatex);
 			processed.code = renderCode(processed.code, filename);
+			processed.code = wrapTableRowsInTbody(processed.code);
 			if (stretchTables) {
 				processed.code = addFullWidthClassToTables(processed.code);
 			}

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -53,7 +53,9 @@ const config = {
 		if (
 			warning.message.includes("unused export property") ||
 			warning.code?.startsWith("a11y") ||
-			warning.message.includes("A11y")
+			warning.message.includes("A11y") ||
+			// md-generated doc content is full of `<video ... />` style self-closing tags
+			warning.code === "element_invalid_self_closing_tag"
 		) {
 			/// Too noisy
 			return;


### PR DESCRIPTION
## What

Follow-up to #792 — **fixes downstream doc builds currently broken on main** (e.g. [hub-docs build](https://github.com/huggingface/hub-docs/actions/runs/28653364001/job/85069446434)).

Svelte 5 raises a hard compile error ([`node_invalid_placement`](https://svelte.dev/e/node_invalid_placement)) when `<tr>` is a direct child of `<table>`: browsers auto-insert `<tbody>` while parsing, which breaks Svelte's hydration assumptions. Svelte 4 tolerated it. Raw-HTML tables in doc markdown commonly use exactly this idiom (`hub-docs/docs/hub/transformers-js.md`, `bertopic.md`, …).

## Fix

- `preprocessors/mdsvex/index.js`: after mdsvex processing, wrap direct-child `<tr>` runs in an explicit `<tbody>`. The rendered DOM is identical to what browsers auto-inserted for the pre-Svelte-5 output, so no visual/CSS change (`tbody tr` selectors already assumed it).
- `svelte.config.js`: silence Svelte 5's new `element_invalid_self_closing_tag` warning — md-generated content triggers it pervasively (`<video ... />`, `<div id=... />`) and it's non-actionable noise in build logs.

Tables that already declare `<thead>`/`<tbody>` are untouched (the regex only fires when `<tr>` directly follows `<table …>`).

## Verification

Full local hub-docs build (`doc-builder build hub docs/hub --not_python_module --html`, 268 pages — the exact job that failed): **passes**, output contains `<table><tbody><tr>`. No other `node_invalid_placement` patterns surfaced across the 274 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)