### PR TITLE
Fix Upload PR Documentation: drop unused doc-builder install

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -32,21 +32,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: 'huggingface/doc-builder'
-          path: doc-builder
-          # Uncomment the following line to use a specific revision of doc-builder
-          # ref: fix-corrupted-zip
-
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
-
-      - name: Setup environment
-        shell: bash
-        id: setup-env
-        run: |
-          uv pip install --system ./doc-builder
-          echo "current_work_dir=$(pwd)" >> $GITHUB_OUTPUT
 
       - name: 'Download artifact'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4


### PR DESCRIPTION
The uv-only conversion broke `upload_pr_documentation.yml`: `uv pip install --system ./doc-builder` fails with `Permission denied` on `/usr/local/lib` (the old `pip install .` silently fell back to the user site-packages). First seen on https://github.com/huggingface/trl/actions/runs/28810540691/job/85437025416.

Nothing in the workflow actually uses doc-builder, its checkout, or the `current_work_dir` output (the bucket sync runs `hf` via `uvx`), so this removes the vestigial checkout + setup step entirely rather than patching the permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)