### PR TITLE
Ship a pre-commit hook for doc-builder style

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: doc-builder-style
+  name: Check style with doc-builder
+  description: Style docstrings in Python files and code examples in mdx files.
+  entry: doc-builder style
+  language: python
+  types_or: [python, mdx]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is the package we use to build the documentation of our Hugging Face repos.
   * [Installation](#installation)
   * [Previewing](#previewing)
   * [Doc building](#doc-building)
+  * [Doc styling](#doc-styling)
+    + [Using the pre-commit hook](#using-the-pre-commit-hook)
   * [Writing in notebooks](#writing-in-notebooks)
   * [Templates for GitHub Actions](#templates-for-github-actions)
     + [Enabling multilingual documentation](#enabling-multilingual-documentation)
@@ -215,6 +217,44 @@ pytest -q tests/docs/test_my_page_docs.py
 This executes trusted documentation code with `exec`, so keep it limited to repo-controlled docs and CI.
 
 For continuation blocks, `# pytest-decorator`, bare-assert warnings, and GitHub Actions wiring, see [docs/runnable-code-blocks.md](docs/runnable-code-blocks.md).
+
+## Doc styling
+
+`doc-builder style` reformats the docstrings of Python files and the code examples of mdx files in place:
+
+```bash
+doc-builder style src/my_package docs/source --max_len 119
+```
+
+Add `--check_only` to report the files that should be restyled without modifying them.
+
+### Using the pre-commit hook
+
+`doc-builder` ships a [pre-commit](https://pre-commit.com) hook, so the same styling can run on every commit. Add it
+to the `.pre-commit-config.yaml` of your repo:
+
+```yaml
+repos:
+  - repo: https://github.com/huggingface/doc-builder
+    rev: <rev>  # The tag or commit to point at, e.g. v0.6.0
+    hooks:
+      - id: doc-builder-style
+```
+
+The hook was added after `v0.5.0`, so pin a later tag, or a commit of `main` while no such tag exists yet. Running
+`pre-commit autoupdate` pins the latest tag for you.
+
+The hook restyles the files that are about to be committed, and fails if any of them was modified, in the same way as
+a formatter such as `ruff-format`. Only Python and mdx files are passed to it, since those are the only ones
+`doc-builder style` handles.
+
+Pass extra options with `args`, and restrict the hook to a subset of your repo with `files`:
+
+```yaml
+      - id: doc-builder-style
+        args: [--max_len, "119"]
+        files: ^(src|docs/source)/
+```
 
 ## Writing in notebooks
 


### PR DESCRIPTION
This PR adds a `.pre-commit-hooks.yaml` manifest, so that `doc-builder style` can be used as a regular [pre-commit](https://pre-commit.com) hook by the repos that consume `doc-builder`.

### Motivation

Repos that want to enforce doc styling currently have to declare a `repo: local` hook and install `doc-builder` from a git URL pinned inside `additional_dependencies`. For example, in `trl`:

```yaml
- repo: local
  hooks:
    - id: doc-builder-style
      language: python
      entry: doc-builder style trl tests docs/source --max_len 119
      additional_dependencies: ["git+https://github.com/huggingface/doc-builder@<sha>"]
      pass_filenames: false
      types_or: [python, markdown, rst]
```

This works, but the pinned revision is invisible to the tooling that would otherwise keep it current: `pre-commit autoupdate` only rewrites the `rev` of remote hook repos, and Dependabot's `pre-commit` ecosystem tracks the same field. Neither looks inside `additional_dependencies`, so the pin can only be moved by hand and silently goes stale.

Shipping a manifest here lets consumers use the standard form instead, where `rev` is a first-class field that both tools can bump:

```yaml
- repo: https://github.com/huggingface/doc-builder
  rev: <rev>
  hooks:
    - id: doc-builder-style
```

It also removes the need for consumers to know about `doc-builder`'s own dependencies, now that `ruff` is declared as one (#815).

### Solution

The hook runs `doc-builder style` as a `language: python` hook, and relies on pre-commit's defaults for the rest.

`types_or` is `[python, mdx]`, which is exactly what `style_doc_files` handles: any other extension only triggers an `Ignoring <file> because it's not a py or an mdx file or a folder` warning. Note this is narrower than the `[python, markdown, rst]` used by the local hooks currently in the wild, which is harmless there only because they also set `pass_filenames: false`.

`pass_filenames` is left at its default, so pre-commit passes the files that are about to be committed and the hook is incremental, rather than restyling the whole tree on every run. `--max_len` is not passed either, since `119` is already the default; consumers can override both behaviours with `args` and `files`.

Verified with `ruff` absent from `PATH`, to make sure the hook is self-sufficient:

- `pre-commit validate-manifest .pre-commit-hooks.yaml` passes
- `pre-commit try-repo` restyles a Python docstring and reformats its code example, leaves `.md` and `.rst` files untouched, and exits non-zero because files were modified, like any other formatter
- a second run passes, so the hook is idempotent
- the documented `repo`/`rev` form, with `args` and a `files` filter, restyles the included folder and skips the excluded one

### Changes

- Add `.pre-commit-hooks.yaml` declaring the `doc-builder-style` hook
- Document `doc-builder style` and the hook in a new `Doc styling` section of the README

### Note

The README example asks for a `rev` rather than showing a concrete one, since the latest release, `v0.5.0`, predates this manifest and would fail with a missing-hook error. It can be replaced by a version once a release includes the hook.