### PR TITLE
Simplify docstring pipeline: python emits the <Docstring> component directly

### DIFF
--- a/kit/preprocessors/docstring.js
+++ b/kit/preprocessors/docstring.js
@@ -3,46 +3,50 @@ import htmlparser2 from "htmlparser2";
 import { replaceAsync, renderSvelteChars, generateTagRegex } from "./utils.js";
 import { mdsvexPreprocess } from "./mdsvex/index.js";
 
-// Preprocessor that converts markdown into Docstring
-// svelte component using mdsvexPreprocess
+const REGEX_PARAMSDESC = generateTagRegex("paramsdesc");
+const REGEX_PARAMSGROUP = generateTagRegex("paramsgroup", true);
+const REGEX_PARAMSGROUP_TITLE = generateTagRegex("paramsgrouptitle");
+const REGEX_PARAMSGROUP_DESC = generateTagRegex("paramsgroupdesc");
+const REGEX_RETDESC = generateTagRegex("retdesc");
+const REGEX_RETTYPE = generateTagRegex("rettype");
+// note: fixes a long-standing tag mismatch (python emits `yielddesc`, the old regex
+// matched `yieldesc`), which silently dropped yield descriptions
+const REGEX_YIELDESC = generateTagRegex("yielddesc");
+const REGEX_YIELDTYPE = generateTagRegex("yieldtype");
+const REGEX_RAISEDESC = generateTagRegex("raises");
+const REGEX_RAISETYPE = generateTagRegex("raisederrors");
+const REGEX_TIP = /<Tip( warning={true})?>(((?!<Tip( warning={true})?>).)*)<\/Tip>/gms;
+const REGEX_CHANGED =
+	/<(Added|Changed|Deprecated) version="([0-9.v]+)" ?\/?>((((?!<(Added|Changed|Deprecated) version="([0-9.v]+)"\/?>).)*)<\/(Added|Changed|Deprecated)>)?/gms;
+
+/**
+ * Python (doc_builder/autodoc.py) emits the `<Docstring ...metadata props...>` component
+ * directly; its body carries the markdown-bearing sections (parameter descriptions,
+ * return/yield/raise types & descriptions), which must be rendered with the same mdsvex
+ * pipeline as the rest of the page. This preprocessor renders those sections into the
+ * remaining component props and closes the component.
+ */
 export const docstringPreprocess = {
 	markup: async ({ content, filename }) => {
-		const REGEX_DOCSTRING = generateTagRegex("docstring", true);
-		const REGEX_NAME = generateTagRegex("name");
-		const REGEX_ANCHOR = generateTagRegex("anchor");
-		const REGEX_SIGNATURE = generateTagRegex("parameters");
-		const REGEX_PARAMSDESC = generateTagRegex("paramsdesc");
-		const REGEX_PARAMSGROUPS = generateTagRegex("paramgroups");
-		const REGEX_RETDESC = generateTagRegex("retdesc");
-		const REGEX_RETTYPE = generateTagRegex("rettype");
-		const REGEX_YIELDESC = generateTagRegex("yieldesc");
-		const REGEX_YIELDTYPE = generateTagRegex("yieldtype");
-		const REGEX_RAISEDESC = generateTagRegex("raises");
-		const REGEX_RAISETYPE = generateTagRegex("raisederrors");
-		const REGEX_SOURCE = generateTagRegex("source");
-		const REGEX_TIP = /<Tip( warning={true})?>(((?!<Tip( warning={true})?>).)*)<\/Tip>/gms;
-		const REGEX_CHANGED =
-			/<(Added|Changed|Deprecated) version="([0-9.v]+)" ?\/?>((((?!<(Added|Changed|Deprecated) version="([0-9.v]+)"\/?>).)*)<\/(Added|Changed|Deprecated)>)?/gms;
-		const REGEX_IS_GETSET_DESC = /<isgetsetdescriptor>/ms;
+		// The open tag ends at the first `>` followed by a newline: attribute values are
+		// single-line JSON, which may contain `>` inside strings but never a raw newline.
+		const REGEX_DOCSTRING = /<Docstring((?:(?!>\n)[\s\S])*)>\n([\s\S]*?)<\/Docstring>/g;
 
-		content = await replaceAsync(content, REGEX_DOCSTRING, async (_, docstringBody) => {
-			docstringBody = renderSvelteChars(docstringBody);
+		content = await replaceAsync(content, REGEX_DOCSTRING, async (_, metadataAttrs, body) => {
+			body = renderSvelteChars(body);
 
-			const name = docstringBody.match(REGEX_NAME)[1];
-			const anchor = docstringBody.match(REGEX_ANCHOR)[1];
-			const signature = docstringBody.match(REGEX_SIGNATURE)[1];
+			// parameter anchors are prefixed with the object's anchor
+			const anchor = metadataAttrs.match(/ anchor=\{"((?:[^"\\]|\\.)*)"\}/)?.[1] ?? "";
 
-			let svelteComponent = `<Docstring name={${JSON.stringify(
-				unescapeUnderscores(name)
-			)}} anchor={${JSON.stringify(anchor)}} parameters={${signature}} `;
+			let svelteComponent = `<Docstring${metadataAttrs} `;
 
-			if (docstringBody.match(REGEX_PARAMSDESC)) {
-				let content = docstringBody.match(REGEX_PARAMSDESC)[1];
+			if (body.match(REGEX_PARAMSDESC)) {
+				let paramsContent = body.match(REGEX_PARAMSDESC)[1];
 				// escape }} by adding void character `&zwnj;` in between
-				content = content.replace(/}}/g, "}&zwnj;}");
-				let { code } = await mdsvexPreprocess.markup({ content, filename });
+				paramsContent = paramsContent.replace(/}}/g, "}&zwnj;}");
+				let { code } = await mdsvexPreprocess.markup({ content: paramsContent, filename });
 				// render <Tip> components that are inside parameter descriptions
-				code = code.replace(REGEX_TIP, (_, isWarning, tipContent) => {
+				code = code.replace(REGEX_TIP, (_tip, isWarning, tipContent) => {
 					const color = isWarning ? "orange" : "green";
 					return `<div
 						class="course-tip ${
@@ -53,12 +57,14 @@ export const docstringPreprocess = {
 					</div>`;
 				});
 				// render <Added>, <Changed>, <Deprecated> components that are inside parameter descriptions
-				code = code.replace(REGEX_CHANGED, (_, componentType, version, __, descriptionContent) => {
-					const color = /Added|Changed/.test(componentType) ? "green" : "orange";
-					if (!descriptionContent) {
-						descriptionContent = "";
-					}
-					return `<div
+				code = code.replace(
+					REGEX_CHANGED,
+					(_changed, componentType, version, __, descriptionContent) => {
+						const color = /Added|Changed/.test(componentType) ? "green" : "orange";
+						if (!descriptionContent) {
+							descriptionContent = "";
+						}
+						return `<div
 						class="course-tip ${
 							color === "orange" ? "course-tip-orange" : ""
 						} bg-gradient-to-br dark:bg-gradient-to-r before:border-${color}-500 dark:before:border-${color}-800 from-${color}-50 dark:from-gray-900 to-white dark:to-gray-950 border border-${color}-50 text-${color}-700 dark:text-gray-400"
@@ -66,120 +72,63 @@ export const docstringPreprocess = {
 						<p class="font-medium">${componentType} in ${version}</p>
 						${descriptionContent}
 					</div>`;
-				});
-
-				const dom = htmlparser2.parseDocument(code);
-				const lists = domUtils.getElementsByTagName("ul", dom);
-				if (lists.length) {
-					const list = lists[0];
-					const result = [];
-					for (const childEl of list.childNodes.filter(({ type }) => type === "tag")) {
-						const nameEl = domUtils.getElementsByTagName("strong", childEl)[0];
-						const name = domUtils.innerText(nameEl);
-						const paramAnchor = `${anchor}.${name}`;
-						let description = domUtils.getInnerHTML(childEl).trim();
-
-						// strip enclosing paragraph tags <p> & </p>
-						if (description.startsWith("<p>")) {
-							description = description.slice("<p>".length);
-						}
-						if (description.endsWith("</p>")) {
-							description = description.slice(0, -"</p>".length);
-						}
-
-						result.push({ anchor: paramAnchor, description, name });
 					}
+				);
+
+				const result = parseRenderedParamsList(code, anchor);
+				if (result) {
 					svelteComponent += ` parametersDescription={${JSON.stringify(result)}} `;
 				}
 			}
 
-			if (docstringBody.match(REGEX_SOURCE)) {
-				const source = docstringBody.match(REGEX_SOURCE)[1];
-				svelteComponent += ` source={${JSON.stringify(source)}} `;
-			}
-
-			if (docstringBody.match(REGEX_RETDESC)) {
-				const retDesc = docstringBody.match(REGEX_RETDESC)[1];
+			if (body.match(REGEX_RETDESC)) {
+				const retDesc = body.match(REGEX_RETDESC)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: retDesc, filename });
 				svelteComponent += ` returnDescription={${JSON.stringify(code)}} `;
 			}
 
-			if (docstringBody.match(REGEX_RETTYPE)) {
-				const retType = docstringBody.match(REGEX_RETTYPE)[1];
+			if (body.match(REGEX_RETTYPE)) {
+				const retType = body.match(REGEX_RETTYPE)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: retType, filename });
 				svelteComponent += ` returnType={${JSON.stringify(code)}} `;
 			}
 
-			if (docstringBody.match(REGEX_YIELDESC)) {
-				const yieldDesc = docstringBody.match(REGEX_YIELDESC)[1];
+			if (body.match(REGEX_YIELDESC)) {
+				const yieldDesc = body.match(REGEX_YIELDESC)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: yieldDesc, filename });
 				svelteComponent += ` returnDescription={${JSON.stringify(code)}} `;
 			}
 
-			if (docstringBody.match(REGEX_YIELDTYPE)) {
-				const yieldType = docstringBody.match(REGEX_YIELDTYPE)[1];
+			if (body.match(REGEX_YIELDTYPE)) {
+				const yieldType = body.match(REGEX_YIELDTYPE)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: yieldType, filename });
 				svelteComponent += ` returnType={${JSON.stringify(code)}} isYield={true} `;
 			}
 
-			if (docstringBody.match(REGEX_RAISEDESC)) {
-				const raiseDesc = docstringBody.match(REGEX_RAISEDESC)[1];
+			if (body.match(REGEX_RAISEDESC)) {
+				const raiseDesc = body.match(REGEX_RAISEDESC)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: raiseDesc, filename });
 				svelteComponent += ` raiseDescription={${JSON.stringify(code)}} `;
 			}
 
-			if (docstringBody.match(REGEX_RAISETYPE)) {
-				const raiseType = docstringBody.match(REGEX_RAISETYPE)[1];
+			if (body.match(REGEX_RAISETYPE)) {
+				const raiseType = body.match(REGEX_RAISETYPE)[1];
 				const { code } = await mdsvexPreprocess.markup({ content: raiseType, filename });
 				svelteComponent += ` raiseType={${JSON.stringify(code)}} `;
 			}
 
-			if (docstringBody.match(REGEX_IS_GETSET_DESC)) {
-				svelteComponent += ` isGetSetDescriptor={true} `;
+			const parameterGroups = [];
+			for (const [, groupBody] of body.matchAll(REGEX_PARAMSGROUP)) {
+				const title = groupBody.match(REGEX_PARAMSGROUP_TITLE)[1];
+				const groupContent = groupBody.match(REGEX_PARAMSGROUP_DESC)[1];
+				const { code } = await mdsvexPreprocess.markup({ content: groupContent, filename });
+				parameterGroups.push({
+					title,
+					parametersDescription: parseRenderedParamsList(code, anchor) ?? [],
+				});
 			}
-
-			if (docstringBody.match(REGEX_PARAMSGROUPS)) {
-				const nParamGroups = parseInt(docstringBody.match(REGEX_PARAMSGROUPS)[1]);
-				if (nParamGroups > 0) {
-					const parameterGroups = [];
-					for (let groupId = 1; groupId <= nParamGroups; groupId++) {
-						const REGEX_GROUP_TITLE = new RegExp(
-							`<paramsdesc${groupId}title>(((?!<paramsdesc${groupId}title>).)*)</paramsdesc${groupId}title>`,
-							"ms"
-						);
-						const REGEX_GROUP_CONTENT = new RegExp(
-							`<paramsdesc${groupId}>(((?!<paramsdesc${groupId}>).)*)</paramsdesc${groupId}>`,
-							"ms"
-						);
-						const title = docstringBody.match(REGEX_GROUP_TITLE)[1];
-						const content = docstringBody.match(REGEX_GROUP_CONTENT)[1];
-						const { code } = await mdsvexPreprocess.markup({ content, filename });
-						const dom = htmlparser2.parseDocument(code);
-						const lists = domUtils.getElementsByTagName("ul", dom);
-						const result = [];
-						if (lists.length) {
-							const list = lists[0];
-							for (const childEl of list.childNodes.filter(({ type }) => type === "tag")) {
-								const nameEl = domUtils.getElementsByTagName("strong", childEl)[0];
-								const name = domUtils.innerText(nameEl);
-								const paramAnchor = `${anchor}.${name}`;
-								let description = domUtils.getInnerHTML(childEl).trim();
-
-								// strip enclosing paragraph tags <p> & </p>
-								if (description.startsWith("<p>")) {
-									description = description.slice("<p>".length);
-								}
-								if (description.endsWith("</p>")) {
-									description = description.slice(0, -"</p>".length);
-								}
-
-								result.push({ anchor: paramAnchor, description, name });
-							}
-						}
-						parameterGroups.push({ title, parametersDescription: result });
-					}
-					svelteComponent += ` parameterGroups={${JSON.stringify(parameterGroups)}} `;
-				}
+			if (parameterGroups.length) {
+				svelteComponent += ` parameterGroups={${JSON.stringify(parameterGroups)}} `;
 			}
 
 			svelteComponent += ` />\n`;
@@ -191,8 +140,35 @@ export const docstringPreprocess = {
 };
 
 /**
- * The mdx file contains unnecessarily escaped underscores in the docstring's name
+ * The parameter descriptions are authored as a markdown bullet list (`- **name** -- desc`)
+ * and must be rendered as one list to keep exact markdown semantics (tight/loose lists);
+ * this parses the rendered `<ul>` back into per-parameter structured data for the
+ * `Docstring` component (tooltips, per-parameter anchors).
+ * @param {string} code rendered html
+ * @param {string} anchor the object's anchor, used as prefix for parameter anchors
  */
-function unescapeUnderscores(content) {
-	return content.replace(/\\_/g, "_");
+function parseRenderedParamsList(code, anchor) {
+	const dom = htmlparser2.parseDocument(code);
+	const lists = domUtils.getElementsByTagName("ul", dom);
+	if (!lists.length) {
+		return undefined;
+	}
+	const result = [];
+	for (const childEl of lists[0].childNodes.filter(({ type }) => type === "tag")) {
+		const nameEl = domUtils.getElementsByTagName("strong", childEl)[0];
+		const name = domUtils.innerText(nameEl);
+		const paramAnchor = `${anchor}.${name}`;
+		let description = domUtils.getInnerHTML(childEl).trim();
+
+		// strip enclosing paragraph tags <p> & </p>
+		if (description.startsWith("<p>")) {
+			description = description.slice("<p>".length);
+		}
+		if (description.endsWith("</p>")) {
+			description = description.slice(0, -"</p>".length);
+		}
+
+		result.push({ anchor: paramAnchor, description, name });
+	}
+	return result;
 }

--- a/kit/svelte.config.js
+++ b/kit/svelte.config.js
@@ -55,7 +55,10 @@ const config = {
 			warning.code?.startsWith("a11y") ||
 			warning.message.includes("A11y") ||
 			// md-generated doc content is full of `<video ... />` style self-closing tags
-			warning.code === "element_invalid_self_closing_tag"
+			warning.code === "element_invalid_self_closing_tag" ||
+			// initial-value capture of props is intentional here: doc pages pass
+			// static props (same semantics as the pre-runes svelte 4 code)
+			warning.code === "state_referenced_locally"
 		) {
 			/// Too noisy
 			return;

--- a/src/doc_builder/autodoc.py
+++ b/src/doc_builder/autodoc.py
@@ -194,29 +194,36 @@ def get_signature_component_svelte(name, anchor, signature, object_doc, source_l
     object_doc = remove_example_tags(object_doc)
     object_doc = hashlink_example_codeblock(object_doc, anchor)
 
-    svelte_str = "<docstring>"
-    svelte_str += f"<name>{name}</name>"
-    svelte_str += f"<anchor>{anchor}</anchor>"
+    # Metadata props are emitted directly as svelte component attributes. Their values
+    # are JS strings/JSON, where `{`, `<` and `#` are safe, so the MDX escaping
+    # (see `convert_special_chars`) is undone; `\_` needs no markdown escaping either.
+    def prop_value(text):
+        return text.replace("&amp;lcub;", "{").replace("&amp;lt;", "<").replace("&amp;num;", "#")
+
+    name = prop_value(str(name)).replace("\\_", "_")
+    svelte_str = f"<Docstring name={{{json.dumps(name)}}}"
+    svelte_str += f" anchor={{{json.dumps(prop_value(str(anchor)))}}}"
     if source_link:
-        svelte_str += f"<source>{source_link}</source>"
-    svelte_str += f"<parameters>{json.dumps(signature)}</parameters>"
+        svelte_str += f" source={{{json.dumps(prop_value(source_link))}}}"
+    svelte_str += f" parameters={{{prop_value(json.dumps(signature))}}}"
     if is_getset_desc:
-        svelte_str += "<isgetsetdescriptor>"
+        svelte_str += " isGetSetDescriptor={true}"
+    # the open tag must end with `>\n`: attribute values are single-line JSON, so the
+    # kit preprocessor (kit/preprocessors/docstring.js) can find the end of the tag
+    # unambiguously. The body carries the markdown-bearing sections, which the kit
+    # preprocessor renders (mdsvex) into the remaining props.
+    svelte_str += ">\n"
 
     if parameters is not None:
-        parameters_str = ""
         groups = _re_parameter_group.split(parameters)
         group_default = groups.pop(0)
-        parameters_str += f"<paramsdesc>{group_default}</paramsdesc>"
-        n_groups = len(groups) // 2
-        for idx in range(n_groups):
-            id = idx + 1
+        svelte_str += f"<paramsdesc>{group_default}</paramsdesc>"
+        for idx in range(len(groups) // 2):
             title, group = groups[2 * idx], groups[2 * idx + 1]
-            parameters_str += f"<paramsdesc{id}title>{title}</paramsdesc{id}title>"
-            parameters_str += f"<paramsdesc{id}>{group}</paramsdesc{id}>"
-
-        svelte_str += parameters_str
-        svelte_str += f"<paramgroups>{n_groups}</paramgroups>"
+            svelte_str += "<paramsgroup>"
+            svelte_str += f"<paramsgrouptitle>{title}</paramsgrouptitle>"
+            svelte_str += f"<paramsgroupdesc>{group}</paramsgroupdesc>"
+            svelte_str += "</paramsgroup>"
 
     if returntype is not None:
         svelte_str += f"<rettype>{returntype}</rettype>"
@@ -233,7 +240,7 @@ def get_signature_component_svelte(name, anchor, signature, object_doc, source_l
     if raisederrors is not None:
         svelte_str += f"<raisederrors>{raisederrors}</raisederrors>"
 
-    svelte_str += "</docstring>"
+    svelte_str += "</Docstring>"
 
     return svelte_str + f"\n{object_doc}\n"
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -220,7 +220,7 @@ class AutodocTester(unittest.TestCase):
         ]
         object_doc = TEST_DOCSTRING
         source_link = "test_link"
-        expected_signature_component = '<docstring><name>class transformers.BertweetTokenizer</name><anchor>transformers.BertweetTokenizer</anchor><source>test_link</source><parameters>[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'&amp;lt;s>\'"}]</parameters><paramsdesc>- **vocab_file** (`str`) --\n  Path to the vocabulary file.\n- **merges_file** (`str`) --\n  Path to the merges file.\n- **normalization** (`bool`, _optional_, defaults to `False`) --\n  Whether or not to apply a normalization preprocess.\n\n<Tip>\n\nWhen building a sequence using special tokens, this is not the token that is used for the beginning of\nsequence. The token used is the `cls_token`.\n\n</Tip></paramsdesc><paramgroups>0</paramgroups><rettype>`List[int]`</rettype><retdesc>List of [input IDs](../glossary.html#input-ids) with the appropriate special tokens.</retdesc><raises>- ``ValuError`` -- this value error will be raised on wrong input type.</raises><raisederrors>``ValuError``</raisederrors></docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n\n\n\n\n\n\n\n'
+        expected_signature_component = '<Docstring name={"class transformers.BertweetTokenizer"} anchor={"transformers.BertweetTokenizer"} source={"test_link"} parameters={[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'<s>\'"}]}>\n<paramsdesc>- **vocab_file** (`str`) --\n  Path to the vocabulary file.\n- **merges_file** (`str`) --\n  Path to the merges file.\n- **normalization** (`bool`, _optional_, defaults to `False`) --\n  Whether or not to apply a normalization preprocess.\n\n<Tip>\n\nWhen building a sequence using special tokens, this is not the token that is used for the beginning of\nsequence. The token used is the `cls_token`.\n\n</Tip></paramsdesc><rettype>`List[int]`</rettype><retdesc>List of [input IDs](../glossary.html#input-ids) with the appropriate special tokens.</retdesc><raises>- ``ValuError`` -- this value error will be raised on wrong input type.</raises><raisederrors>``ValuError``</raisederrors></Docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n\n\n\n\n\n\n\n'
         self.assertEqual(
             get_signature_component_svelte(name, anchor, signature, object_doc, source_link),
             expected_signature_component,
@@ -238,7 +238,7 @@ class AutodocTester(unittest.TestCase):
 This tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.
 Users should refer to this superclass for more information regarding those methods.
 """
-        expected_signature_component = '<docstring><name>class transformers.BertweetTokenizer</name><anchor>transformers.BertweetTokenizer</anchor><source>test_link</source><parameters>[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'&amp;lt;s>\'"}]</parameters></docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n'
+        expected_signature_component = '<Docstring name={"class transformers.BertweetTokenizer"} anchor={"transformers.BertweetTokenizer"} source={"test_link"} parameters={[{"name": "vocab_file", "val": ""}, {"name": "normalization", "val": " = False"}, {"name": "bos_token", "val": " = \'<s>\'"}]}>\n</Docstring>\nConstructs a BERTweet tokenizer, using Byte-Pair-Encoding.\n\nThis tokenizer inherits from [`~transformers.PreTrainedTokenizer`] which contains most of the main methods.\nUsers should refer to this superclass for more information regarding those methods.\n\n'
         self.assertEqual(
             get_signature_component_svelte(name, anchor, signature, object_doc_without_params_and_return, source_link),
             expected_signature_component,
@@ -254,7 +254,7 @@ Users should refer to this superclass for more information regarding those metho
         ]
         object_doc = TEST_DOCSTRING_WITH_PARAM_GROUPS
         source_link = "test_link"
-        expected_signature_component = '<docstring><name>class transformers.cool_function</name><anchor>transformers.cool_function</anchor><source>test_link</source><parameters>[{"name": "param_a", "val": ""}, {"name": "param_b", "val": ""}, {"name": "cool_param_a", "val": ""}, {"name": "cool_param_b", "val": ""}]</parameters><paramsdesc>- **param_a** (`str`) --\n  First default parameter\n- **param_b** (`int`) --\n  Second default parameter\n\n</paramsdesc><paramsdesc1title>New group with cool parameters!</paramsdesc1title><paramsdesc1>\n\n- **cool_param_a** (`str`) --\n  First cool parameter\n- **cool_param_b** (`int`) --\n  Second cool parameter</paramsdesc1><paramgroups>1</paramgroups></docstring>\n\nBuilds something very cool!\n\n\n\n'
+        expected_signature_component = '<Docstring name={"class transformers.cool_function"} anchor={"transformers.cool_function"} source={"test_link"} parameters={[{"name": "param_a", "val": ""}, {"name": "param_b", "val": ""}, {"name": "cool_param_a", "val": ""}, {"name": "cool_param_b", "val": ""}]}>\n<paramsdesc>- **param_a** (`str`) --\n  First default parameter\n- **param_b** (`int`) --\n  Second default parameter\n\n</paramsdesc><paramsgroup><paramsgrouptitle>New group with cool parameters!</paramsgrouptitle><paramsgroupdesc>\n\n- **cool_param_a** (`str`) --\n  First cool parameter\n- **cool_param_b** (`int`) --\n  Second cool parameter</paramsgroupdesc></paramsgroup></Docstring>\n\nBuilds something very cool!\n\n\n\n'
         self.assertEqual(
             get_signature_component_svelte(name, anchor, signature, object_doc, source_link),
             expected_signature_component,
@@ -275,9 +275,10 @@ Users should refer to this superclass for more information regarding those metho
         page_info = {"package_name": "transformers"}
 
         model_output_doc = """
-<docstring><name>class transformers.utils.ModelOutput</name><anchor>transformers.utils.ModelOutput</anchor><source>"""
-        model_output_doc += f"{self.test_source_link}"
-        model_output_doc += """</source><parameters>[{"name": "*args", "val": ""}, {"name": "**kwargs", "val": ""}]</parameters></docstring>
+<Docstring name={"class transformers.utils.ModelOutput"} anchor={"transformers.utils.ModelOutput"} source={"""
+        model_output_doc += f'"{self.test_source_link}"'
+        model_output_doc += """} parameters={[{"name": "*args", "val": ""}, {"name": "**kwargs", "val": ""}]}>
+</Docstring>
 
 Base class for all model outputs as dataclass. Has a `__getitem__` that allows indexing by integer or slice (like a
 tuple) or strings (like a dictionary) that will ignore the `None` attributes. Otherwise behaves like a regular
@@ -542,7 +543,8 @@ before.
         expected_documentation = """<div class="docstring border-l-2 border-t-2 pl-4 pt-3.5 border-gray-100 rounded-tl-xl mb-6 mt-8">
 
 
-<docstring><name>content</name><anchor>None</anchor><parameters>[]</parameters><isgetsetdescriptor></docstring>
+<Docstring name={"content"} anchor={"None"} parameters={[]} isGetSetDescriptor={true}>
+</Docstring>
 Get the content of this `AddedToken`
 
 </div>\n"""


### PR DESCRIPTION
## What

Docstring rendering used to go through two regex transformation layers: `autodoc.py` serialized metadata into custom tags (`<docstring><name>…</name><anchor>…</anchor><parameters>…</parameters>…<paramgroups>N</paramgroups>`), and `kit/preprocessors/docstring.js` regex-parsed them all back out to build a `<Docstring …/>` component.

Now **python emits the component directly**: the `<Docstring>` open tag carries all metadata props as final values (`name`/`anchor`/`source`/`parameters`/`isGetSetDescriptor`, with MDX escaping undone since JS string/JSON props need none), and the component body carries only the markdown-bearing sections (parameter descriptions, return/yield/raise types & descriptions). The kit preprocessor's only remaining job is rendering those sections with mdsvex into the remaining props — it no longer parses names, anchors, sources, signatures, or group counts.

### Why the JS stage still exists at all
The prop values are *rendered markdown* — they must go through the same mdsvex pipeline (remark + custom hljs highlighter + KaTeX) as the rest of the page, and that renderer lives in JS. Likewise the rendered-`<ul>` parsing stays (now documented in a dedicated helper): parameter lists must be rendered as **one** markdown list to preserve exact tight/loose list semantics, then parsed back into per-parameter structured data for the tooltips/anchors.

### Also fixes a latent bug
Python emits `<yielddesc>`, but the old regex matched `<yieldesc>` — yield descriptions have been silently dropped forever. The tag names now match, so docstrings with `Yields:` sections will (correctly) start showing their description. This doesn't affect accelerate (no rendered yields), but other libraries may gain previously-missing content.

### Compatibility note
The tag format is an internal contract between the python package and `kit/`; the doc-build workflows always build both from the same repo checkout, so the change is atomic. Mixing an old PyPI `hf-doc-builder` with a newer kit checkout (or vice versa) would break docstring rendering — same caveat as any change to this format.

## Verification

- **Byte-identical output**: full accelerate e2e build compared against the pre-change build — **48/48 pages byte-identical**, normalizing only hashed asset paths, the kit build timestamp, and nondeterministic python `<object object at 0x…>` addresses. (accelerate is docstring-dense: 15 `package_reference` pages.)
- `pytest tests/` passing (expectations updated for the new format; the one `test_style_doc` failure is pre-existing on main in my env and unrelated).
- eslint/prettier clean, including fixing the `no-shadow` violations the old file carried.

Second commit: a one-hunk `svelte.config.js` change (`state_referenced_locally` warning suppression) that was verified as part of #795 but accidentally left out of that PR (`git add kit/src` missed the config at `kit/` root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)