### PR TITLE
delete-old-prs: use a trusted publisher instead of the HF_ACCESS_TOKEN secret

### DIFF
--- a/.github/workflows/delete_old_pr_documentations.yml
+++ b/.github/workflows/delete_old_pr_documentations.yml
@@ -11,6 +11,9 @@ defaults:
 jobs:
   delete_old_prs:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC exchange with the Hub (trusted publisher)
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d  # v1.5.2
@@ -19,6 +22,15 @@ jobs:
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
       - name: Install hf CLI
         run: uv tool install huggingface_hub
-      - run: deno run --allow-env --allow-net --allow-run --allow-read ./delete-old-prs.ts
+      - name: Exchange OIDC token for a short-lived HF token
+        # Trusted publisher configured on the hf-doc-build/doc-dev bucket
+        # (Settings -> Trusted Publishers: repository=huggingface/doc-builder,
+        # branch=main, workflow=delete_old_pr_documentations.yml). The token
+        # is write-scoped to that single bucket and expires after 1 hour.
         env:
-          HF_ACCESS_TOKEN: ${{ secrets.HF_ACCESS_TOKEN }}
+          HF_OIDC_RESOURCE: buckets/hf-doc-build/doc-dev
+        run: |
+          TOKEN="$(hf auth token)"
+          echo "::add-mask::$TOKEN"
+          echo "HF_ACCESS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+      - run: deno run --allow-env --allow-net --allow-run --allow-read ./delete-old-prs.ts


### PR DESCRIPTION
Follow-up to #821. The endpoint fix works (the cron now lists and attempts deletions), but every deletion fails:

```
Failed to delete accelerate/pr_4046: Error: Client error '401 Unauthorized'
for url 'https://huggingface.co/api/buckets/hf-doc-build/doc-dev/batch'
```

— the stored `HF_ACCESS_TOKEN` secret only has **read** access to the bucket.

## Change

Replace the static secret with a [Trusted Publisher](https://huggingface.co/docs/hub/trusted-publishers): the job requests a GitHub OIDC token (`permissions: id-token: write`) and `hf auth token` exchanges it for a 1-hour HF token **write-scoped to `buckets/hf-doc-build/doc-dev` only** (`HF_OIDC_RESOURCE`). The token is `::add-mask::`-ed before being exported to `GITHUB_ENV`, and the script keeps reading `HF_ACCESS_TOKEN` unchanged. No secret to store or rotate; the `HF_ACCESS_TOKEN` repo secret can be deleted (or downgraded) once this lands.

## Required setup before merging

Someone with **Write** on the `hf-doc-build/doc-dev` bucket must add a trusted publisher on
`https://huggingface.co/buckets/hf-doc-build/doc-dev/settings` → **Trusted Publishers**:

| Field | Value |
| --- | --- |
| Provider | GitHub Actions |
| `repository` | `huggingface/doc-builder` |
| `branch` | `main` |
| `workflow` | `delete_old_pr_documentations.yml` |

Then trigger via `workflow_dispatch` to verify (note: `workflow_dispatch` runs on `main`, so the `branch=main` claim matches; the first successful run will delete the ~4-month backlog of stale `pr_*` previews).
