### PR TITLE
fix(ci): read _versions.yml from the serving bucket

### DIFF
--- a/.github/workflows/build_main_documentation.yml
+++ b/.github/workflows/build_main_documentation.yml
@@ -150,12 +150,18 @@ jobs:
           git config --global user.name "Hugging Face Doc Builder"
           git config --global user.email docs@huggingface.co
 
+      # The version list is read from the bucket we serve from, not from the legacy
+      # dataset: a version advertised in _versions.yml with no matching folder in the
+      # bucket makes hf.co/docs/<package> 404 on its default version.
       - name: Create build directory
+        env:
+          HF_TOKEN: ${{ secrets.hf_token }}
+          PACKAGE_NAME: ${{ env.package_name }}
         run: |
           mkdir build_dir
-          mkdir build_dir/${{ env.package_name }}
-          cd build_dir/${{ env.package_name }}
-          wget https://huggingface.co/datasets/hf-doc-build/doc-build/raw/main/${{ env.package_name }}/_versions.yml
+          mkdir build_dir/$PACKAGE_NAME
+          cd build_dir/$PACKAGE_NAME
+          uvx --from huggingface_hub hf cp "hf://buckets/hf-doc-build/doc/$PACKAGE_NAME/_versions.yml" _versions.yml
 
       - name: Run pre-command
         shell: bash


### PR DESCRIPTION
## Problem

`https://huggingface.co/docs/tokenizers/index` returned a 404.

moon-landing serves docs from the `hf-doc-build/doc` bucket. It reads `{package}/_versions.yml` from that bucket, takes the first non-`main` entry as the default version, then `readdir`s `{package}/{version}` and turns `ENOENT` into a 404 (`server/app/contentRoutes.ts:1774-1786` and `:1841`).

The `Create build directory` step here fetched `_versions.yml` from the legacy `hf-doc-build/doc-build` **dataset**, and the later `Sync to bucket` step pushed that list to the **bucket**. So the bucket could advertise versions it did not contain.

That is what happened to tokenizers:

- 27 Apr 2026: the `v0.23.1` tag build ran when this workflow had no `Sync to bucket` step, so the build only landed in the dataset.
- 15 Jul 2026: the `main` build imported the dataset's version list (first non-`main` entry: `v0.23.1`) into the bucket, while uploading only `main/`. From then on the default version pointed at a folder the bucket never received.

## Fix

Read the version list from the bucket that is actually served, so the served list stays consistent with the served content by construction.

The bucket has been backfilled for the version folders that were dataset-only (`tokenizers/v0.23.1`, `tokenizers/v0.23.1-rc0`, `datasets/v4.8.5`, `datasets/v5.0.0`, `datasets/v5.0.1`, `huggingface_hub/v1.11.0`, `optimum/v2.2.0`, `optimum-intel/v2.0.0`), so this change loses no version. `/docs/tokenizers/index` serves v0.23.1 again.

Every package present in the dataset also has a bucket folder, so no package loses its version list with this change.