### PR TITLE
Keep shorthand doc URLs in the address bar on client-side navigation

### DIFF
--- a/kit/src/routes/+layout.svelte
+++ b/kit/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 
 <script lang="ts">
 	import { onMount } from "svelte";
+	import { afterNavigate } from "$app/navigation";
 	import { base } from "$app/paths";
 	import { getHfDocFullPath } from "$lib/hfDocPaths.js";
 	import type { RawChapter } from "./endpoints/toc/+server";
@@ -9,22 +10,54 @@
 	export let data;
 	$: toc = (data.toc ?? []) as RawChapter[];
 
+	/**
+	 * Shorthand hf doc links (e.g. /docs/lib/page) should partial-load like
+	 * internal routes while keeping the shorthand URL in the address bar —
+	 * the behavior of the old `svelteKitCustomClient` fork.
+	 * SvelteKit treats URLs that don't start with the app's base path as
+	 * external before it consults the `reroute` hook (src/hooks.js), so:
+	 *  1. on click, momentarily expand the anchor's pathname to the full path
+	 *     so SvelteKit's own click handler resolves it as an internal route,
+	 *  2. after the navigation completes, restore the shorthand URL in the
+	 *     history entry.
+	 * Caveat: going back/forward onto a shorthand history entry falls back to
+	 * a full page load (the server serves the same page at shorthand URLs).
+	 */
+	let pendingShorthand: { href: string; fullPath: string } | null = null;
+
 	onMount(() => {
-		// Expand shorthand hf doc links (e.g. /docs/lib/page) to the full path
-		// before SvelteKit's own click handler reads the anchor, so they are
-		// treated as internal routes (partial loading instead of a full reload).
-		// Complements the `reroute` hook (src/hooks.js), which is not consulted
-		// for URLs that don't start with the app's base path.
 		const canonicalizeDocLinks = (event: MouseEvent) => {
+			// same conditions as SvelteKit's click handler: plain left-clicks only,
+			// so that e.g. cmd/ctrl-click opens the shorthand URL in a new tab
+			if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+				return;
+			}
 			const anchor = (event.target as Element | null)?.closest("a");
-			if (!anchor || anchor.origin !== location.origin) return;
-			const fullPath = getHfDocFullPath(anchor.pathname);
-			if (fullPath && fullPath !== anchor.pathname) {
+			if (!anchor || anchor.origin !== location.origin || anchor.target) return;
+			const shorthandPathname = anchor.pathname;
+			const fullPath = getHfDocFullPath(shorthandPathname);
+			if (fullPath && fullPath !== shorthandPathname) {
+				pendingShorthand = { href: anchor.href, fullPath };
 				anchor.pathname = fullPath;
+				// restore the DOM link once SvelteKit's handler has read it
+				setTimeout(() => {
+					anchor.pathname = shorthandPathname;
+				});
 			}
 		};
 		document.addEventListener("click", canonicalizeDocLinks, { capture: true });
 		return () => document.removeEventListener("click", canonicalizeDocLinks, { capture: true });
+	});
+
+	afterNavigate((navigation) => {
+		if (
+			pendingShorthand &&
+			navigation.type === "link" &&
+			navigation.to?.url.pathname === pendingShorthand.fullPath
+		) {
+			history.replaceState(history.state, "", pendingShorthand.href);
+		}
+		pendingShorthand = null;
 	});
 </script>
 


### PR DESCRIPTION
## What

Follow-up to #792. Clicking a shorthand doc link (e.g. `/docs/hub/advanced-compute-options`) was canonicalizing the address bar to the full `/docs/hub/main/en/advanced-compute-options` URL. This restores the old `svelteKitCustomClient` behavior: the URL bar keeps the shorthand the user clicked.

## How

SvelteKit's router still needs the expanded path to resolve the route (its external-URL check runs before `reroute`, see #792), so the click listener in `+layout.svelte` now:

1. expands the anchor's pathname just long enough for SvelteKit's click handler to read it (then restores the DOM href),
2. lets the client-side navigation happen on the expanded route,
3. in `afterNavigate`, rewrites the history entry back to the shorthand URL via `history.replaceState` (equivalent to the old fork pushing `originalUrl`).

Modified clicks (cmd/ctrl/shift/alt, non-left button, `target=`) are left untouched, so open-in-new-tab uses the shorthand URL too.

**Known caveat** (same class of trade-off as the fork removal): pressing back/forward onto a shorthand history entry falls back to a full page load — the server serves the identical page at shorthand URLs, so content is always correct.

## Verification

Browser test (Chrome via playwright) on the built accelerate docs — clicking an injected `/docs/accelerate/quicktour` link:

- navigates client-side (JS state survives) ✚ renders Quicktour ✅
- address bar shows `/docs/accelerate/quicktour` (not `/docs/accelerate/main/en/quicktour`) ✅
- the DOM anchor's href is restored to the shorthand ✅

`svelte-check`: 0 errors, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)