### PR TITLE
fix(kit): escape curly braces in markdown link & image URLs

### DIFF
--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -191,6 +191,12 @@ function getTitleText(node) {
 }
 
 function treeVisitor() {
+	// Doc-body marker offsets, recomputed per document in transform(). Used to
+	// decide whether a link/image node sits inside the doc body without
+	// depending on visitor traversal order (see onLink).
+	let bodyStartOffset = -1;
+	let bodyEndOffset = Infinity;
+
 	return transform;
 
 	function transform(tree) {
@@ -223,8 +229,25 @@ function treeVisitor() {
 			// Replace the old node with the new Svelte node
 			parent.children[index] = svelteNode;
 		});
+		// The doc-body region is delimited by the HF DOC BODY markers. The
+		// stateful isWithinDocBody() check only works for visitors running in
+		// document order before the END marker is seen; for link/image URLs we
+		// instead locate the marker offsets up front and compare positions.
+		bodyStartOffset = -1;
+		bodyEndOffset = Infinity;
+		visit(tree, ["text", "html"], (node) => {
+			if (["<!--HF DOCBUILD BODY START-->", "HF_DOC_BODY_START"].includes(node.value)) {
+				bodyStartOffset = node.position?.start?.offset ?? -1;
+			}
+			if (["<!--HF DOCBUILD BODY END-->", "HF_DOC_BODY_END"].includes(node.value)) {
+				bodyEndOffset = Math.min(bodyEndOffset, node.position?.start?.offset ?? Infinity);
+			}
+		});
+
 		visit(tree, "text", onText);
 		visit(tree, "html", onHtml);
+		visit(tree, "link", onLink);
+		visit(tree, "image", onLink);
 		visit(tree, "blockquote", onBlockquote);
 
 		let jsonString = JSON.stringify(headings[0]);
@@ -263,6 +286,29 @@ function treeVisitor() {
 		}
 		node.value = node.value.replaceAll("{", "&#123;");
 		node.value = node.value.replaceAll("<", "&#60;");
+	}
+
+	/**
+	 * A link's URL is stored on the mdast node's `url` property, not in a
+	 * child text node, so `onText` never escapes curly braces inside it.
+	 * mdsvex then emits the raw braces into the `href`/`src` attribute of the
+	 * generated HTML, where Svelte 5 interprets `{...}` as an expression.
+	 * During prerendering this throws `ReferenceError: <name> is not defined`
+	 * (e.g. for URLs containing OpenAPI path params like `{username}`).
+	 * Escaping `{` as an HTML entity keeps the rendered URL identical while
+	 * making it inert to the Svelte compiler.
+	 */
+	function onLink(node) {
+		const offset = node.position?.start?.offset ?? -1;
+		if (bodyStartOffset === -1 || offset < bodyStartOffset || offset > bodyEndOffset) {
+			return;
+		}
+		if (typeof node.url === "string") {
+			node.url = node.url.replaceAll("{", "&#123;");
+		}
+		if (typeof node.title === "string") {
+			node.title = node.title.replaceAll("{", "&#123;");
+		}
 	}
 
 	function onHtml(node) {


### PR DESCRIPTION
## Problem

A markdown link whose URL contains curly braces — e.g. OpenAPI-style path params:

```md
[overview endpoint](https://huggingface-openapi.hf.space/#tag/users/GET/api/users/{username}/overview)
```

fails the whole HTML doc build (`doc-builder build ... --html`) at SvelteKit prerender time with:

```
ReferenceError: username is not defined
```

Hit in practice by a hub-docs PR linking to an OpenAPI endpoint with a `{username}` path parameter.

## Root cause

In `kit/preprocessors/mdsvex/index.js`, the `treeVisitor` remark plugin escapes `{` → `&#123;` in `text` nodes (`onText`) and in raw-HTML text children (`onHtml`) so Svelte doesn't interpret braces as expression tags. But a link's URL is stored on the mdast `link`/`image` node's `url` **property**, not in a child text node — so it is never escaped. mdsvex emits the raw braces into the generated `href`/`src` attribute, Svelte 5 compiles `{username}` into `${$.stringify(username)}` in the SSR output, and prerendering (adapter-static) throws.

## Fix

Escape `{` as `&#123;` in link/image `url` and `title` inside the doc body, mirroring `onText`. The rendered output is byte-identical from the browser's perspective (`&#123;` resolves back to `{` in the attribute value), and the compiled component becomes a static string again.

Note on the doc-body check: `isWithinDocBody()`'s module-level state machine only works for visitor passes that run **before** the `HF_DOC_BODY_END` text node has been visited — the `text` pass flips the state off at the end of the document, so any later pass (like a new `link` pass) would see "outside body" for every node. Instead, the marker offsets are located up front and node positions compared against them.

## Verified

Ran the actual `mdsvexPreprocess` + `svelte.compile(generate: "server")` pipeline on a doc page containing the failing link:

- **before**: compiled JS contains `${$.stringify(username)}` → `ReferenceError` at prerender
- **after**: compiled JS is a static string; final markup renders `href="...api/users/{username}/overview"` verbatim
- links outside the doc body and pages without markers are untouched
- `prettier --check` passes