### PR TITLE
Fix delete-old-prs.ts: correct bucket tree endpoint, fail loudly

### DIFF
--- a/scripts/delete-old-prs.ts
+++ b/scripts/delete-old-prs.ts
@@ -11,27 +11,47 @@ const oneMonthAgo = new Date(Date.now() - MAX_AGE_DAYS * 24 * 3600 * 1000);
 const token = Deno.env.get("HF_ACCESS_TOKEN")!;
 const headers = { Authorization: `Bearer ${token}` };
 
-// Step 1: List all top-level packages in the bucket
-const packagesRes = await fetch(
-	`https://huggingface.co/api/repos/bucket/${BUCKET_ID}/tree?recursive=false`,
-	{ headers },
-);
-const packages: { path: string; type: string }[] = await packagesRes.json();
+interface BucketEntry {
+	path: string;
+	type: string;
+	uploadedAt?: string;
+}
+
+/**
+ * Non-recursive listing of one level of the bucket tree, following the
+ * Link header for pagination.
+ * https://huggingface.co/api/buckets/{namespace}/{name}/tree/{path}?recursive=false
+ */
+async function listDir(path = ""): Promise<BucketEntry[]> {
+	const entries: BucketEntry[] = [];
+	let url: string | undefined = `https://huggingface.co/api/buckets/${BUCKET_ID}/tree${
+		path ? `/${path}` : ""
+	}?recursive=false&limit=1000`;
+	while (url) {
+		const res = await fetch(url, { headers });
+		if (!res.ok) {
+			throw new Error(`Failed to list ${url}: HTTP ${res.status} ${(await res.text()).slice(0, 500)}`);
+		}
+		const batch = await res.json();
+		if (!Array.isArray(batch)) {
+			throw new Error(`Unexpected response listing ${url}: ${JSON.stringify(batch).slice(0, 500)}`);
+		}
+		entries.push(...batch);
+		url = res.headers.get("link")?.match(/<([^>]+)>;\s*rel="next"/)?.[1];
+	}
+	return entries;
+}
 
 let totalDeleted = 0;
 let totalKept = 0;
+let failures = 0;
 
-for (const pkg of packages) {
+// Step 1: List all top-level packages in the bucket
+for (const pkg of await listDir()) {
 	if (pkg.type !== "directory") continue;
 
 	// Step 2: List pr_* directories inside each package
-	const entriesRes = await fetch(
-		`https://huggingface.co/api/repos/bucket/${BUCKET_ID}/tree?path_prefix=${pkg.path}/&recursive=false`,
-		{ headers },
-	);
-	const entries: { path: string; type: string; uploadedAt?: string }[] = await entriesRes.json();
-
-	for (const entry of entries) {
+	for (const entry of await listDir(pkg.path)) {
 		if (entry.type !== "directory" || !entry.path.includes("/pr_")) continue;
 
 		const uploadedAt = entry.uploadedAt ? new Date(entry.uploadedAt) : null;
@@ -40,7 +60,7 @@ for (const pkg of packages) {
 		if (uploadedAt < oneMonthAgo) {
 			console.log(`Deleting ${entry.path} (uploaded ${uploadedAt.toISOString()})`);
 			const proc = new Deno.Command("hf", {
-				args: ["buckets", "rm", `hf-doc-build/doc-dev/${entry.path}`, "--recursive", "-y"],
+				args: ["buckets", "rm", `${BUCKET_ID}/${entry.path}`, "--recursive", "-y"],
 				env: { HF_TOKEN: token },
 				stdout: "piped",
 				stderr: "piped",
@@ -48,6 +68,8 @@ for (const pkg of packages) {
 			const output = await proc.output();
 			if (!output.success) {
 				console.error(`Failed to delete ${entry.path}:`, new TextDecoder().decode(output.stderr));
+				failures++;
+				continue;
 			}
 			totalDeleted++;
 		} else {
@@ -56,4 +78,10 @@ for (const pkg of packages) {
 	}
 }
 
-console.log({ totalDeleted, totalKept });
+console.log({ totalDeleted, totalKept, failures });
+
+// Fail the job loudly when something went wrong, so breakage is visible
+// instead of silently accumulating previews for months.
+if (failures > 0) {
+	Deno.exit(1);
+}


### PR DESCRIPTION
## Problem

The daily `delete_old_pr_documentations.yml` cron has **failed on every run since at least May 16** (100/100 recorded runs):

```
error: Uncaught (in promise) TypeError: packages is not iterable
for (const pkg of packages) {
```

`delete-old-prs.ts` calls `https://huggingface.co/api/repos/bucket/{id}/tree`, which is not a real endpoint — the bucket tree API is `GET /api/buckets/{namespace}/{name}/tree/{path}` (path segment in the URL; `path_prefix` isn't a supported query param either). The 404 error body isn't an array, and the script had no `res.ok` check, so it crashed with the TypeError.

Net effect: **no PR docs have ever been pruned from `hf-doc-build/doc-dev`** — the bucket still holds previews of PRs merged in April, despite the "available until 30 days after the last update" notice posted on PRs. Unbounded growth of that bucket is also what pushed moon-ci-docs to disable FUSE polling, which in turn caused doc previews to 404 (huggingface-internal/moon-landing#19646).

## Changes

- Use the real endpoint: `/api/buckets/{namespace}/{name}/tree/{path}?recursive=false` (response verified against moon-landing's `bucketRoutes.listTreeEndpoint` schema: array of `{ type: "file"|"directory", path, uploadedAt, ... }`)
- Check `res.ok` and the array shape — API failures now raise a descriptive error instead of an opaque TypeError
- Follow `Link`-header pagination (`limit=1000` per page)
- Count `hf buckets rm` failures and exit non-zero, so partial breakage turns the cron red instead of silently skipping

Behavior (30-day cutoff based on the directory's `uploadedAt`, `pr_*` dirs only, `hf buckets rm --recursive`) is unchanged.

Note: on the first successful run this will delete a large backlog (~everything since April minus the last 30 days). If you'd rather dry-run first, trigger it manually via `workflow_dispatch` after reviewing the `Deleting …` log lines.
