### PR TITLE
Mock quantization backends (optimum, torchao, gguf) for diffusers docs

### DIFF
--- a/src/doc_builder/mock_deps/diffusers.txt
+++ b/src/doc_builder/mock_deps/diffusers.txt
@@ -12,3 +12,6 @@ real:pillow
 real:transformers
 bitsandbytes
 real:sentencepiece  # kolors tokenizer imports it at module level
+optimum  # optimum-quanto backend for quantization docs (also avoids diffusers' optimum_quanto/quanto BACKENDS_MAPPING KeyError in the dummy path)
+torchao
+gguf


### PR DESCRIPTION
Follow-up to #805: the diffusers main doc build got past sentencepiece and then failed with `KeyError: 'optimum_quanto'` on `api/quantization.md` (https://github.com/huggingface/diffusers/actions/runs/28853508918). Two things:

1. The page needs the quantization backends importable under `DIFFUSERS_SLOW_IMPORT=yes` (which the shared workflows set globally) — this adds `optimum`, `torchao`, and `gguf` as mocks, so autodoc documents the real `QuantoConfig`/`TorchAoConfig`/`GGUF` classes instead of dummies.
2. The `KeyError` itself is a latent diffusers bug the container had been masking: `dummy_optimum_quanto_objects.py` declares backend `"optimum_quanto"` but `BACKENDS_MAPPING` only has the key `"quanto"`, so `requires_backends` crashes instead of raising the intended "requires optimum-quanto" ImportError. Worth a one-line fix in diffusers regardless (cc'd on huggingface/diffusers#14134).

Validated: full diffusers docs (363 pages from current main) build in a fresh venv with only doc-builder + registry deps + diffusers `--no-deps`, with `DIFFUSERS_SLOW_IMPORT=yes` — the exact CI conditions (my earlier validations missed that env var; the local harness now sets it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)