### PR TITLE
Fix build abort on broken autodoc reference blocking link resolution

### DIFF
--- a/src/doc_builder/build_doc.py
+++ b/src/doc_builder/build_doc.py
@@ -206,6 +206,7 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
 
     all_files = list(doc_folder.glob("**/*"))
     all_errors = []
+    failed_files = []
     for file in tqdm(all_files, desc="Building the MDX files"):
         new_anchors = None
         errors = None
@@ -252,7 +253,9 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
                 shutil.copy(file, dest_file)
 
         except Exception as e:
-            raise type(e)(f"There was an error when converting {file} to the MDX format.\n" + e.args[0]) from e
+            all_errors.append(f"There was an error when converting {file} to the MDX format.\n{e.args[0]}")
+            failed_files.append(str(file.with_suffix("").relative_to(doc_folder)))
+            continue
 
         if new_anchors is not None:
             page_name = str(file.with_suffix("").relative_to(doc_folder))
@@ -267,12 +270,8 @@ def build_mdx_files(package, doc_folder, output_dir, page_info, version_tag_suff
         if errors is not None:
             all_errors.extend(errors)
 
-    if len(all_errors) > 0:
-        raise ValueError(
-            "The deployment of the documentation will fail because of the following errors:\n" + "\n".join(all_errors)
-        )
-
-    return anchor_mapping, source_files_mapping
+    return anchor_mapping, source_files_mapping, all_errors, failed_files
+        
 
 
 def resolve_links(doc_folder, package, mapping, page_info):
@@ -394,11 +393,11 @@ def build_doc(
     read_doc_config(doc_folder)
 
     package = importlib.import_module(package_name) if is_python_module else None
-    anchors_mapping, source_files_mapping = build_mdx_files(
+    anchors_mapping, source_files_mapping, mdx_errors, failed_files = build_mdx_files(
         package, doc_folder, output_dir, page_info, version_tag_suffix=version_tag_suffix
     )
     if not watch_mode:
-        sphinx_refs = check_toc_integrity(doc_folder, output_dir)
+        sphinx_refs = check_toc_integrity(doc_folder, output_dir, known_failed_files=failed_files)
         sphinx_refs.extend(convert_anchors_mapping_to_sphinx_format(anchors_mapping, package))
 
     if is_python_module:
@@ -414,6 +413,11 @@ def build_doc(
 
     if not watch_mode:
         toctree_renamings(output_dir)
+    
+    if len(mdx_errors) > 0:
+        raise ValueError(
+            "The deployment of the documentation will fail because of the following errors:\n" + "\n".join(mdx_errors)
+        )
 
     return source_files_mapping, output_dir
 
@@ -463,7 +467,7 @@ def toctree_renamings(output_dir):
                 doc_file.rename(newlocal)
 
 
-def check_toc_integrity(doc_folder, output_dir):
+def check_toc_integrity(doc_folder, output_dir, known_failed_files=None):
     """
     Checks all the MDX files obtained after building the documentation are present in the table of contents.
 
@@ -510,6 +514,8 @@ def check_toc_integrity(doc_folder, output_dir):
         )
 
     files_not_exist = [f for f in toc_sections if f not in doc_files]
+    if known_failed_files:
+        files_not_exist = [f for f in files_not_exist if f not in known_failed_files]
     if len(files_not_exist) > 0:
         message = "\n".join([f"- {f}" for f in files_not_exist])
         raise RuntimeError(


### PR DESCRIPTION
Fixes #475

Root cause

build_mdx_files() aborted the entire build immediately on the first file with a broken [[autodoc]] reference. This happened before resolve_links() ran, so every [~Class.method]-style reference across the whole doc set was left unresolved when any single reference broke — including the trailing-underscore case in #475, where the unresolved raw text got picked up by markdown's emphasis parsing.

A second issue surfaced once the abort was removed: check_toc_integrity(), called right after, independently failed because the file that errored was legitimately absent from the output directory (never written) but still listed in _toctree.yml.

Fix
build_mdx_files() now collects per-file errors and continues instead of raising immediately
check_toc_integrity() accepts a set of known-failed files and skips them when checking for missing output
build_doc() now lets resolve_links, notebook building, and toctree renaming run regardless of MDX errors, and raises the deployment-failure error only at the very end
Testing
Reproduced the original bug: single broken [[autodoc]] reference → full build abort → every reference left unresolved
Verified fix: same broken reference → build completes, clip_grad_value_ (and all other references) resolve correctly, error is raised only at the end
Verified multi-error case: two broken references in different files → both correctly reported together, neither dropped
Verified clean build (no broken references) has zero regressions
Ran full existing test suite; confirmed the 3 pre-existing failures (GlmAsrForConditionalGeneration import error, a cascading AutoProcessor NameError, and a Windows-specific [WinError 2] subprocess issue in test_format_code_example) are present identically on unmodified main, unrelated to this change