### PR TITLE
Add reachy_mini mock-deps registry entry

### DIFF
--- a/src/doc_builder/mock_deps/reachy_mini.txt
+++ b/src/doc_builder/mock_deps/reachy_mini.txt
@@ -1,0 +1,59 @@
+# Dependencies for building reachy_mini docs without a full install (see mock_imports.py).
+# Bare names are mocked at build time; real:/nodeps: lines are installed for real
+# by `doc-builder light-install` (nodeps: = with --no-deps).
+#
+# Mocked: need system libraries (gi/dbus), are hardware/robot or optional-extra
+# packages, or are heavy wheels not needed to introspect docstrings.
+gi
+dbus
+cv2
+cv2_enumerate_cameras
+mujoco
+rerun
+placo
+placo_utils
+pinocchio
+meshcat
+onnxruntime
+rustypot
+reachy_mini_motor_controller
+reachy_mini_rust_kinematics
+usb
+libusb_package
+soundfile
+sounddevice
+pynput
+gradio_client
+onshape_to_robot
+gpiozero
+lgpio
+nmcli
+pulsectl
+pycaw
+pollen_BMI088_imu_library
+Foundation
+CryptoKit
+real:numpy
+real:scipy
+real:pydantic
+real:fastapi
+real:starlette
+real:uvicorn
+real:aiohttp
+real:websockets
+real:requests
+real:pyyaml
+real:rich
+real:jinja2
+real:huggingface_hub
+real:toml
+real:psutil
+real:questionary
+real:platformdirs
+real:zeroconf
+real:asgiref
+real:semver
+real:cryptography
+real:log-throttling
+real:pyserial
+real:python-multipart


### PR DESCRIPTION
## What

Adds `src/doc_builder/mock_deps/reachy_mini.txt` so the [pollen-robotics/reachy_mini](https://github.com/pollen-robotics/reachy_mini) docs build on a bare runner via `light-install` + `mock_deps`, instead of the custom Docker image the project relied on before `custom_container` was removed from the build workflows.

## Why

`reachy_mini` pulls in `PyGObject` (needs `libgirepository`/cairo system headers at install time), `dbus-python`, plus hardware/robot and optional-extra packages (gstreamer bindings, mujoco, rerun, placo, opencv…). On the current `ubuntu-22.04` build runner none of these are available, and `pre_command` runs after the package install — too late for the install-time system libs. The registry entry sidesteps this: only the light, wheel-only deps are installed for real; everything native/heavy is mocked at introspection time.

## Validation

Reproduced the CI light-install path locally against `reachy_mini` v1.9.0:

- `doc-builder light-install reachy_mini --check` → recognized ✓
- `doc-builder build reachy_mini docs/source --html --clean` → **exit 0**, every `API/*.html` page generated.
- Autodoc content is real, not hollowed by the mocks: e.g. `media` classes that depend on the mocked `gi`/`dbus` (`GStreamerAudio.get_DoA`, …) and the top-level `ReachyMini.__init__` render their real signatures, defaults, and docstrings.

## Notes

Bare lines are import names (mocked); `real:` lines are the light deps installed for real. Follows the format of the existing `lerobot.txt` / `transformers.txt` entries.