### PR TITLE
Add tomli to openenv real doc-build deps

### DIFF
--- a/src/doc_builder/mock_deps/openenv.txt
+++ b/src/doc_builder/mock_deps/openenv.txt
@@ -11,3 +11,4 @@ real:requests
 real:pydantic
 real:aiohttp
 real:typer
+real:tomli  # py<3.11 fallback for tomllib in openenv.cli.importers


### PR DESCRIPTION
openenv's CLI falls back to `import tomli as tomllib` on Python < 3.11 (what the shared-workflow runners use), so a light doc build needs it real. Caught by the doc build on huggingface/OpenEnv#923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)