### PR TITLE
Add python_version input to doc build workflows

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -46,6 +46,9 @@ on:
       convert_notebooks:
         type: boolean
         description: "Convert notebooks to markdown files before building docs."
+      python_version:
+        type: string
+        description: "Python version for the build venv (e.g. '3.11'). Defaults to the runner's system Python."
     secrets:
       hf_token:
         required: true
@@ -120,7 +123,7 @@ jobs:
       - name: Setup environment
         shell: bash
         run: |
-          uv venv
+          uv venv ${{ inputs.python_version && format('--python {0}', inputs.python_version) || '' }}
           source .venv/bin/activate
           cd doc-builder
           git pull origin main

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -55,6 +55,9 @@ on:
         type: boolean
         default: false
         description: "Fail doc build when runnable warnings are emitted. Requires `additional_args` to include `--emit-warning`."
+      python_version:
+        type: string
+        description: "Python version for the build venv (e.g. '3.11'). Defaults to the runner's system Python."
 
 
 jobs:
@@ -133,7 +136,7 @@ jobs:
       - name: Setup environment
         shell: bash
         run: |
-          uv venv
+          uv venv ${{ inputs.python_version && format('--python {0}', inputs.python_version) || '' }}
           source .venv/bin/activate
           cd doc-builder
           git pull origin ${{ inputs.doc_builder_revision }}


### PR DESCRIPTION
## What

Adds an optional `python_version` input to both reusable build workflows (`build_main_documentation.yml` and `build_pr_documentation.yml`). When set, the build venv is created with that Python:

```yaml
uv venv ${{ inputs.python_version && format('--python {0}', inputs.python_version) || '' }}
```

Unset by default → bare `uv venv`, i.e. **no behavior change for any existing caller**.

## Why

The build venv is currently created with a bare `uv venv`, which picks the runner's system Python — **3.10** on `ubuntu-22.04`. A documented package that requires a newer Python then can't be installed, and the build fails during "Setup environment":

```
× No solution found when resolving dependencies:
╰─▶ Because the current Python version (3.10.12) does not satisfy Python>=3.11
    and reachy-mini==1.9.0 depends on Python>=3.11 ...
```

There's no way for a caller to select the interpreter today: `pre_command` runs after the venv is created, and a reusable workflow can't inherit env like `UV_PYTHON` from the caller. This surfaced building the [pollen-robotics/reachy_mini](https://github.com/pollen-robotics/reachy_mini) docs (`requires-python = ">=3.11"`).

`uv` provisions the requested version automatically (the job already exports `UV_PYTHON_INSTALL_DIR`), so callers just pass e.g. `python_version: "3.11"`.