### PR TITLE
Migrate kit/ components to Svelte 5 runes (fixes broken docstring tooltips)

### DIFF
--- a/kit/src/lib/Added.svelte
+++ b/kit/src/lib/Added.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import Tip from "./Tip.svelte";
 
-	export let version: string;
+	interface Props {
+		version: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { version, children }: Props = $props();
 </script>
 
 <Tip>
 	<p class="font-medium">Added in {version}</p>
-	<slot />
+	{@render children?.()}
 </Tip>

--- a/kit/src/lib/Changed.svelte
+++ b/kit/src/lib/Changed.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import Tip from "./Tip.svelte";
 
-	export let version: string;
+	interface Props {
+		version: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { version, children }: Props = $props();
 </script>
 
 <Tip>
 	<p class="font-medium">Changed in {version}</p>
-	<slot />
+	{@render children?.()}
 </Tip>

--- a/kit/src/lib/CodeBlock.svelte
+++ b/kit/src/lib/CodeBlock.svelte
@@ -1,11 +1,15 @@
-<script>
+<script lang="ts">
 	import CopyButton from "./CopyButton.svelte";
-	let hideCopyButton = true;
-	export let code = "";
-	export let highlighted = "";
-	export let lang = "";
-	export let wrap = false;
-	export let classNames = "";
+	let hideCopyButton = $state(true);
+	interface Props {
+		code?: string;
+		highlighted?: string;
+		lang?: string;
+		wrap?: boolean;
+		classNames?: string;
+	}
+
+	let { code = "", highlighted = "", lang = "", wrap = false, classNames = "" }: Props = $props();
 
 	function handleMouseOver() {
 		hideCopyButton = false;
@@ -17,10 +21,10 @@
 
 <div
 	class="code-block relative {classNames}"
-	on:mouseover={handleMouseOver}
-	on:focus={handleMouseOver}
-	on:mouseout={handleMouseOut}
-	on:blur={handleMouseOut}
+	onmouseover={handleMouseOver}
+	onfocus={handleMouseOver}
+	onmouseout={handleMouseOut}
+	onblur={handleMouseOut}
 >
 	<div class="absolute top-2.5 right-4">
 		<CopyButton

--- a/kit/src/lib/CodeBlockFw.svelte
+++ b/kit/src/lib/CodeBlockFw.svelte
@@ -3,16 +3,20 @@
 	import CopyButton from "./CopyButton.svelte";
 	import FrameworkSwitch from "./FrameworkSwitch.svelte";
 
-	export let group1: { id: string; code: string; highlighted: string };
-	export let group2: { id: string; code: string; highlighted: string };
-	export let lang = "";
-	export let wrap = false;
+	interface Props {
+		group1: { id: string; code: string; highlighted: string };
+		group2: { id: string; code: string; highlighted: string };
+		lang?: string;
+		wrap?: boolean;
+	}
+
+	let { group1, group2, lang = "", wrap = false }: Props = $props();
 
 	const ids = [group1.id, group2.id];
 	const storeKey = ids.join("-");
 	const group = getGroupStore(storeKey);
 
-	let hideCopyButton = true;
+	let hideCopyButton = $state(true);
 
 	function handleMouseOver() {
 		hideCopyButton = false;
@@ -24,10 +28,13 @@
 
 <div
 	class="code-block relative"
-	on:mouseover={handleMouseOver}
-	on:focus={handleMouseOver}
-	on:mouseout={handleMouseOut}
-	on:focus={handleMouseOut}
+	onmouseover={handleMouseOver}
+	onfocus={() => {
+		// preserved from the svelte 4 version, which bound focus to both handlers
+		handleMouseOver();
+		handleMouseOut();
+	}}
+	onmouseout={handleMouseOut}
 >
 	{#if $group === "group1"}
 		<div class="absolute top-2.5 right-4">

--- a/kit/src/lib/ColabDropdown.svelte
+++ b/kit/src/lib/ColabDropdown.svelte
@@ -2,8 +2,13 @@
 	import Dropdown from "./Dropdown.svelte";
 	import DropdownEntry from "./DropdownEntry.svelte";
 
-	export let options: { label: string; value: string }[] = [];
-	export let classNames = "";
+	interface Props {
+		options?: { label: string; value: string }[];
+		classNames?: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { options = [], classNames = "", children }: Props = $props();
 
 	function onClick(url: string) {
 		window.open(url);
@@ -12,23 +17,27 @@
 
 <div class={classNames}>
 	<Dropdown btnLabel="" classNames="colab-dropdown" noBtnClass useDeprecatedJS={false}>
-		<slot slot="button">
-			<img
-				alt="Open In Colab"
-				class="!m-0"
-				src="https://colab.research.google.com/assets/colab-badge.svg"
-			/>
-		</slot>
-		<slot slot="menu">
-			{#each options as { label, value }}
-				<DropdownEntry
-					classNames="text-sm !no-underline"
-					iconClassNames="text-gray-500"
-					{label}
-					onClick={() => onClick(value)}
-					useDeprecatedJS={false}
+		{#snippet button()}
+			{#if children}{@render children()}{:else}
+				<img
+					alt="Open In Colab"
+					class="!m-0"
+					src="https://colab.research.google.com/assets/colab-badge.svg"
 				/>
-			{/each}
-		</slot>
+			{/if}
+		{/snippet}
+		{#snippet menu()}
+			{#if children}{@render children()}{:else}
+				{#each options as { label, value }}
+					<DropdownEntry
+						classNames="text-sm !no-underline"
+						iconClassNames="text-gray-500"
+						{label}
+						onClick={() => onClick(value)}
+						useDeprecatedJS={false}
+					/>
+				{/each}
+			{/if}
+		{/snippet}
 	</Dropdown>
 </div>

--- a/kit/src/lib/CopyButton.svelte
+++ b/kit/src/lib/CopyButton.svelte
@@ -5,13 +5,17 @@
 	import IconCopy from "./IconCopy.svelte";
 	import Tooltip from "./Tooltip.svelte";
 
-	export let classNames = "";
-	export let label = "";
-	export let style: "button" | "button-clear" | "text" = "text";
-	export let title = "";
-	export let value: string;
+	interface Props {
+		classNames?: string;
+		label?: string;
+		style?: "button" | "button-clear" | "text";
+		title?: string;
+		value: string;
+	}
 
-	let isSuccess = false;
+	let { classNames = "", label = "", style = "text", title = "", value }: Props = $props();
+
+	let isSuccess = $state(false);
 	let timeout: any;
 
 	onDestroy(() => {
@@ -41,7 +45,7 @@
 		{!isSuccess && ['button-clear', 'text'].includes(style) ? 'text-gray-600' : ''}
 		{isSuccess ? 'text-green-500' : ''}
 	"
-	on:click={handleClick}
+	onclick={handleClick}
 	title={title || label || "Copy to clipboard"}
 	type="button"
 >

--- a/kit/src/lib/CopyLLMTxtMenu.svelte
+++ b/kit/src/lib/CopyLLMTxtMenu.svelte
@@ -10,10 +10,19 @@
 	import IconMCP from "./IconMCP.svelte";
 	import IconHuggingChat from "./IconHuggingChat.svelte";
 
-	export let label = "Copy page";
-	export let markdownDescription = "Copy page as Markdown for LLMs";
-	export let containerClass = "";
-	export let containerStyle = "";
+	interface Props {
+		label?: string;
+		markdownDescription?: string;
+		containerClass?: string;
+		containerStyle?: string;
+	}
+
+	let {
+		label = "Copy page",
+		markdownDescription = "Copy page as Markdown for LLMs",
+		containerClass = "",
+		containerStyle = "",
+	}: Props = $props();
 
 	const isClient = typeof window !== "undefined";
 	const hasDocument = typeof document !== "undefined";
@@ -28,11 +37,11 @@
 	const SOURCE_URL_MD = SOURCE_URL.endsWith(".md") ? SOURCE_URL : SOURCE_URL + ".md";
 	let encodedPrompt: string | null = null;
 
-	let open = false;
-	let copied = false;
-	let triggerEl: HTMLDivElement | null = null;
-	let menuEl: HTMLDivElement | null = null;
-	let menuStyle = "";
+	let open = $state(false);
+	let copied = $state(false);
+	let triggerEl: HTMLDivElement | null = $state(null);
+	let menuEl: HTMLDivElement | null = $state(null);
+	let menuStyle = $state("");
 	let closeTimeout: ReturnType<typeof setTimeout> | null = null;
 	let sourceMarkdown: string | null = null;
 	let sourceFetchPromise: Promise<string> | null = null;
@@ -204,10 +213,10 @@
 </script>
 
 <svelte:window
-	on:mousedown={handleWindowPointer}
-	on:keydown={handleWindowKeydown}
-	on:resize={handleWindowResize}
-	on:scroll={handleWindowScroll}
+	onmousedown={handleWindowPointer}
+	onkeydown={handleWindowKeydown}
+	onresize={handleWindowResize}
+	onscroll={handleWindowScroll}
 />
 
 <div
@@ -218,7 +227,7 @@
 >
 	<div bind:this={triggerEl} class="inline-flex rounded-md max-sm:rounded-sm">
 		<button
-			on:click={copyMarkdown}
+			onclick={copyMarkdown}
 			class="inline-flex items-center gap-1 h-7 max-sm:h-7 px-2 max-sm:px-1.5 text-sm font-medium text-gray-800 border border-r-0 rounded-l-md max-sm:rounded-l-sm border-gray-200 bg-white hover:shadow-inner dark:border-gray-850 dark:bg-gray-950 dark:text-gray-200 dark:hover:bg-gray-800"
 			aria-live="polite"
 		>
@@ -230,7 +239,7 @@
 			<span>{copied ? "Copied" : label}</span>
 		</button>
 		<button
-			on:click={toggleMenu}
+			onclick={toggleMenu}
 			class="inline-flex items-center justify-center w-6 max-sm:w-5 h-7 max-sm:h-7 disabled:pointer-events-none text-sm text-gray-500 hover:text-gray-700 dark:hover:text-white rounded-r-md max-sm:rounded-r-sm border border-l transition border-gray-200 bg-white hover:shadow-inner dark:border-gray-850 dark:bg-gray-950 dark:text-gray-200 dark:hover:bg-gray-800"
 			aria-haspopup="menu"
 			aria-expanded={open}
@@ -249,7 +258,7 @@
 			class="fixed inset-0 z-40"
 			aria-hidden="true"
 			style="background: transparent;"
-			on:click={closeMenu}
+			onclick={closeMenu}
 		></div>
 		<div
 			bind:this={menuEl}
@@ -260,7 +269,7 @@
 		>
 			<button
 				role="menuitem"
-				on:click={() => {
+				onclick={() => {
 					copyMarkdown();
 					closeMenu();
 				}}
@@ -284,7 +293,7 @@
 				href={SOURCE_URL_MD}
 				target="_blank"
 				rel="noopener noreferrer"
-				on:click={closeMenu}
+				onclick={closeMenu}
 				class="{baseMenuItemClass} no-underline!"
 			>
 				<div class="border border-gray-200 dark:border-gray-850 rounded-lg p-1.5">
@@ -305,7 +314,7 @@
 					href={option.buildUrl()}
 					target="_blank"
 					rel="noopener noreferrer"
-					on:click={closeMenu}
+					onclick={closeMenu}
 					class="{baseMenuItemClass} no-underline!"
 				>
 					<div class="border border-gray-200 dark:border-gray-850 rounded-lg p-1.5">

--- a/kit/src/lib/CourseFloatingBanner.svelte
+++ b/kit/src/lib/CourseFloatingBanner.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
 	import DocNotebookDropdown from "./DocNotebookDropdown.svelte";
 
-	export let chapter: number;
-	export let notebooks: { label: string; value: string }[] = [];
-	export let classNames = "";
-	export let askForHelpUrl = `https://discuss.huggingface.co/t/chapter-${chapter}-questions`;
+	interface Props {
+		chapter: number;
+		notebooks?: { label: string; value: string }[];
+		classNames?: string;
+		askForHelpUrl?: any;
+	}
+
+	let {
+		chapter,
+		notebooks = [],
+		classNames = "",
+		askForHelpUrl = `https://discuss.huggingface.co/t/chapter-${chapter}-questions`,
+	}: Props = $props();
 </script>
 
 <DocNotebookDropdown options={notebooks} {classNames}>
-	<svelte:fragment slot="alwaysVisible">
+	{#snippet alwaysVisible()}
 		<a href={askForHelpUrl} target="_blank">
 			<img
 				alt="Ask a Question"
@@ -16,5 +25,5 @@
 				src="https://img.shields.io/badge/Ask%20a%20question-ffcb4c.svg?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgLTEgMTA0IDEwNiI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiMyMzFmMjA7fS5jbHMtMntmaWxsOiNmZmY5YWU7fS5jbHMtM3tmaWxsOiMwMGFlZWY7fS5jbHMtNHtmaWxsOiMwMGE5NGY7fS5jbHMtNXtmaWxsOiNmMTVkMjI7fS5jbHMtNntmaWxsOiNlMzFiMjM7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5EaXNjb3Vyc2VfbG9nbzwvdGl0bGU+PGcgaWQ9IkxheWVyXzIiPjxnIGlkPSJMYXllcl8zIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MS44NywwQzIzLjcxLDAsMCwyMi44MywwLDUxYzAsLjkxLDAsNTIuODEsMCw1Mi44MWw1MS44Ni0uMDVjMjguMTYsMCw1MS0yMy43MSw1MS01MS44N1M4MCwwLDUxLjg3LDBaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNNTIuMzcsMTkuNzRBMzEuNjIsMzEuNjIsMCwwLDAsMjQuNTgsNjYuNDFsLTUuNzIsMTguNEwzOS40LDgwLjE3YTMxLjYxLDMxLjYxLDAsMSwwLDEzLTYwLjQzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTc3LjQ1LDMyLjEyYTMxLjYsMzEuNiwwLDAsMS0zOC4wNSw0OEwxOC44Niw4NC44MmwyMC45MS0yLjQ3QTMxLjYsMzEuNiwwLDAsMCw3Ny40NSwzMi4xMloiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik03MS42MywyNi4yOUEzMS42LDMxLjYsMCwwLDEsMzguOCw3OEwxOC44Niw4NC44MiwzOS40LDgwLjE3QTMxLjYsMzEuNiwwLDAsMCw3MS42MywyNi4yOVoiLz48cGF0aCBjbGFzcz0iY2xzLTUiIGQ9Ik0yNi40Nyw2Ny4xMWEzMS42MSwzMS42MSwwLDAsMSw1MS0zNUEzMS42MSwzMS42MSwwLDAsMCwyNC41OCw2Ni40MWwtNS43MiwxOC40WiIvPjxwYXRoIGNsYXNzPSJjbHMtNiIgZD0iTTI0LjU4LDY2LjQxQTMxLjYxLDMxLjYxLDAsMCwxLDcxLjYzLDI2LjI5YTMxLjYxLDMxLjYxLDAsMCwwLTQ5LDM5LjYzbC0zLjc2LDE4LjlaIi8+PC9nPjwvZz48L3N2Zz4="
 			/>
 		</a>
-	</svelte:fragment>
+	{/snippet}
 </DocNotebookDropdown>

--- a/kit/src/lib/Deprecated.svelte
+++ b/kit/src/lib/Deprecated.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import Tip from "./Tip.svelte";
 
-	export let version: string;
+	interface Props {
+		version: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { version, children }: Props = $props();
 </script>
 
 <Tip warning>
 	<p class="font-medium">Deprecated in {version}</p>
-	<slot />
+	{@render children?.()}
 </Tip>

--- a/kit/src/lib/DocNotebookDropdown.svelte
+++ b/kit/src/lib/DocNotebookDropdown.svelte
@@ -2,9 +2,21 @@
 	import Dropdown from "./Dropdown.svelte";
 	import DropdownEntry from "./DropdownEntry.svelte";
 
-	export let options: { label: string; value: string }[] = [];
-	export let classNames = "";
-	export let containerStyle = "";
+	interface Props {
+		options?: { label: string; value: string }[];
+		classNames?: string;
+		containerStyle?: string;
+		alwaysVisible?: import("svelte").Snippet;
+		children?: import("svelte").Snippet;
+	}
+
+	let {
+		options = [],
+		classNames = "",
+		containerStyle = "",
+		alwaysVisible,
+		children,
+	}: Props = $props();
 
 	const googleColabOptions = options.filter((o) => o.value.includes("colab.research.google.com"));
 	const awsStudioOptions = options.filter((o) => o.value.includes("studiolab.sagemaker.aws"));
@@ -15,7 +27,7 @@
 </script>
 
 <div class="flex space-x-1 {classNames}" style={containerStyle}>
-	<slot name="alwaysVisible" />
+	{@render alwaysVisible?.()}
 	{#if googleColabOptions.length === 1}
 		<a href={googleColabOptions[0].value} target="_blank">
 			<img
@@ -26,24 +38,28 @@
 		</a>
 	{:else if googleColabOptions.length > 1}
 		<Dropdown btnLabel="" classNames="colab-dropdown" noBtnClass useDeprecatedJS={false}>
-			<slot slot="button">
-				<img
-					alt="Open In Colab"
-					class="!m-0"
-					src="https://colab.research.google.com/assets/colab-badge.svg"
-				/>
-			</slot>
-			<slot slot="menu">
-				{#each googleColabOptions as { label, value }}
-					<DropdownEntry
-						classNames="text-sm !no-underline"
-						iconClassNames="text-gray-500"
-						{label}
-						onClick={() => onClick(value)}
-						useDeprecatedJS={false}
+			{#snippet button()}
+				{#if children}{@render children()}{:else}
+					<img
+						alt="Open In Colab"
+						class="!m-0"
+						src="https://colab.research.google.com/assets/colab-badge.svg"
 					/>
-				{/each}
-			</slot>
+				{/if}
+			{/snippet}
+			{#snippet menu()}
+				{#if children}{@render children()}{:else}
+					{#each googleColabOptions as { label, value }}
+						<DropdownEntry
+							classNames="text-sm !no-underline"
+							iconClassNames="text-gray-500"
+							{label}
+							onClick={() => onClick(value)}
+							useDeprecatedJS={false}
+						/>
+					{/each}
+				{/if}
+			{/snippet}
 		</Dropdown>
 	{/if}
 	{#if awsStudioOptions.length === 1}
@@ -56,24 +72,28 @@
 		</a>
 	{:else if awsStudioOptions.length > 1}
 		<Dropdown btnLabel="" classNames="colab-dropdown" noBtnClass useDeprecatedJS={false}>
-			<slot slot="button">
-				<img
-					alt="Open In Studio Lab"
-					class="!m-0"
-					src="https://studiolab.sagemaker.aws/studiolab.svg"
-				/>
-			</slot>
-			<slot slot="menu">
-				{#each awsStudioOptions as { label, value }}
-					<DropdownEntry
-						classNames="text-sm !no-underline"
-						iconClassNames="text-gray-500"
-						{label}
-						onClick={() => onClick(value)}
-						useDeprecatedJS={false}
+			{#snippet button()}
+				{#if children}{@render children()}{:else}
+					<img
+						alt="Open In Studio Lab"
+						class="!m-0"
+						src="https://studiolab.sagemaker.aws/studiolab.svg"
 					/>
-				{/each}
-			</slot>
+				{/if}
+			{/snippet}
+			{#snippet menu()}
+				{#if children}{@render children()}{:else}
+					{#each awsStudioOptions as { label, value }}
+						<DropdownEntry
+							classNames="text-sm !no-underline"
+							iconClassNames="text-gray-500"
+							{label}
+							onClick={() => onClick(value)}
+							useDeprecatedJS={false}
+						/>
+					{/each}
+				{/if}
+			{/snippet}
 		</Dropdown>
 	{/if}
 </div>

--- a/kit/src/lib/Docstring.svelte
+++ b/kit/src/lib/Docstring.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, tick } from "svelte";
-	import { tooltip } from "./tooltip";
+	import { tooltip } from "./tooltipAction.svelte";
 	import IconCopyLink from "./IconCopyLink.svelte";
 
 	type Parameter = {
@@ -9,26 +9,44 @@
 		description: string;
 	};
 
-	export let anchor: string;
-	export let name: string;
-	export let parameters: { name: string; val: string }[] = [];
-	export let parametersDescription: Parameter[];
-	export let parameterGroups: {
-		title: string;
+	interface Props {
+		anchor: string;
+		name: string;
+		parameters?: { name: string; val: string }[];
 		parametersDescription: Parameter[];
-	}[];
-	export let returnDescription: string;
-	export let returnType: string;
-	export let isYield = false;
-	export let raiseDescription: string;
-	export let raiseType: string;
-	export let source: string | undefined = undefined;
-	export let hashlink: string | undefined;
-	export let isGetSetDescriptor = false;
+		parameterGroups: {
+			title: string;
+			parametersDescription: Parameter[];
+		}[];
+		returnDescription: string;
+		returnType: string;
+		isYield?: boolean;
+		raiseDescription: string;
+		raiseType: string;
+		source?: string | undefined;
+		hashlink: string | undefined;
+		isGetSetDescriptor?: boolean;
+	}
 
-	let parametersElement: HTMLElement;
+	let {
+		anchor,
+		name,
+		parameters = [],
+		parametersDescription,
+		parameterGroups,
+		returnDescription,
+		returnType,
+		isYield = false,
+		raiseDescription,
+		raiseType,
+		source = undefined,
+		hashlink = $bindable(),
+		isGetSetDescriptor = false,
+	}: Props = $props();
+
+	let parametersElement = $state<HTMLElement>()!;
 	let containerEl: HTMLElement;
-	let collapsed: boolean = false;
+	let collapsed: boolean = $state(false);
 
 	const tooltipMapper: Record<string, string> =
 		parametersDescription?.reduce((acc, element) => {
@@ -94,7 +112,7 @@
 	}
 </script>
 
-<svelte:window on:hashchange={onHashChange} />
+<svelte:window onhashchange={onHashChange} />
 
 <div>
 	<span
@@ -128,8 +146,11 @@
 				<span
 					use:tooltip={tooltipMapper[name] || ""}
 					class="comma {tooltipMapper[name] ? 'cursor-pointer' : 'cursor-default'}"
-					on:click|preventDefault|stopPropagation={() =>
-						onClick(`${anchor}.${name}`, !!tooltipMapper[name])}
+					onclick={(event: MouseEvent) => {
+						event.preventDefault();
+						event.stopPropagation();
+						onClick(`${anchor}.${name}`, !!tooltipMapper[name]);
+					}}
 				>
 					<span
 						class="rounded hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black"
@@ -145,9 +166,11 @@
 					class="rounded hover:bg-gray-400 {returnDescription
 						? 'cursor-pointer'
 						: 'cursor-default'}"
-					on:click|preventDefault|stopPropagation={() =>
-						onClick(`${anchor}.${returnsAnchor}`, !!returnDescription)}
-					>{@html replaceParagraphWithSpan(returnType)}</span
+					onclick={(event: MouseEvent) => {
+						event.preventDefault();
+						event.stopPropagation();
+						onClick(`${anchor}.${returnsAnchor}`, !!returnDescription);
+					}}>{@html replaceParagraphWithSpan(returnType)}</span
 				>
 			{/if}
 		</p>
@@ -163,7 +186,7 @@
 				class="absolute inset-0 bg-gradient-to-t from-white to-white/0 dark:from-gray-950 dark:to-gray-950/0 z-10 flex justify-center"
 			>
 				<button
-					on:click={() => (collapsed = false)}
+					onclick={() => (collapsed = false)}
 					class="absolute leading-tight px-3 py-1.5 dark:bg-gray-900 bg-black text-gray-200 hover:text-white rounded-xl bottom-12 ring-offset-2 hover:ring-black hover:ring-2"
 					>Expand {parametersDescription?.length} parameters</button
 				>
@@ -171,7 +194,8 @@
 		{/if}
 		{#if !!parametersDescription}
 			<p class="flex items-center font-semibold !mt-2 !mb-2 text-gray-800">
-				Parameters <span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700 ml-3" />
+				Parameters <span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700 ml-3"
+				></span>
 			</p>
 			<ul class="px-2">
 				{#each parametersDescription as { anchor, description }}
@@ -195,7 +219,7 @@
 		{#if parameterGroups}
 			{#each parameterGroups as { title, parametersDescription }}
 				<p class="flex items-center font-semibold">
-					{title} <span class="flex-auto border-t-2 ml-3" />
+					{title} <span class="flex-auto border-t-2 ml-3"></span>
 				</p>
 				<ul class="px-2">
 					{#each parametersDescription as { anchor, description }}
@@ -229,7 +253,7 @@
 				{#if !!returnType}
 					{@html returnType}
 				{/if}
-				<span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700" />
+				<span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700"></span>
 			</div>
 			<p class="text-base">{@html returnDescription || ""}</p>
 		{/if}
@@ -242,7 +266,7 @@
 				{#if !!raiseType}
 					{@html raiseType}
 				{/if}
-				<span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700" />
+				<span class="flex-auto border-t-2 border-gray-100 dark:border-gray-700"></span>
 			</div>
 			<p class="text-base">{@html raiseDescription || ""}</p>
 		{/if}

--- a/kit/src/lib/Dropdown.svelte
+++ b/kit/src/lib/Dropdown.svelte
@@ -1,22 +1,42 @@
 <script lang="ts">
-	import type { SvelteComponent } from "svelte";
+	import type { Component } from "svelte";
 	import DropdownMenu from "./DropdownMenu.svelte";
 	import IconCaretDown from "./IconCaretDown.svelte";
 
-	export let classNames = "";
-	export let btnClassNames = "";
-	export let btnIcon: (new (...args: any) => SvelteComponent) | undefined = undefined;
-	export let btnIconClassNames = "";
-	export let btnLabel = "";
-	export let forceMenuAlignement: "left" | "right" | undefined = undefined;
-	export let menuClassNames = "";
-	export let noBtnClass: boolean | undefined = undefined;
-	export let selectedValue: string | undefined = undefined;
-	export let useDeprecatedJS = true;
-	export let withBtnCaret = false;
+	interface Props {
+		classNames?: string;
+		btnClassNames?: string;
+		btnIcon?: Component<{ classNames?: string }> | undefined;
+		btnIconClassNames?: string;
+		btnLabel?: string;
+		forceMenuAlignement?: "left" | "right" | undefined;
+		menuClassNames?: string;
+		noBtnClass?: boolean | undefined;
+		selectedValue?: string | undefined;
+		useDeprecatedJS?: boolean;
+		withBtnCaret?: boolean;
+		button?: import("svelte").Snippet;
+		menu?: import("svelte").Snippet;
+	}
 
-	let element: HTMLElement | undefined = undefined;
-	let isOpen = false;
+	let {
+		classNames = "",
+		btnClassNames = "",
+		btnIcon = undefined,
+		btnIconClassNames = "",
+		btnLabel = "",
+		forceMenuAlignement = undefined,
+		menuClassNames = "",
+		noBtnClass = undefined,
+		selectedValue = undefined,
+		useDeprecatedJS = true,
+		withBtnCaret = false,
+		button,
+		menu,
+	}: Props = $props();
+
+	let element: HTMLElement | undefined = $state(undefined);
+	let isOpen = $state(false);
 
 	function onClose(e: Event) {
 		if (e.target) {
@@ -35,15 +55,16 @@
 			{btnClassNames}
 			{!noBtnClass ? 'cursor-pointer w-full btn text-sm' : ''}
 			{useDeprecatedJS ? 'v2-dropdown-button' : ''}"
-		on:click={() => (isOpen = !isOpen)}
+		onclick={() => (isOpen = !isOpen)}
 		type="button"
 	>
 		<!-- The "button" slot can overwrite the defaut button content -->
-		{#if $$slots.button}
-			<slot name="button" />
+		{#if button}
+			{@render button?.()}
 		{:else}
 			{#if btnIcon}
-				<svelte:component this={btnIcon} classNames="mr-1.5 {btnIconClassNames}" />
+				{@const SvelteComponent_1 = btnIcon}
+				<SvelteComponent_1 classNames="mr-1.5 {btnIconClassNames}" />
 			{/if}
 			{btnLabel}
 			{#if withBtnCaret}
@@ -60,7 +81,7 @@
 			forceAlignement={forceMenuAlignement}
 			{onClose}
 		>
-			<slot name="menu" />
+			{@render menu?.()}
 		</DropdownMenu>
 	{/if}
 	<!-- Menu -->

--- a/kit/src/lib/DropdownEntry.svelte
+++ b/kit/src/lib/DropdownEntry.svelte
@@ -1,19 +1,39 @@
 <script lang="ts">
-	import type { SvelteComponent } from "svelte";
+	import type { Component } from "svelte";
 
-	export let classNames = "";
-	export let dataLabel: string | undefined = undefined;
-	export let dataUrl: string | undefined = undefined;
-	export let dataValue: string | undefined = undefined;
-	export let href: string | undefined = undefined;
-	export let icon: (new (...args: any) => SvelteComponent) | undefined = undefined;
-	export let iconClassNames = "";
-	export let label = "";
-	export let noFollow = false;
-	export let underline = false;
-	export let onClick: (e: MouseEvent) => void = () => {};
-	export let targetBlank = false;
-	export let useDeprecatedJS = true;
+	interface Props {
+		classNames?: string;
+		dataLabel?: string | undefined;
+		dataUrl?: string | undefined;
+		dataValue?: string | undefined;
+		href?: string | undefined;
+		icon?: Component<{ classNames?: string }> | undefined;
+		iconClassNames?: string;
+		label?: string;
+		noFollow?: boolean;
+		underline?: boolean;
+		onClick?: (e: MouseEvent) => void;
+		targetBlank?: boolean;
+		useDeprecatedJS?: boolean;
+		children?: import("svelte").Snippet;
+	}
+
+	let {
+		classNames = "",
+		dataLabel = undefined,
+		dataUrl = undefined,
+		dataValue = undefined,
+		href = undefined,
+		icon = undefined,
+		iconClassNames = "",
+		label = "",
+		noFollow = false,
+		underline = false,
+		onClick = () => {},
+		targetBlank = false,
+		useDeprecatedJS = true,
+		children,
+	}: Props = $props();
 </script>
 
 <li class="not-prose">
@@ -26,16 +46,17 @@
 		data-url={dataUrl}
 		data-value={dataValue}
 		{href}
-		on:click={onClick}
+		onclick={onClick}
 		rel={noFollow ? "nofollow" : undefined}
 		target={targetBlank ? "_blank" : undefined}
 	>
 		<!-- Adding children to the DropdownEntry element overwrite the default label/icon stuff -->
-		{#if $$slots.default}
-			<slot />
+		{#if children}
+			{@render children?.()}
 		{:else}
 			{#if icon}
-				<svelte:component this={icon} classNames="mr-1.5 {iconClassNames}" />
+				{@const SvelteComponent_1 = icon}
+				<SvelteComponent_1 classNames="mr-1.5 {iconClassNames}" />
 			{/if}
 			{label}
 		{/if}

--- a/kit/src/lib/DropdownMenu.svelte
+++ b/kit/src/lib/DropdownMenu.svelte
@@ -3,15 +3,26 @@
 
 	type Alignement = "left" | "right";
 
-	export let classNames = "";
-	export let dropdownElement: HTMLElement | undefined = undefined;
-	export let forceAlignement: Alignement | undefined = undefined;
-	export let onClose: (e: MouseEvent) => void;
+	interface Props {
+		classNames?: string;
+		dropdownElement?: HTMLElement | undefined;
+		forceAlignement?: Alignement | undefined;
+		onClose: (e: MouseEvent) => void;
+		children?: import("svelte").Snippet;
+	}
+
+	let {
+		classNames = "",
+		dropdownElement = undefined,
+		forceAlignement = undefined,
+		onClose,
+		children,
+	}: Props = $props();
 
 	// MUST be set to left if forceAlignement is undefined or else
 	// the browser won't be able to properly compute x and width
-	let alignement: Alignement = forceAlignement ?? "left";
-	let element: HTMLElement | undefined;
+	let alignement: Alignement = $state(forceAlignement ?? "left");
+	let element: HTMLElement | undefined = $state();
 
 	onMount(() => {
 		document.addEventListener("click", handleClickDocument);
@@ -44,9 +55,9 @@
 	class="absolute top-full mt-1 min-w-full w-auto bg-white rounded-xl overflow-hidden shadow-lg z-10 border border-gray-100
 		{alignement === 'right' ? 'right-0' : 'left-0'}
 		{classNames}"
-	on:click={onClose}
+	onclick={onClose}
 >
 	<ul class="min-w-full w-auto">
-		<slot />
+		{@render children?.()}
 	</ul>
 </div>

--- a/kit/src/lib/EditOnGithub.svelte
+++ b/kit/src/lib/EditOnGithub.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import IconCode from "./IconCode.svelte";
-	export let source: string = "";
+	interface Props {
+		source?: string;
+	}
+
+	let { source = "" }: Props = $props();
 </script>
 
 <a

--- a/kit/src/lib/ExampleCodeBlock.svelte
+++ b/kit/src/lib/ExampleCodeBlock.svelte
@@ -3,10 +3,15 @@
 
 	import IconCopyLink from "./IconCopyLink.svelte";
 
-	export let anchor: string;
+	interface Props {
+		anchor: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { anchor, children }: Props = $props();
 
 	const bgHighlightClass = "bg-yellow-50 dark:bg-[#494a3d]";
-	let containerEl: HTMLElement;
+	let containerEl = $state<HTMLElement>()!;
 
 	function onHashChange() {
 		const { hash } = window.location;
@@ -25,7 +30,7 @@
 	});
 </script>
 
-<svelte:window on:hashchange={onHashChange} />
+<svelte:window onhashchange={onHashChange} />
 
 <div class="relative group rounded-md" bind:this={containerEl}>
 	<a
@@ -35,5 +40,5 @@
 	>
 		<span><IconCopyLink classNames="text-smd" /></span>
 	</a>
-	<slot />
+	{@render children?.()}
 </div>

--- a/kit/src/lib/FrameworkContent.svelte
+++ b/kit/src/lib/FrameworkContent.svelte
@@ -1,3 +1,9 @@
+<!--
+	Intentionally kept in Svelte 4 (legacy) syntax: this component exposes named
+	slots whose names collide with its props, which the runes migration cannot
+	express as snippet props. Its slot API is consumed by the generated doc pages
+	(also legacy syntax); mixing legacy and runes components is fully supported.
+-->
 <script lang="ts">
 	import FrameworkContentBlock from "./FrameworkContentBlock.svelte";
 	export let pytorch = false;

--- a/kit/src/lib/FrameworkContentBlock.svelte
+++ b/kit/src/lib/FrameworkContentBlock.svelte
@@ -9,9 +9,14 @@
 	import IconEyeShow from "./IconEyeShow.svelte";
 	import IconEyeHide from "./IconEyeHide.svelte";
 
-	export let framework: Framework;
+	interface Props {
+		framework: Framework;
+		children?: import("svelte").Snippet;
+	}
 
-	let containerEl: HTMLDivElement;
+	let { framework, children }: Props = $props();
+
+	let containerEl = $state<HTMLDivElement>()!;
 	let hashLinks = new Set();
 
 	type SvelteComponent = typeof IconPytorch;
@@ -34,7 +39,7 @@
 	const localStorageKey = `hf_doc_framework_${framework}_is_hidden`;
 	const fwStore = getFrameworkStore(framework);
 
-	$: isClosed = $fwStore === AccordianState.CLOSED;
+	let isClosed = $derived($fwStore === AccordianState.CLOSED);
 
 	function toggleHidden() {
 		$fwStore = $fwStore !== AccordianState.CLOSED ? AccordianState.CLOSED : AccordianState.OPEN;
@@ -64,18 +69,18 @@
 	});
 </script>
 
-<svelte:window on:hashchange={onHashChange} />
+<svelte:window onhashchange={onHashChange} />
 
 <div class="border border-gray-200 rounded-xl px-4 relative" bind:this={containerEl}>
 	<div class="flex h-[22px] mt-[-12.5px] justify-between leading-none">
 		<div class="flex px-1 items-center space-x-1 bg-white dark:bg-gray-950">
-			<svelte:component this={Icon} />
+			<Icon />
 			<span>{label}</span>
 		</div>
 		{#if !isClosed}
 			<div
 				class="cursor-pointer flex items-center justify-center space-x-1 text-sm px-2 bg-white dark:bg-gray-950 hover:underline leading-none"
-				on:click={toggleHidden}
+				onclick={toggleHidden}
 			>
 				<IconEyeHide size={"0.9em"} />
 				<span>Hide {label} content</span>
@@ -85,14 +90,14 @@
 	{#if isClosed}
 		<div
 			class="cursor-pointer mt-[-12.5px] flex items-center justify-center space-x-1 py-4 text-sm hover:underline leading-none"
-			on:click={toggleHidden}
+			onclick={toggleHidden}
 		>
 			<IconEyeShow size={"0.9em"} />
 			<span>Show {label} content</span>
 		</div>
 	{:else}
 		<div class="framework-content">
-			<slot />
+			{@render children?.()}
 		</div>
 	{/if}
 </div>

--- a/kit/src/lib/FrameworkSwitch.svelte
+++ b/kit/src/lib/FrameworkSwitch.svelte
@@ -4,7 +4,11 @@
 	import IconPytorch from "./IconPytorch.svelte";
 	import IconTensorflow from "./IconTensorflow.svelte";
 
-	export let ids: string[];
+	interface Props {
+		ids: string[];
+	}
+
+	let { ids }: Props = $props();
 	const storeKey = ids.join("-");
 	const group = getGroupStore(storeKey);
 
@@ -51,10 +55,10 @@
 				class="flex justify-center py-1.5 px-2.5 focus:outline-none
 			rounded-{i ? 'r' : 'l'}
 			{g.group !== $group && 'text-gray-500 filter grayscale'}"
-				on:click={() => changeGroup(g.group)}
+				onclick={() => changeGroup(g.group)}
 			>
 				{#if g.icon}
-					<svelte:component this={g.icon} classNames="mr-1.5" />
+					<g.icon classNames="mr-1.5" />
 				{/if}
 				<p class="!m-0 {g.classNames}">
 					{g.name}

--- a/kit/src/lib/FrameworkSwitchCourse.svelte
+++ b/kit/src/lib/FrameworkSwitchCourse.svelte
@@ -4,7 +4,11 @@
 	import IconPytorch from "./IconPytorch.svelte";
 	import IconTensorflow from "./IconTensorflow.svelte";
 
-	export let fw: CourseFramework;
+	interface Props {
+		fw: CourseFramework;
+	}
+
+	let { fw }: Props = $props();
 
 	const FRAMEWORKS = [
 		{
@@ -30,7 +34,7 @@
                 {f.id === fw ? f.classNames : 'text-gray-500 filter grayscale'}"
 			href="?fw={f.id}"
 		>
-			<svelte:component this={f.icon} classNames="mr-1.5" />
+			<f.icon classNames="mr-1.5" />
 			{f.name}
 		</a>
 	{/each}

--- a/kit/src/lib/Heading.svelte
+++ b/kit/src/lib/Heading.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import IconCopyLink from "./IconCopyLink.svelte";
 
-	export let title: string;
-	export let local: string;
-	export let headingTag: string;
+	interface Props {
+		title: string;
+		local: string;
+		headingTag: string;
+	}
+
+	let { title, local, headingTag }: Props = $props();
 </script>
 
 <!-- 

--- a/kit/src/lib/HfOption.svelte
+++ b/kit/src/lib/HfOption.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import { selectedHfOptions } from "./stores";
 
-	export let id: string;
-	export let option: string;
+	interface Props {
+		id: string;
+		option: string;
+		children?: import("svelte").Snippet;
+	}
+
+	let { id, option, children }: Props = $props();
 </script>
 
 {#if $selectedHfOptions[id] === option}
-	<slot />
+	{@render children?.()}
 {/if}

--- a/kit/src/lib/HfOptions.svelte
+++ b/kit/src/lib/HfOptions.svelte
@@ -3,8 +3,13 @@
 	import { selectedHfOptions } from "./stores";
 	import { getQueryParamValue, updateQueryParamAndReplaceHistory } from "./utils";
 
-	export let id: string;
-	export let options: string[];
+	interface Props {
+		id: string;
+		options: string[];
+		children?: import("svelte").Snippet;
+	}
+
+	let { id, options, children }: Props = $props();
 
 	$selectedHfOptions[id] = options[0];
 
@@ -28,7 +33,7 @@
 			{$selectedHfOptions[id] === option
 				? 'border-gray-800 bg-black dark:bg-gray-700 text-white'
 				: 'text-gray-500 cursor-pointer opacity-90 hover:text-gray-700 dark:hover:text-gray-200 hover:shadow-sm'}"
-			on:click={() => updateSelectedOption(option)}
+			onclick={() => updateSelectedOption(option)}
 		>
 			{option}
 		</div>
@@ -36,5 +41,5 @@
 </div>
 
 <div class="language-select">
-	<slot />
+	{@render children?.()}
 </div>

--- a/kit/src/lib/IconAnthropic.svelte
+++ b/kit/src/lib/IconAnthropic.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconArrowUpRight.svelte
+++ b/kit/src/lib/IconArrowUpRight.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCaret.svelte
+++ b/kit/src/lib/IconCaret.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCaretDown.svelte
+++ b/kit/src/lib/IconCaretDown.svelte
@@ -1,5 +1,9 @@
-<script>
-	export let classNames = "";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCode.svelte
+++ b/kit/src/lib/IconCode.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCopy.svelte
+++ b/kit/src/lib/IconCopy.svelte
@@ -1,5 +1,9 @@
-<script>
-	export let classNames = "";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCopyLink.svelte
+++ b/kit/src/lib/IconCopyLink.svelte
@@ -1,5 +1,9 @@
-<script>
-	export let classNames = "";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconCurl.svelte
+++ b/kit/src/lib/IconCurl.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconEyeHide.svelte
+++ b/kit/src/lib/IconEyeHide.svelte
@@ -1,6 +1,10 @@
-<script>
-	export let classNames = "";
-	export let size = "1em";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+		size?: string;
+	}
+
+	let { classNames = "", size = "1em" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconEyeShow.svelte
+++ b/kit/src/lib/IconEyeShow.svelte
@@ -1,6 +1,10 @@
-<script>
-	export let classNames = "";
-	export let size = "1em";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+		size?: string;
+	}
+
+	let { classNames = "", size = "1em" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconHuggingChat.svelte
+++ b/kit/src/lib/IconHuggingChat.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconJax.svelte
+++ b/kit/src/lib/IconJax.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconJs.svelte
+++ b/kit/src/lib/IconJs.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconMCP.svelte
+++ b/kit/src/lib/IconMCP.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconNode.svelte
+++ b/kit/src/lib/IconNode.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconOpenAI.svelte
+++ b/kit/src/lib/IconOpenAI.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconPython.svelte
+++ b/kit/src/lib/IconPython.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconPytorch.svelte
+++ b/kit/src/lib/IconPytorch.svelte
@@ -1,5 +1,9 @@
-<script>
-	export let classNames = "";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconRust.svelte
+++ b/kit/src/lib/IconRust.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/IconTensorflow.svelte
+++ b/kit/src/lib/IconTensorflow.svelte
@@ -1,5 +1,9 @@
-<script>
-	export let classNames = "";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceApi.svelte
+++ b/kit/src/lib/InferenceApi.svelte
@@ -1,3 +1,9 @@
+<!--
+	Intentionally kept in Svelte 4 (legacy) syntax: this component exposes named
+	slots whose names collide with its props, which the runes migration cannot
+	express as snippet props. Its slot API is consumed by the generated doc pages
+	(also legacy syntax); mixing legacy and runes components is fully supported.
+-->
 <script lang="ts">
 	import type { InferenceSnippetLang } from "./types";
 	import { onMount } from "svelte";

--- a/kit/src/lib/InferenceSnippet/IconInferenceBaseten.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceBaseten.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceBlackForest.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceBlackForest.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceCerebras.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceCerebras.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceClarifai.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceClarifai.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceCohere.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceCohere.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceFal.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceFal.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceFeatherless.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceFeatherless.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceFireworks.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceFireworks.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceGroq.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceGroq.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceHf.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceHf.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceHyperbolic.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceHyperbolic.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames: string = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceNebius.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceNebius.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames: string = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceNovita.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceNovita.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames: string = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceNscale.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceNscale.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceOvh.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceOvh.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferencePublicAI.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferencePublicAI.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceReplicate.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceReplicate.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceSambaNova.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceSambaNova.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceScaleway.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceScaleway.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceTogetherAI.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceTogetherAI.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceWavespeed.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceWavespeed.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconInferenceZai.svelte
+++ b/kit/src/lib/InferenceSnippet/IconInferenceZai.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconLinkExternal.svelte
+++ b/kit/src/lib/InferenceSnippet/IconLinkExternal.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/IconSettings.svelte
+++ b/kit/src/lib/InferenceSnippet/IconSettings.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
+++ b/kit/src/lib/InferenceSnippet/InferenceSnippet.svelte
@@ -6,7 +6,7 @@
 		PipelineType,
 	} from "@huggingface/tasks";
 	import { type InferenceProvider, snippets } from "@huggingface/inference";
-	import { onMount, SvelteComponent } from "svelte";
+	import { onMount, type Component } from "svelte";
 
 	import CodeBlock from "$lib/CodeBlock.svelte";
 	import IconCurl from "$lib/IconCurl.svelte";
@@ -42,21 +42,26 @@
 
 	type InferenceProviderNotOpenAI = Exclude<InferenceProvider, "openai">;
 
-	export let pipeline: PipelineType;
-	export let conversational = false;
-	export let providersMapping: Partial<
-		Record<
-			InferenceProviderNotOpenAI,
-			{
-				modelId: string;
-				providerModelId: string;
-			}
-		>
-	> = {};
+	interface Props {
+		pipeline: PipelineType;
+		conversational?: boolean;
+		providersMapping?: Partial<
+			Record<
+				InferenceProviderNotOpenAI,
+				{
+					modelId: string;
+					providerModelId: string;
+				}
+			>
+		>;
+		children?: import("svelte").Snippet;
+	}
 
-	let providers = Object.keys(providersMapping) as InferenceProviderNotOpenAI[];
-	let selectedProvider = providers[0];
-	let streaming = false;
+	let { pipeline, conversational = false, providersMapping = {}, children }: Props = $props();
+
+	let providers = $state(Object.keys(providersMapping) as InferenceProviderNotOpenAI[]);
+	let selectedProvider = $state(providers[0]);
+	let streaming = $state(false);
 
 	const availableSnippets = snippets.getInferenceSnippets(
 		{
@@ -74,36 +79,38 @@
 		}
 	);
 	const languages = [...new Set(availableSnippets.map((s) => s.language))];
-	let selectedLanguage = languages[0];
+	let selectedLanguage = $state(languages[0]);
 	const clientsByLanguage = Object.fromEntries(
 		languages.map((lang) => [
 			lang,
 			[...new Set(availableSnippets.filter((s) => s.language === lang).map((s) => s.client))],
 		])
 	);
-	$: clients = clientsByLanguage[selectedLanguage] ?? [];
-	$: selectedClient = clients?.[0];
+	let clients = $derived(clientsByLanguage[selectedLanguage] ?? []);
+	let selectedClient = $derived(clients?.[0]);
 
-	$: code = snippets
-		.getInferenceSnippets(
-			{
-				id: providersMapping[selectedProvider]!.modelId,
-				pipeline_tag: pipeline,
-				tags: conversational ? ["conversational"] : [],
-			} as ModelDataMinimal,
-			selectedProvider,
-			{
-				hfModelId: providersMapping[selectedProvider]!.modelId,
-				providerId: providersMapping[selectedProvider]!.providerModelId,
-				status: "live",
-				task: pipeline,
-				provider: selectedProvider,
-			},
-			{
-				streaming,
-			}
-		)
-		.find((s) => s.language === selectedLanguage && s.client === selectedClient)?.content;
+	let code = $derived(
+		snippets
+			.getInferenceSnippets(
+				{
+					id: providersMapping[selectedProvider]!.modelId,
+					pipeline_tag: pipeline,
+					tags: conversational ? ["conversational"] : [],
+				} as ModelDataMinimal,
+				selectedProvider,
+				{
+					hfModelId: providersMapping[selectedProvider]!.modelId,
+					providerId: providersMapping[selectedProvider]!.providerModelId,
+					status: "live",
+					task: pipeline,
+					provider: selectedProvider,
+				},
+				{
+					streaming,
+				}
+			)
+			.find((s) => s.language === selectedLanguage && s.client === selectedClient)?.content
+	);
 
 	const PRETTY_NAMES: Partial<
 		Record<InferenceProviderNotOpenAI | InferenceSnippetLanguage, string>
@@ -141,7 +148,7 @@
 	const ICONS: Partial<
 		Record<
 			InferenceProviderNotOpenAI | InferenceSnippetLanguage,
-			new (...args: any) => SvelteComponent
+			Component<{ classNames?: string }>
 		>
 	> = {
 		// inference providers
@@ -198,10 +205,11 @@
 							? 'border-gray-800 bg-black text-white dark:bg-gray-700'
 							: 'hover:shadow-xs cursor-pointer text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200'}"
 						type="button"
-						on:click={() => (selectedLanguage = language)}
+						onclick={() => (selectedLanguage = language)}
 					>
 						{#if ICONS[language]}
-							<svelte:component this={ICONS[language]} classNames="mr-1.5 text-current" />
+							{@const SvelteComponent_1 = ICONS[language]}
+							<SvelteComponent_1 classNames="mr-1.5 text-current" />
 						{/if}
 						{PRETTY_NAMES[language] ?? language}
 					</button>
@@ -222,7 +230,7 @@
 							? 'border-gray-800 bg-black text-white dark:bg-gray-700'
 							: 'hover:shadow-xs cursor-pointer text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200'}"
 						type="button"
-						on:click={() => (selectedClient = client)}
+						onclick={() => (selectedClient = client)}
 					>
 						{client}
 					</button>
@@ -244,41 +252,46 @@
 							? 'border-gray-800 bg-black text-white dark:bg-gray-700'
 							: 'hover:shadow-xs cursor-pointer text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200'}"
 						type="button"
-						on:click={() => (selectedProvider = provider)}
+						onclick={() => (selectedProvider = provider)}
 					>
 						{#if ICONS[provider]}
-							<svelte:component this={ICONS[provider]} classNames="mr-1.5 text-current" />
+							{@const SvelteComponent_2 = ICONS[provider]}
+							<SvelteComponent_2 classNames="mr-1.5 text-current" />
 						{/if}
 						{PRETTY_NAMES[provider] ?? provider}
 					</button>
 				{/each}
 				{#if providers.length > nVisibleProviders}
 					<Dropdown btnLabel="" classNames="colab-dropdown" noBtnClass useDeprecatedJS={false}>
-						<slot slot="button">
-							<p
-								class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
-							>
-								+{providers.length - nVisibleProviders}
-							</p>
-						</slot>
-						<slot slot="menu">
-							{#each providers.slice(nVisibleProviders) as provider, idx}
-								<DropdownEntry
-									classNames="text-sm !no-underline"
-									iconClassNames="mr-1.5 text-current"
-									icon={ICONS[provider]}
-									label={PRETTY_NAMES[provider] ?? provider}
-									useDeprecatedJS={false}
-									onClick={() => {
-										selectedProvider = provider;
-										providers = [
-											selectedProvider,
-											...providers.filter((p) => p !== selectedProvider),
-										];
-									}}
-								/>
-							{/each}
-						</slot>
+						{#snippet button()}
+							{#if children}{@render children()}{:else}
+								<p
+									class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
+								>
+									+{providers.length - nVisibleProviders}
+								</p>
+							{/if}
+						{/snippet}
+						{#snippet menu()}
+							{#if children}{@render children()}{:else}
+								{#each providers.slice(nVisibleProviders) as provider, idx}
+									<DropdownEntry
+										classNames="text-sm !no-underline"
+										iconClassNames="mr-1.5 text-current"
+										icon={ICONS[provider]}
+										label={PRETTY_NAMES[provider] ?? provider}
+										useDeprecatedJS={false}
+										onClick={() => {
+											selectedProvider = provider;
+											providers = [
+												selectedProvider,
+												...providers.filter((p) => p !== selectedProvider),
+											];
+										}}
+									/>
+								{/each}
+							{/if}
+						{/snippet}
 					</Dropdown>
 				{/if}
 			</div>
@@ -295,52 +308,56 @@
 				useDeprecatedJS={false}
 				forceMenuAlignement="right"
 			>
-				<slot slot="button">
-					<button
-						class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
-						type="button"
-						title="Settings dropdown"
-					>
-						<IconSettings classNames="mr-1" />
-						Settings
-					</button>
-				</slot>
-				<slot slot="menu">
-					<div class="flex flex-col gap-y-2 p-2">
-						{#if conversational}
-							<button
-								class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
-								on:click={() => (streaming = !streaming)}
-								type="button"
+				{#snippet button()}
+					{#if children}{@render children()}{:else}
+						<button
+							class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
+							type="button"
+							title="Settings dropdown"
+						>
+							<IconSettings classNames="mr-1" />
+							Settings
+						</button>
+					{/if}
+				{/snippet}
+				{#snippet menu()}
+					{#if children}{@render children()}{:else}
+						<div class="flex flex-col gap-y-2 p-2">
+							{#if conversational}
+								<button
+									class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
+									onclick={() => (streaming = !streaming)}
+									type="button"
+								>
+									<input
+										class="form-input not-prose do-not-close-dropdown"
+										type="checkbox"
+										bind:checked={streaming}
+										id="stream-checkbox"
+									/>
+									<span class="do-not-close-dropdown">Stream</span>
+								</button>
+							{/if}
+							<a
+								href="https://huggingface.co/settings/tokens"
+								class="flex items-center gap-x-1 whitespace-nowrap"
+								target="_blank"
+								title="Tokens settings"
 							>
-								<input
-									class="form-input not-prose do-not-close-dropdown"
-									type="checkbox"
-									bind:checked={streaming}
-									id="stream-checkbox"
-								/>
-								<span class="do-not-close-dropdown">Stream</span>
-							</button>
-						{/if}
-						<a
-							href="https://huggingface.co/settings/tokens"
-							class="flex items-center gap-x-1 whitespace-nowrap"
-							target="_blank"
-							title="Tokens settings"
-						>
-							<IconLinkExternal /> Manage tokens
-						</a>
+								<IconLinkExternal /> Manage tokens
+							</a>
 
-						<a
-							href="https://huggingface.co/settings/inference-providers/settings"
-							class="flex items-center gap-x-1 whitespace-nowrap"
-							title="Inference providers settings"
-							target="_blank"
-						>
-							<IconLinkExternal /> Manage providers
-						</a>
-					</div>
-				</slot>
+							<a
+								href="https://huggingface.co/settings/inference-providers/settings"
+								class="flex items-center gap-x-1 whitespace-nowrap"
+								title="Inference providers settings"
+								target="_blank"
+							>
+								<IconLinkExternal /> Manage providers
+							</a>
+						</div>
+					{/if}
+				{/snippet}
 			</Dropdown>
 			<Dropdown
 				classNames="md:hidden"
@@ -348,53 +365,57 @@
 				useDeprecatedJS={false}
 				forceMenuAlignement="left"
 			>
-				<slot slot="button">
-					<button
-						class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
-						type="button"
-						title="Settings dropdown"
-					>
-						<IconSettings classNames="mr-1" />
-						Settings
-					</button>
-				</slot>
-				<slot slot="menu">
-					<div class="flex flex-col gap-y-2 p-2">
-						{#if conversational}
-							<button
-								class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
-								on:click={() => (streaming = !streaming)}
-								type="button"
+				{#snippet button()}
+					{#if children}{@render children()}{:else}
+						<button
+							class="text-md hover:shadow-xs flex cursor-pointer select-none items-center rounded-lg border px-1.5 py-1 leading-none text-gray-500 opacity-90 hover:text-gray-700 dark:hover:text-gray-200"
+							type="button"
+							title="Settings dropdown"
+						>
+							<IconSettings classNames="mr-1" />
+							Settings
+						</button>
+					{/if}
+				{/snippet}
+				{#snippet menu()}
+					{#if children}{@render children()}{:else}
+						<div class="flex flex-col gap-y-2 p-2">
+							{#if conversational}
+								<button
+									class="text-md do-not-close-dropdown group relative flex w-full cursor-default items-center gap-x-2 self-start border-b pb-2 leading-tight"
+									onclick={() => (streaming = !streaming)}
+									type="button"
+								>
+									<input
+										class="form-input not-prose do-not-close-dropdown"
+										type="checkbox"
+										bind:checked={streaming}
+									/>
+									<span class="do-not-close-dropdown">Stream</span>
+								</button>
+							{/if}
+							<a
+								href="/settings/tokens"
+								class="flex items-center gap-x-1 whitespace-nowrap"
+								target="_blank"
+								title="Tokens settings"
 							>
-								<input
-									class="form-input not-prose do-not-close-dropdown"
-									type="checkbox"
-									bind:checked={streaming}
-								/>
-								<span class="do-not-close-dropdown">Stream</span>
-							</button>
-						{/if}
-						<a
-							href="/settings/tokens"
-							class="flex items-center gap-x-1 whitespace-nowrap"
-							target="_blank"
-							title="Tokens settings"
-						>
-							<IconLinkExternal /> Manage tokens
-						</a>
+								<IconLinkExternal /> Manage tokens
+							</a>
 
-						<a
-							href="/settings/inference-providers"
-							class="flex items-center gap-x-1 whitespace-nowrap"
-							title="Inference providers settings"
-							target="_blank"
-						>
-							<IconLinkExternal /> Manage providers
-						</a>
-					</div>
-				</slot>
+							<a
+								href="/settings/inference-providers"
+								class="flex items-center gap-x-1 whitespace-nowrap"
+								title="Inference providers settings"
+								target="_blank"
+							>
+								<IconLinkExternal /> Manage providers
+							</a>
+						</div>
+					{/if}
+				{/snippet}
 			</Dropdown>
-			<div class="flex-grow md:hidden" />
+			<div class="flex-grow md:hidden"></div>
 		</div>
 	</div>
 </div>

--- a/kit/src/lib/Markdown.svelte
+++ b/kit/src/lib/Markdown.svelte
@@ -1,2 +1,10 @@
+<script lang="ts">
+	interface Props {
+		children?: import("svelte").Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
 <!-- used for FrameworkContent.svelte as a slot for markdown -->
-<slot />
+{@render children?.()}

--- a/kit/src/lib/MermaidChart.svelte
+++ b/kit/src/lib/MermaidChart.svelte
@@ -2,10 +2,14 @@
 	import { onMount } from "svelte";
 	import mermaid from "mermaid";
 
-	export let code = "";
-	export let classNames = "";
+	interface Props {
+		code?: string;
+		classNames?: string;
+	}
 
-	let container: HTMLDivElement;
+	let { code = "", classNames = "" }: Props = $props();
+
+	let container = $state<HTMLDivElement>()!;
 	let chartId: string;
 
 	onMount(async () => {

--- a/kit/src/lib/PipelineIcon.svelte
+++ b/kit/src/lib/PipelineIcon.svelte
@@ -32,8 +32,12 @@
 	import IconUnconditionalImageGeneration from "./PipelineIcons/IconUnconditionalImageGeneration.svelte";
 	import IconDocumentQuestionAnswering from "./PipelineIcons/IconDocumentQuestionAnswering.svelte";
 
-	export let classNames = "";
-	export let pipeline = "";
+	interface Props {
+		classNames?: string;
+		pipeline?: string;
+	}
+
+	let { classNames = "", pipeline = "" }: Props = $props();
 
 	type SvelteComponent = typeof IconTextClassification;
 
@@ -75,9 +79,8 @@
 	const PIPELINE_TAG_ICO_CLASS = Object.fromEntries(
 		Object.entries(PIPELINE_DATA).map(([tagType, data]) => [tagType, `tag-ico-${data.color}`])
 	);
+
+	const SvelteComponent = $derived(ICON_COMPONENTS[pipeline] ?? IconFillMask);
 </script>
 
-<svelte:component
-	this={ICON_COMPONENTS[pipeline] ?? IconFillMask}
-	classNames="{classNames} tag-ico {PIPELINE_TAG_ICO_CLASS[pipeline]}"
-/>
+<SvelteComponent classNames="{classNames} tag-ico {PIPELINE_TAG_ICO_CLASS[pipeline]}" />

--- a/kit/src/lib/PipelineIcons/IconAudioClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconAudioClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconAudioToAudio.svelte
+++ b/kit/src/lib/PipelineIcons/IconAudioToAudio.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconAutomaticSpeechRecognition.svelte
+++ b/kit/src/lib/PipelineIcons/IconAutomaticSpeechRecognition.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconConversational.svelte
+++ b/kit/src/lib/PipelineIcons/IconConversational.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconDocumentQuestionAnswering.svelte
+++ b/kit/src/lib/PipelineIcons/IconDocumentQuestionAnswering.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg class={classNames} width="1em" height="1em" viewBox="0 0 32 32"

--- a/kit/src/lib/PipelineIcons/IconFeatureExtraction.svelte
+++ b/kit/src/lib/PipelineIcons/IconFeatureExtraction.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconFillMask.svelte
+++ b/kit/src/lib/PipelineIcons/IconFillMask.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconImageClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconImageClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconImageSegmentation.svelte
+++ b/kit/src/lib/PipelineIcons/IconImageSegmentation.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconImageToImage.svelte
+++ b/kit/src/lib/PipelineIcons/IconImageToImage.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconImageToText.svelte
+++ b/kit/src/lib/PipelineIcons/IconImageToText.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 ​

--- a/kit/src/lib/PipelineIcons/IconObjectDetection.svelte
+++ b/kit/src/lib/PipelineIcons/IconObjectDetection.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconQuestionAnswering.svelte
+++ b/kit/src/lib/PipelineIcons/IconQuestionAnswering.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconReinforcementLearning.svelte
+++ b/kit/src/lib/PipelineIcons/IconReinforcementLearning.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconRobotics.svelte
+++ b/kit/src/lib/PipelineIcons/IconRobotics.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconSentenceSimilarity.svelte
+++ b/kit/src/lib/PipelineIcons/IconSentenceSimilarity.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconSummarization.svelte
+++ b/kit/src/lib/PipelineIcons/IconSummarization.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTableQuestionAnswering.svelte
+++ b/kit/src/lib/PipelineIcons/IconTableQuestionAnswering.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTabularClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconTabularClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTabularRegression.svelte
+++ b/kit/src/lib/PipelineIcons/IconTabularRegression.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconText2textGeneration.svelte
+++ b/kit/src/lib/PipelineIcons/IconText2textGeneration.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTextClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconTextClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTextGeneration.svelte
+++ b/kit/src/lib/PipelineIcons/IconTextGeneration.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTextToImage.svelte
+++ b/kit/src/lib/PipelineIcons/IconTextToImage.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTextToSpeech.svelte
+++ b/kit/src/lib/PipelineIcons/IconTextToSpeech.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTokenClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconTokenClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconTranslation.svelte
+++ b/kit/src/lib/PipelineIcons/IconTranslation.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconUnconditionalImageGeneration.svelte
+++ b/kit/src/lib/PipelineIcons/IconUnconditionalImageGeneration.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconVoiceActivityDetection.svelte
+++ b/kit/src/lib/PipelineIcons/IconVoiceActivityDetection.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineIcons/IconZeroShotClassification.svelte
+++ b/kit/src/lib/PipelineIcons/IconZeroShotClassification.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let classNames = "";
+	interface Props {
+		classNames?: string;
+	}
+
+	let { classNames = "" }: Props = $props();
 </script>
 
 <svg

--- a/kit/src/lib/PipelineTag.svelte
+++ b/kit/src/lib/PipelineTag.svelte
@@ -2,8 +2,12 @@
 	import { PIPELINE_DATA } from "./pipeline";
 	import PipelineIcon from "./PipelineIcon.svelte";
 
-	export let classNames = "";
-	export let pipeline = "";
+	interface Props {
+		classNames?: string;
+		pipeline?: string;
+	}
+
+	let { classNames = "", pipeline = "" }: Props = $props();
 </script>
 
 <div class="inline-flex items-center border pr-1 rounded-xl {classNames}">

--- a/kit/src/lib/Question.svelte
+++ b/kit/src/lib/Question.svelte
@@ -3,7 +3,11 @@
 
 	import { answers } from "./stores";
 
-	export let choices: Choice[];
+	interface Props {
+		choices: Choice[];
+	}
+
+	let { choices }: Props = $props();
 
 	interface Choice {
 		text: string;
@@ -14,10 +18,10 @@
 
 	const id = randomId();
 
-	let isFalse: boolean = false;
-	let isIncomplete: boolean = false;
-	let selected: number[] = [];
-	let submitted: number[] = [];
+	let isFalse: boolean = $state(false);
+	let isIncomplete: boolean = $state(false);
+	let selected: number[] = $state([]);
+	let submitted: number[] = $state([]);
 
 	onMount(() => {
 		$answers = { ...$answers, [id]: { correct: false } };
@@ -54,7 +58,12 @@
 </script>
 
 <div>
-	<form on:submit|preventDefault={() => checkAnswer()}>
+	<form
+		onsubmit={(event) => {
+			event.preventDefault();
+			checkAnswer();
+		}}
+	>
 		{#each choices as choice, index}
 			<label class="block">
 				<input

--- a/kit/src/lib/Tip.svelte
+++ b/kit/src/lib/Tip.svelte
@@ -1,7 +1,12 @@
-<script>
-	export let warning = false;
+<script lang="ts">
+	interface Props {
+		warning?: boolean;
+		children?: import("svelte").Snippet;
+	}
+
+	let { warning = false, children }: Props = $props();
 </script>
 
 <blockquote class={warning ? "warning" : "tip"}>
-	<slot />
+	{@render children?.()}
 </blockquote>

--- a/kit/src/lib/TokenizersLanguageContent.svelte
+++ b/kit/src/lib/TokenizersLanguageContent.svelte
@@ -1,3 +1,9 @@
+<!--
+	Intentionally kept in Svelte 4 (legacy) syntax: this component exposes named
+	slots whose names collide with its props, which the runes migration cannot
+	express as snippet props. Its slot API is consumed by the generated doc pages
+	(also legacy syntax); mixing legacy and runes components is fully supported.
+-->
 <script lang="ts">
 	import type { TokenizersLanguage } from "./types";
 	import { onMount } from "svelte";

--- a/kit/src/lib/Tooltip.svelte
+++ b/kit/src/lib/Tooltip.svelte
@@ -1,7 +1,15 @@
-<script>
-	export let classNames = "";
-	export let label = "Copied";
-	export let position = "left-1/2 top-full transform -translate-x-1/2 translate-y-2";
+<script lang="ts">
+	interface Props {
+		classNames?: string;
+		label?: string;
+		position?: string;
+	}
+
+	let {
+		classNames = "",
+		label = "Copied",
+		position = "left-1/2 top-full transform -translate-x-1/2 translate-y-2",
+	}: Props = $props();
 </script>
 
 <div
@@ -17,6 +25,6 @@
 				border-left-color: transparent;
 				border-right-color: transparent;
 			"
-	/>
+	></div>
 	{label}
 </div>

--- a/kit/src/lib/TooltipFromAction.svelte
+++ b/kit/src/lib/TooltipFromAction.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-	export let txt: string;
-	export let x: number;
-	export let y: number;
-	export let id: string;
+	interface Props {
+		txt: string;
+		x: number;
+		y: number;
+		id: string;
+	}
+
+	let { txt, x, y, id }: Props = $props();
 </script>
 
 {#if txt}

--- a/kit/src/lib/Youtube.svelte
+++ b/kit/src/lib/Youtube.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let id: string;
+	interface Props {
+		id: string;
+	}
+
+	let { id }: Props = $props();
 </script>
 
 <iframe
@@ -9,4 +13,4 @@
 	frameborder="0"
 	allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
 	allowfullscreen
-/>
+></iframe>

--- a/kit/src/lib/tooltipAction.svelte.ts
+++ b/kit/src/lib/tooltipAction.svelte.ts
@@ -1,35 +1,36 @@
+import { mount, unmount } from "svelte";
 import Tooltip from "./TooltipFromAction.svelte";
 
 const id = "docstring-tooltip";
 
-export function tooltip(element: HTMLElement, txt: string): any {
-	let tooltipComponent: any;
+export function tooltip(element: HTMLElement, txt: string) {
+	let tooltipComponent: Record<string, unknown> | undefined;
+	const props = $state({ txt, x: 0, y: 0, id });
+
 	function mouseOver(event: MouseEvent) {
 		cleanPrevious();
-		tooltipComponent = new Tooltip({
-			props: {
-				txt,
-				x: event.pageX,
-				y: event.pageY,
-				id,
-			},
+		props.x = event.pageX;
+		props.y = event.pageY;
+		tooltipComponent = mount(Tooltip, {
 			target: document.body,
+			props,
 		});
 	}
 	function mouseMove(event: MouseEvent) {
-		tooltipComponent.$set({
-			x: event.pageX,
-			y: event.pageY,
-		});
+		props.x = event.pageX;
+		props.y = event.pageY;
 	}
 	function mouseLeave() {
-		tooltipComponent.$destroy();
+		if (tooltipComponent) {
+			unmount(tooltipComponent);
+			tooltipComponent = undefined;
+		}
 	}
 
 	function cleanPrevious() {
-		const tooltipComponent = document.getElementById(id);
-		if (tooltipComponent) {
-			tooltipComponent.parentNode?.removeChild(tooltipComponent);
+		const previousTooltip = document.getElementById(id);
+		if (previousTooltip) {
+			previousTooltip.parentNode?.removeChild(previousTooltip);
 		}
 	}
 

--- a/kit/src/routes/+layout.svelte
+++ b/kit/src/routes/+layout.svelte
@@ -7,8 +7,8 @@
 	import type { RawChapter } from "./endpoints/toc/+server";
 	import "../app.css";
 
-	export let data;
-	$: toc = (data.toc ?? []) as RawChapter[];
+	let { data, children } = $props();
+	let toc = $derived((data.toc ?? []) as RawChapter[]);
 
 	/**
 	 * Shorthand hf doc links (e.g. /docs/lib/page) should partial-load like
@@ -62,7 +62,7 @@
 </script>
 
 {#if !import.meta.env.DEV}
-	<slot />
+	{@render children?.()}
 {:else}
 	<style>
 		body,
@@ -94,7 +94,7 @@
 		</div>
 		<div class="px-4 pt-3 grow">
 			<div class="prose prose-doc dark:prose-light max-w-4xl mx-auto break-words relative">
-				<slot />
+				{@render children?.()}
 			</div>
 		</div>
 		<div class="w-[270px] 2xl:w-[305px] hidden lg:block border-l-2 shrink-0 opacity-50 p-4">


### PR DESCRIPTION
## What

Migrates all `kit/src` components (110 files) from Svelte 4 legacy syntax to runes (`$props`/`$state`/`$derived`, event attributes, snippets), using `migrate()` from `svelte/compiler` plus manual finishing. Follow-up to #792.

## ⚠️ Includes a production fix

Docstring parameter tooltips have been **silently broken since #792**: `src/lib/tooltip.ts` used the Svelte 4 class API (`new Tooltip({...})`, `$set`, `$destroy`), which throws on Svelte 5 components — the error was swallowed by the hover handler, so nothing surfaced in builds. Rewritten as a `.svelte.ts` action using `mount`/`unmount` with reactive `$state` props. Verified in a browser against the Svelte 4 baseline: tooltips mount on hover and unmount on leave, exactly like before the upgrade.

## Notable decisions

- **3 components intentionally stay legacy** (`FrameworkContent`, `InferenceApi`, `TokenizersLanguageContent`): they expose named slots (`pytorch`, `python`, …) that collide with same-named props, which snippet props cannot express. Their slot API is consumed by the generated doc pages (also legacy syntax); mixing legacy and runes components is fully supported by Svelte 5. Each carries a comment explaining this.
- Generated doc pages (mdx → `+page.svelte`) remain legacy syntax by design — they're emitted by the Python/mdsvex pipeline; legacy pages rendering runes components (children snippets) is standard interop.
- `svelte/legacy` shims the migrator inserted (`preventDefault`, `stopPropagation`, `handlers`) were replaced with plain event handlers — zero `svelte/legacy` imports remain.
- Icon/component props are now typed `Component<{ classNames?: string }>` instead of constructor signatures.
- `state_referenced_locally` warnings are silenced in `onwarn`: the flagged initial-value captures have identical semantics to the previous Svelte 4 code (doc pages pass static props), and they would flood every downstream doc build log. They remain visible in `svelte-check`.

## Verification

- `svelte-check`: 0 errors
- **hub-docs build (268 pages)**: output identical to pre-migration on every compared dimension (metadata, visible text, hrefs, imgs, heading ids, code blocks)
- **accelerate e2e** (same as CI workflow): equivalent to the original Svelte 4 baseline (only the known Svelte-5 whitespace-trim diffs from #792)
- **Browser tests** (Chrome via playwright, against built docs): hydration, SPA navigation, shorthand-URL preservation (#794 behavior), HfOptions tab switching, docstring tooltip mount/unmount, docstring expand/collapse parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)