### PR TITLE
Add bitsandbytes and sentencepiece to diffusers doc-build deps

### DIFF
--- a/src/doc_builder/mock_deps/diffusers.txt
+++ b/src/doc_builder/mock_deps/diffusers.txt
@@ -10,3 +10,5 @@ real:requests
 real:safetensors
 real:pillow
 real:transformers
+bitsandbytes
+real:sentencepiece  # kolors tokenizer imports it at module level


### PR DESCRIPTION
Requested in huggingface/diffusers#14134: the old `diffusers/diffusers-doc-builder` container provided these, so the light path needs them in the registry — `real:sentencepiece` (kolors' tokenizer imports it at module level) and `bitsandbytes` as a mock (quantization docs autodoc availability-gated classes).

Validated: full diffusers docs (363 pages) build in a fresh venv with only doc-builder + the registry deps + diffusers `--no-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)