### PR TITLE
Declare ruff as a runtime dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "meilisearch==0.34.1",
     "watchdog>=6.0.0",
     "httpx",
+    "ruff",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR declares `ruff` as a runtime dependency in `pyproject.toml`, so that it is actually installed with the package.

Follow-up to:
- #785

### Motivation

`doc-builder style` invokes `ruff` unconditionally through `subprocess.run(["ruff", ...])` when formatting code examples, so `ruff` must be present in the environment.

#785 added `ruff` to `install_requires` in `setup.py`, but that file is no longer used to build the package metadata: since #636, `pyproject.toml` declares a complete `[project]` table, which setuptools treats as authoritative. As a result, #785 had no effect.

This can be confirmed by inspecting the metadata of an install from the merge commit of #785:

```
$ pip install "git+https://github.com/huggingface/doc-builder@ffa5997"
$ python -c "from importlib.metadata import metadata; print(metadata('hf-doc-builder').get_all('Requires-Dist'))"
GitPython
...
httpx
ruff>=0.1.0; extra == "quality"
```

`ruff` only appears under the `quality`, `all` and `dev` extras, never as a core dependency. So a plain install still fails when styling a code example:

```
ValueError: Some code examples can't be interpreted by ruff, which means they aren't regular python:
Error message: [Errno 2] No such file or directory: 'ruff'
```

Note that this error only surfaces for docstrings or mdx files that contain code examples, and it is easily masked locally when `ruff` happens to be on `PATH` from an active virtual environment.

See the related downstream issue in `trl`:
- https://github.com/huggingface/trl/issues/5633

### Changes

- Add `ruff` to `[project].dependencies` in `pyproject.toml`

### Note

`setup.py` is now unused for packaging metadata and has drifted: its `install_requires` still lists `black` and its `extras["quality"]` still pins `black~=22.0`, `isort` and `flake8`, all replaced by `ruff` in #636, while its `extras["testing"]` still lists `requests`, replaced by `httpx` in #754. Removing it would avoid similar confusion in the future. Left out of this PR to keep the change minimal.