### PR TITLE
fix(kit): restore whitespace eaten by \(...\) and $$ KaTeX markers

### DIFF
--- a/kit/package.json
+++ b/kit/package.json
@@ -8,6 +8,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "node --test preprocessors/mdsvex/markKatex.test.js",
 		"lint": "prettier --check --plugin prettier-plugin-svelte .",
 		"format": "prettier --write --plugin prettier-plugin-svelte .",
 		"update-inference-providers": "npm ci && npm i @huggingface/inference@latest && npm i @huggingface/tasks@latest"

--- a/kit/preprocessors/mdsvex/index.js
+++ b/kit/preprocessors/mdsvex/index.js
@@ -97,24 +97,28 @@ export const mdsvexPreprocess = {
  * @param {string} content
  * @param {Record<any, any>} markedKatex
  */
-function markKatex(content, markedKatex) {
-	const REGEX_LATEX_DISPLAY = /\n\$\$([\s\S]+?)\$\$/g;
-	const REGEX_LATEX_INLINE = /\s\\\\\(([\s\S]+?)\\\\\)/g;
+export function markKatex(content, markedKatex) {
+	// Capture-and-restore the required boundary whitespace so formulas are not
+	// glued to the preceding text (and consecutive `\( ... \)` lines don't
+	// collapse into one paragraph). `$...$` already does this; `\(...\)` and
+	// `$$...$$` previously consumed the leading `\s`/`\n` and dropped it.
+	const REGEX_LATEX_DISPLAY = /(\n)\$\$([\s\S]+?)\$\$/g;
+	const REGEX_LATEX_INLINE = /(\s)\\\\\(([\s\S]+?)\\\\\)/g;
 	// Match $...$ with whitespace boundaries to avoid matching in HTML/code
 	const REGEX_LATEX_INLINE_DOLLAR = /(\s)(\$)([^$\n`<>]+?)(\$)(\s)/g;
 	let counter = 0;
 	return content
-		.replace(REGEX_LATEX_DISPLAY, (_, tex) => {
+		.replace(REGEX_LATEX_DISPLAY, (_, newline, tex) => {
 			const displayMode = true;
 			const marker = `KATEXPARSE${counter++}MARKER`;
 			markedKatex[marker] = { tex, displayMode };
-			return marker;
+			return newline + marker;
 		})
-		.replace(REGEX_LATEX_INLINE, (_, tex) => {
+		.replace(REGEX_LATEX_INLINE, (_, space, tex) => {
 			const displayMode = false;
 			const marker = `KATEXPARSE${counter++}MARKER`;
 			markedKatex[marker] = { tex, displayMode };
-			return marker;
+			return space + marker;
 		})
 		.replace(
 			REGEX_LATEX_INLINE_DOLLAR,

--- a/kit/preprocessors/mdsvex/markKatex.test.js
+++ b/kit/preprocessors/mdsvex/markKatex.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { markKatex } from "./index.js";
+
+// MDX pages pass `\\(...\\)` (two backslashes) into markKatex, matching
+// `convert_rst_to_mdx` / notebook conversion.
+
+test("inline \\(...\\) keeps the space before the formula", () => {
+	const marked = {};
+	const result = markKatex("one step \\\\(S_{t+1}\\\\) later", marked);
+	assert.equal(result, "one step KATEXPARSE0MARKER later");
+	assert.equal(marked.KATEXPARSE0MARKER.tex, "S_{t+1}");
+	assert.equal(marked.KATEXPARSE0MARKER.displayMode, false);
+});
+
+test("consecutive \\(...\\) lines keep the separating newline", () => {
+	const marked = {};
+	const result = markKatex("text \\\\(a\\\\)\n\\\\(b\\\\)", marked);
+	assert.equal(result, "text KATEXPARSE0MARKER\nKATEXPARSE1MARKER");
+	assert.equal(marked.KATEXPARSE0MARKER.tex, "a");
+	assert.equal(marked.KATEXPARSE1MARKER.tex, "b");
+});
+
+test("display $$...$$ keeps the leading newline", () => {
+	const marked = {};
+	const result = markKatex("before\n$$x + y$$\nafter", marked);
+	assert.equal(result, "before\nKATEXPARSE0MARKER\nafter");
+	assert.equal(marked.KATEXPARSE0MARKER.tex, "x + y");
+	assert.equal(marked.KATEXPARSE0MARKER.displayMode, true);
+});
+
+test("inline $...$ still restores surrounding whitespace", () => {
+	const marked = {};
+	const result = markKatex("see $x$ here", marked);
+	assert.equal(result, "see KATEXPARSE0MARKER here");
+	assert.equal(marked.KATEXPARSE0MARKER.tex, "x");
+});


### PR DESCRIPTION
## Summary
- Fixes the KaTeX preprocessor dropping the leading whitespace that `\(...\)` and `$$...$$` require to match, which glued formulas to the preceding text and collapsed consecutive `\( ... \)` lines (reported in #809).
- `$...$` already captured and restored surrounding spaces; the other two delimiters now do the same.
- Adds `node --test` coverage for `markKatex` (`npm test` in `kit/`).

This does **not** take on the rest of #809 (switching to `remark-math` / supporting `\[...\]` / relaxing `$...$` punctuation boundaries). Those are larger syntax-policy changes.

## Test plan
- [x] `cd kit && npm test`
- [x] `uv run --python 3.10 python -m pytest -n 1 --dist=loadfile -q ./tests/` (138 passed; unrelated to this change)
- [ ] Confirm Deep RL course page (`units/en/unit2/mc-vs-td`) no longer renders `one stepS_{t+1}`

Fixes #809 (whitespace-eating part)