### PR TITLE
Accept a lowercase region in language codes (pt-br) when expanding shorthand doc paths

### DIFF
--- a/kit/src/lib/hfDocPaths.js
+++ b/kit/src/lib/hfDocPaths.js
@@ -21,7 +21,7 @@ export function getHfDocFullPath(pathname) {
 		const isCourse = _docType === "learn";
 		const versionRegex = isCourse ? /^(?:pr_\d+)$/ : /^(?:(master|main)|v[\d.]+(rc\d+)?|pr_\d+)$/;
 		const _version = versionRegex.test(params[0]) ? params.shift() : __DOCS_VERSION__;
-		const _lang = /^[a-z]{2}(-[A-Z]{2})?$/.test(params[0]) ? params.shift() : __DOCS_LANGUAGE__;
+		const _lang = /^[a-z]{2}(-[A-Za-z]{2})?$/.test(params[0]) ? params.shift() : __DOCS_LANGUAGE__;
 		const newChapterId = params.join("/");
 		if (
 			__DOCS_LIBRARY__ === _library &&


### PR DESCRIPTION
# What does this PR do?

Fixes the doc build for repos whose language code has a lowercase region, broken since the kit upgrade to Svelte 5 (#792). Today that is huggingface/smol-course (`pt-br`), where every PR doc build fails.

`getHfDocFullPath` ($lib/hfDocPaths.js) expands shorthand doc URLs to the full route, and its language matcher is `/^[a-z]{2}(-[A-Z]{2})?$/`. `pt-br` fails that test, so the language segment is never shifted off `params` and ends up inside the chapter id, while `_lang` falls back to `__DOCS_LANGUAGE__` and still satisfies the equality checks below:

```
/docs/smol-course/pr_306/pt-br/unit1/1
  -> /docs/smol-course/pr_306/pt-br/pt-br/unit1/1     (404)
```

That function is the `reroute` hook, and SvelteKit applies it while prerendering too, so every page of the language 404s and the build aborts on the first one. Before #792 this logic lived in the `svelteKitCustomClient` fork of SvelteKit's client, which only ran in the browser, so the build never saw it.

`zh-CN` (agents-course, course, cookbook), `ru-RU` (agents-course) and `pt-BR` (audio-transformers-course) already matched. `pt-br` in smol-course is the only code in the org that does not.

Changes:
- Accept a lowercase region in the language matcher: `/^[a-z]{2}(-[A-Za-z]{2})?$/`.

Verified by building `smol-course/units/pt-br` locally with `--html`:

```
before:  exit 1, 14 x [404] GET /docs/smol-course/pr_306/pt-br/..., 0 HTML files
         Error: 404 /docs/smol-course/pr_306/pt-br/README
after:   exit 0, no 404s, 14 HTML files
```

which reproduces the CI failure of huggingface/smol-course#306 line for line. Building `units/ko` still passes (exit 0, 8 HTML files), and I checked the reroute mapping for `en`, `zh-CN`, `ru-RU`, `pt-BR` and `pt-br`, plus the shorthand (`/docs/lib/page`) and other-language (returns `undefined`) paths.

`kit/` has no JS test runner, so there is no unit test to add here without pulling in one.

Once merged, re-running the smol-course checks should go green with no smol-course-side change (the reusable PR-doc workflow checks out doc-builder from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
