### PR TITLE
Escape HTML and strip ANSI codes in notebook-to-mdx text outputs

### DIFF
--- a/src/doc_builder/commands/notebook_to_mdx.py
+++ b/src/doc_builder/commands/notebook_to_mdx.py
@@ -14,7 +14,9 @@
 
 import argparse
 import base64
+import html
 import io
+import re
 from pathlib import Path
 
 import nbformat
@@ -22,6 +24,23 @@ from PIL import Image
 from tqdm import tqdm
 
 from ..style_doc import format_code_example
+
+
+# CSI sequences (colors, cursor control like `\x1b[?25h`) and OSC sequences (e.g. terminal titles).
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)")
+
+
+def text_output_to_pre(output):
+    """
+    Wrap a cell's text output in a `<pre>` block, made safe for the MDX/Svelte pipeline.
+
+    ANSI color codes are stripped (they would render as garbage characters), and the text is
+    HTML-escaped: anything tag-like in an output (e.g. `<MODEL_ID>` in a CLI --help dump, or an
+    object repr like `<transformers.Trainer object at 0x...>`) would otherwise reach the Svelte
+    compiler as raw markup, which Svelte 5 rejects as an invalid element or component name.
+    """
+    output = _ANSI_ESCAPE_RE.sub("", output)
+    return f"<pre>\n{html.escape(output.strip(), quote=False)}\n</pre>"
 
 
 def png_to_jpeg(png_base64):
@@ -58,11 +77,9 @@ def notebook_to_mdx(notebook, max_len):
 
                 first_output = outputs[0]
                 if "text" in first_output:
-                    output = first_output["text"]
-                    output = f"<pre>\n{output.strip()}\n</pre>"
+                    output = text_output_to_pre(first_output["text"])
                 elif "text/plain" in first_output:
-                    output = first_output["text/plain"]
-                    output = f"<pre>\n{output.strip()}\n</pre>"
+                    output = text_output_to_pre(first_output["text/plain"])
                 elif "data" in first_output and "image/png" in first_output["data"]:
                     jpeg_base64 = png_to_jpeg(first_output["data"]["image/png"])
                     output = f'<img src="data:image/jpeg;base64,{jpeg_base64}">\n'

--- a/src/doc_builder/commands/notebook_to_mdx.py
+++ b/src/doc_builder/commands/notebook_to_mdx.py
@@ -25,7 +25,6 @@ from tqdm import tqdm
 
 from ..style_doc import format_code_example
 
-
 # CSI sequences (colors, cursor control like `\x1b[?25h`) and OSC sequences (e.g. terminal titles).
 _ANSI_ESCAPE_RE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)")
 

--- a/tests/test_notebook_to_mdx.py
+++ b/tests/test_notebook_to_mdx.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from doc_builder.commands.notebook_to_mdx import notebook_to_mdx, text_output_to_pre
+
+
+class NotebookToMdxTester(unittest.TestCase):
+    def test_text_output_to_pre_escapes_tag_like_text(self):
+        # Tag-like text in an output (CLI help placeholders, object reprs) must be escaped,
+        # otherwise it reaches the Svelte compiler as raw markup and fails the doc build.
+        result = text_output_to_pre("--model-id <MODEL_ID>\nSee <https://hf.co/models>")
+        self.assertEqual(result, "<pre>\n--model-id &lt;MODEL_ID&gt;\nSee &lt;https://hf.co/models&gt;\n</pre>")
+
+        result = text_output_to_pre("<transformers.trainer.Trainer object at 0x7f0000000000>")
+        self.assertNotIn("<transformers", result)
+        self.assertIn("&lt;transformers.trainer.Trainer object at 0x7f0000000000&gt;", result)
+
+    def test_text_output_to_pre_strips_ansi_sequences(self):
+        # Color codes and cursor-control sequences (as emitted by CLI tools and progress bars).
+        result = text_output_to_pre("\x1b[1m\x1b[4mOptions:\x1b[0m\n\x1b[?25l⠋ loading\x1b[?25h done")
+        self.assertEqual(result, "<pre>\nOptions:\n⠋ loading done\n</pre>")
+
+    def test_notebook_to_mdx_escapes_stream_output(self):
+        notebook = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": "!text-generation-launcher -h",
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stdout",
+                            "text": "\x1b[1mUsage:\x1b[0m --model-id <MODEL_ID>",
+                        }
+                    ],
+                }
+            ]
+        }
+        mdx = notebook_to_mdx(notebook, max_len=119)
+        self.assertIn("<pre>\nUsage: --model-id &lt;MODEL_ID&gt;\n</pre>", mdx)
+        self.assertNotIn("<MODEL_ID>", mdx)
+        self.assertNotIn("\x1b", mdx)


### PR DESCRIPTION
# What does this PR do?

Fixes the doc build for repos using `convert_notebooks: true` (the cookbook), broken for every PR since the kit upgrade to Svelte 5 (#792).

`notebook_to_mdx` wrapped cell text outputs in `<pre>` without escaping, so tag-like text in an output reached the Svelte compiler as raw markup. Example from `benchmarking_tgi.ipynb` (the committed output of `text-generation-launcher -h`):

```
[vite-plugin-svelte:compile] src/routes/benchmarking_tgi/+page.svelte (89:26):
Expected a valid element or component name.
 89 |        --model-id <MODEL_ID>
```

Svelte 4 tolerated these as unknown elements, Svelte 5 rejects them, and 41 of the 71 English cookbook notebooks have outputs with tag-like text (`<MODEL_ID>`, `<https://...>`, object reprs like `<transformers.Trainer object at 0x...>`), so this can't reasonably be fixed notebook-side. Curly braces were already handled by the kit's `onHtml` preprocessor, which is why JSON in outputs never broke.

Changes:
- HTML-escape the output text before wrapping it in `<pre>` (`html.escape(..., quote=False)`).
- Strip ANSI escape sequences (colors, cursor control like `\x1b[?25h`), which rendered as garbage characters inside the `<pre>` blocks.
- Add tests for both behaviours.

Verified by converting all 71 cookbook `en` notebooks with the patched command: no tag-like text and no ANSI sequences remain inside any generated `<pre>` block, and `benchmarking_tgi.md` now renders `--model-id &lt;MODEL_ID&gt;` correctly.

Once merged, re-running the failed cookbook checks should go green with no cookbook-side change (the reusable PR-doc workflow installs doc-builder from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
