### PR TITLE
Unify full-text-only documentation ingestion

### DIFF
--- a/src/doc_builder/api_docs.py
+++ b/src/doc_builder/api_docs.py
@@ -1,0 +1,238 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+
+_BLOCK_TAGS = {
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "br",
+    "dd",
+    "div",
+    "dl",
+    "dt",
+    "figcaption",
+    "figure",
+    "footer",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+}
+_SKIPPED_TAGS = {"pre", "script", "style", "svg"}
+_VOID_TAGS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+_DETAIL_SECTION = re.compile(
+    r"^(?:args?|arguments?|attributes?|class attributes?|components?|example(?:s| usage)?|inputs?|outputs?|"
+    r"parameters?|raises?|returns?|usage(?: example)?|yields?)(?:\s*:.*)?$",
+    re.IGNORECASE,
+)
+_PARAMETER_DEFINITION = re.compile(
+    r"^[A-Za-z_][\w.]*"
+    r"(?:\s*,\s*[A-Za-z_][\w.]*)*"
+    r"\s+\(.*\)\s*(?::|—|–|-)\s*"
+)
+
+
+@dataclass
+class _Docstring:
+    root_depth: int
+    order: int
+    api_id: str | None = None
+    body: list[str] = field(default_factory=list)
+    signature_started: bool = False
+    signature_done: bool = False
+    nested_docstrings: int = 0
+
+
+@dataclass
+class _Element:
+    tag: str
+    docstring: _Docstring | None = None
+    signature_for: list[_Docstring] = field(default_factory=list)
+    skipped: bool = False
+
+
+def _normalize_body(parts: list[str]) -> str:
+    lines = []
+    for line in "".join(parts).splitlines():
+        normalized = re.sub(r"\s+", " ", line).strip()
+        if not normalized:
+            continue
+        if (
+            normalized.lower() == "copied"
+            or _DETAIL_SECTION.match(normalized)
+            or _PARAMETER_DEFINITION.match(normalized)
+        ):
+            break
+        lines.append(normalized)
+    return "\n".join(lines)
+
+
+class _APIDocstringParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._elements: list[_Element] = []
+        self._docstrings: list[_Docstring] = []
+        self._skipped_depth = 0
+        self.results: list[tuple[int, str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
+        self._open_element(tag, attrs, is_void=tag in _VOID_TAGS)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]):
+        self._open_element(tag, attrs, is_void=True)
+
+    def handle_endtag(self, tag: str):
+        matching_index = next(
+            (index for index in range(len(self._elements) - 1, -1, -1) if self._elements[index].tag == tag),
+            None,
+        )
+        if matching_index is None:
+            return
+
+        closing_elements = self._elements[matching_index:]
+        del self._elements[matching_index:]
+        for element in reversed(closing_elements):
+            self._close_element(element)
+
+    def _close_element(self, element: _Element):
+        if element.skipped:
+            self._skipped_depth -= 1
+
+        for docstring in element.signature_for:
+            docstring.signature_done = True
+
+        if element.docstring is not None:
+            docstring = element.docstring
+            self.results.append((docstring.order, docstring.api_id or "", _normalize_body(docstring.body)))
+            self._docstrings.remove(docstring)
+            for parent in self._docstrings:
+                parent.nested_docstrings -= 1
+
+        if element.tag in _BLOCK_TAGS:
+            self._append_breaks()
+
+    def handle_data(self, data: str):
+        if self._skipped_depth:
+            return
+        for docstring in self._docstrings:
+            if self._captures_body(docstring):
+                docstring.body.append(data)
+
+    def _open_element(self, tag: str, attrs: list[tuple[str, str | None]], is_void: bool):
+        attributes = dict(attrs)
+        classes = set((attributes.get("class") or "").split())
+        is_docstring = "docstring" in classes
+
+        signature_for = []
+        for docstring in self._docstrings:
+            if not docstring.signature_started and len(self._elements) == docstring.root_depth:
+                docstring.signature_started = True
+                signature_for.append(docstring)
+
+        if is_docstring:
+            for parent in self._docstrings:
+                parent.nested_docstrings += 1
+        elif tag in _BLOCK_TAGS:
+            self._append_breaks()
+
+        api_id = attributes.get("id")
+        if api_id:
+            for docstring in self._docstrings:
+                if docstring.signature_started and not docstring.signature_done and docstring.api_id is None:
+                    docstring.api_id = api_id
+
+        element = _Element(
+            tag=tag,
+            signature_for=signature_for,
+            skipped=tag in _SKIPPED_TAGS,
+        )
+
+        if is_docstring:
+            docstring = _Docstring(
+                root_depth=len(self._elements) + 1,
+                order=len(self.results) + len(self._docstrings),
+            )
+            element.docstring = docstring
+            self._docstrings.append(docstring)
+
+        if element.skipped:
+            self._skipped_depth += 1
+
+        if is_void:
+            if element.skipped:
+                self._skipped_depth -= 1
+            for docstring in signature_for:
+                docstring.signature_done = True
+            if tag in _BLOCK_TAGS:
+                self._append_breaks()
+            return
+
+        self._elements.append(element)
+
+    def _append_breaks(self):
+        if self._skipped_depth:
+            return
+        for docstring in self._docstrings:
+            if self._captures_body(docstring):
+                docstring.body.append("\n")
+
+    @staticmethod
+    def _captures_body(docstring: _Docstring) -> bool:
+        return docstring.signature_done and docstring.nested_docstrings == 0
+
+
+def extract_api_docstrings(html: str) -> list[tuple[str, str]]:
+    parser = _APIDocstringParser()
+    parser.feed(html)
+    parser.close()
+    return [(api_id, body) for _, api_id, body in sorted(parser.results)]

--- a/src/doc_builder/build_embeddings.py
+++ b/src/doc_builder/build_embeddings.py
@@ -696,30 +696,27 @@ def create_chunks(package, doc_folder, page_info, version_tag_suffix, is_python_
     return chunks
 
 
-def chunks_to_embeddings(client, chunks, is_python_module) -> list[Embedding]:
-    texts = []
-    for c in chunks:
-        prefix = f'Documentation of {"library" if is_python_module else "service"} "{c.package_name}" under section: {" > ".join(c.headings)}'
-        texts.append(prefix + "\n\n" + c.text)
-
-    inference_output = client.feature_extraction(texts, truncate=True)
-    inference_output = inference_output.tolist()
+def chunks_to_documents(chunks, embedding_vectors=None) -> list[Embedding]:
+    if embedding_vectors is None:
+        embedding_vectors = [None] * len(chunks)
+    if len(chunks) != len(embedding_vectors):
+        raise ValueError("Each chunk must have a corresponding embedding vector")
 
     embeddings = []
-    for c, embed in zip(chunks, inference_output, strict=False):
+    for c, embed in zip(chunks, embedding_vectors, strict=True):
         headings = [None] * 5
         last_heading = None
 
         for heading_str in c.headings:
-            level = heading_str.count("#")
+            level = len(heading_str) - len(heading_str.lstrip("#"))
             heading_text = heading_str.lstrip("# ").strip()
             if 1 <= level <= 5:
                 headings[level - 1] = heading_text
                 last_heading = heading_text
 
-        # If the page does not have any heading, add the last heading to the page URL
+        # Blog records must preserve the canonical URL returned by the Hub API.
         source_page_url = c.source_page_url
-        if "#" not in c.source_page_url and last_heading is not None:
+        if c.package_name != "blog" and "#" not in c.source_page_url and last_heading is not None:
             source_page_url += "#" + slugify(last_heading)
 
         embeddings.append(
@@ -739,6 +736,17 @@ def chunks_to_embeddings(client, chunks, is_python_module) -> list[Embedding]:
         )
 
     return embeddings
+
+
+def chunks_to_embeddings(client, chunks, is_python_module) -> list[Embedding]:
+    texts = []
+    for c in chunks:
+        prefix = f'Documentation of {"library" if is_python_module else "service"} "{c.package_name}" under section: {" > ".join(c.headings)}'
+        texts.append(prefix + "\n\n" + c.text)
+
+    inference_output = client.feature_extraction(texts, truncate=True)
+    inference_output = inference_output.tolist()
+    return chunks_to_documents(chunks, inference_output)
 
 
 def call_embedding_inference(chunks: list[Chunk], hf_ie_url, hf_ie_token, is_python_module) -> list[Embedding]:

--- a/src/doc_builder/commands/embeddings.py
+++ b/src/doc_builder/commands/embeddings.py
@@ -18,9 +18,9 @@ import os
 from pathlib import Path
 
 from doc_builder import clean_meilisearch
-from doc_builder.build_embeddings import add_gradio_docs, call_embedding_inference
+from doc_builder.build_embeddings import add_gradio_docs, call_embedding_inference, chunks_to_documents
 from doc_builder.meilisearch_helper import add_embeddings_to_db
-from doc_builder.process_hf_docs import process_all_libraries
+from doc_builder.process_hf_docs import get_public_library_name, process_all_libraries, should_embed_chunk
 from doc_builder.utils import chunk_list
 
 
@@ -34,7 +34,7 @@ def get_credential(arg_value, env_var_name):
 def process_hf_docs_command(args):
     """
     Process documentation from HF doc-build dataset.
-    Downloads pre-built docs and generates embeddings.
+    Downloads pre-built docs and generates embeddings for eligible documents.
 
     With --incremental: only indexes new/changed pages and deletes stale ones,
     using the HF Hub tracker (hf-doc-build/doc-builder-embeddings-tracker) to
@@ -63,10 +63,6 @@ def process_hf_docs_command(args):
         hf_ie_token = get_credential(args.hf_ie_token, "HF_IE_TOKEN")
         meilisearch_key = get_credential(args.meilisearch_key, "MEILISEARCH_KEY")
 
-        if not hf_ie_url:
-            raise ValueError("HF_IE_URL is required. Set via --hf_ie_url or HF_IE_URL env var.")
-        if not hf_ie_token:
-            raise ValueError("HF_IE_TOKEN is required. Set via --hf_ie_token or HF_IE_TOKEN env var.")
         if not meilisearch_key:
             raise ValueError("MEILISEARCH_KEY is required. Set via --meilisearch_key or MEILISEARCH_KEY env var.")
         meilisearch_url = get_credential(args.meilisearch_url, "MEILISEARCH_URL")
@@ -88,33 +84,58 @@ def process_hf_docs_command(args):
 
 
 def _run_full(all_chunks, hf_ie_url, hf_ie_token, meilisearch_key, meilisearch_url, items_per_chunk):
-    """Full (non-incremental) indexing: embed everything and upload to the temp index."""
+    """Full (non-incremental) indexing: prepare every document and upload to the temp index."""
     import meilisearch
     from tqdm import tqdm
 
     from doc_builder.build_embeddings import MEILI_INDEX_TEMP
 
     print("\n" + "=" * 80)
-    print("GENERATING EMBEDDINGS (full rebuild)")
+    print("PREPARING SEARCH DOCUMENTS (full rebuild)")
     print("=" * 80)
-    print(f"\nTotal chunks to embed: {len(all_chunks)}")
+    print(f"\nTotal documents to index: {len(all_chunks)}")
 
-    embeddings = call_embedding_inference(
-        all_chunks,
-        hf_ie_url,
-        hf_ie_token,
-        is_python_module=False,
-    )
+    documents = _chunks_to_search_documents(all_chunks, hf_ie_url, hf_ie_token)
 
     print("\n" + "=" * 80)
     print("UPLOADING TO MEILISEARCH (temp index)")
     print("=" * 80)
 
     client = meilisearch.Client(meilisearch_url, meilisearch_key)
-    for chunk_embeddings in tqdm(chunk_list(embeddings, items_per_chunk), desc="Uploading to meilisearch"):
-        add_embeddings_to_db(client, MEILI_INDEX_TEMP, chunk_embeddings)
+    for document_chunk in tqdm(chunk_list(documents, items_per_chunk), desc="Uploading to meilisearch"):
+        add_embeddings_to_db(client, MEILI_INDEX_TEMP, document_chunk)
 
-    print(f"\nSuccessfully uploaded {len(embeddings)} embeddings to Meilisearch (temp index)")
+    print(f"\nSuccessfully uploaded {len(documents)} documents to Meilisearch (temp index)")
+
+
+def _chunks_to_search_documents(chunks, hf_ie_url, hf_ie_token):
+    chunks_to_embed = []
+    vectorless_chunks = []
+    for chunk in chunks:
+        if should_embed_chunk(chunk):
+            chunks_to_embed.append(chunk)
+        else:
+            vectorless_chunks.append(chunk)
+
+    print(f"Chunks requiring embeddings: {len(chunks_to_embed)}")
+    print(f"Full-text-only chunks      : {len(vectorless_chunks)}")
+
+    documents = []
+    if chunks_to_embed:
+        if not hf_ie_url:
+            raise ValueError("HF_IE_URL is required. Set via --hf_ie_url or HF_IE_URL env var.")
+        if not hf_ie_token:
+            raise ValueError("HF_IE_TOKEN is required. Set via --hf_ie_token or HF_IE_TOKEN env var.")
+        documents.extend(
+            call_embedding_inference(
+                chunks_to_embed,
+                hf_ie_url,
+                hf_ie_token,
+                is_python_module=False,
+            )
+        )
+    documents.extend(chunks_to_documents(vectorless_chunks))
+    return documents
 
 
 def _run_incremental(args, all_chunks, hf_ie_url, hf_ie_token, meilisearch_key, meilisearch_url, items_per_chunk):
@@ -152,7 +173,7 @@ def _run_incremental(args, all_chunks, hf_ie_url, hf_ie_token, meilisearch_key, 
 
     # When processing specific libraries, scope the diff to those libraries only
     if args.libraries:
-        lib_prefixes = tuple(sanitize_for_id(lib) + "-" for lib in args.libraries)
+        lib_prefixes = tuple(sanitize_for_id(get_public_library_name(lib)) + "-" for lib in args.libraries)
         existing_ids_in_scope = {doc_id for doc_id in existing_ids if doc_id.startswith(lib_prefixes)}
     else:
         existing_ids_in_scope = existing_ids
@@ -168,28 +189,23 @@ def _run_incremental(args, all_chunks, hf_ie_url, hf_ie_token, meilisearch_key, 
 
     # Embed and upload new/changed chunks
     if to_add_ids:
-        chunks_to_embed = [new_ids_map[doc_id] for doc_id in to_add_ids]
+        chunks_to_index = [new_ids_map[doc_id] for doc_id in to_add_ids]
 
         print("\n" + "=" * 80)
-        print("GENERATING EMBEDDINGS (incremental)")
+        print("PREPARING SEARCH DOCUMENTS (incremental)")
         print("=" * 80)
-        print(f"\nChunks to embed: {len(chunks_to_embed)}")
+        print(f"\nChunks to index: {len(chunks_to_index)}")
 
-        embeddings = call_embedding_inference(
-            chunks_to_embed,
-            hf_ie_url,
-            hf_ie_token,
-            is_python_module=False,
-        )
+        documents = _chunks_to_search_documents(chunks_to_index, hf_ie_url, hf_ie_token)
 
         print("\n" + "=" * 80)
         print("UPLOADING TO MEILISEARCH (main index)")
         print("=" * 80)
 
-        for chunk_embeddings in tqdm(chunk_list(embeddings, items_per_chunk), desc="Uploading to meilisearch"):
-            add_embeddings_to_db(client, MEILI_INDEX, chunk_embeddings)
+        for document_chunk in tqdm(chunk_list(documents, items_per_chunk), desc="Uploading to meilisearch"):
+            add_embeddings_to_db(client, MEILI_INDEX, document_chunk)
 
-        print(f"\nSuccessfully uploaded {len(embeddings)} embeddings to Meilisearch")
+        print(f"\nSuccessfully uploaded {len(documents)} documents to Meilisearch")
     else:
         print("\nNo new or changed documents — skipping embedding and upload.")
 
@@ -302,7 +318,7 @@ def embeddings_command_parser(subparsers=None):
         type=str,
         nargs="+",
         default=None,
-        help="Specific libraries to process (e.g., accelerate diffusers). If not specified, processes all libraries.",
+        help="Specific libraries to process (e.g., accelerate diffusers blog). If not specified, processes all libraries.",
     )
     parser_process_hf_docs.add_argument(
         "--excerpt-length", type=int, default=1000, help="Maximum length of each excerpt in characters (default: 1000)"
@@ -318,11 +334,14 @@ def embeddings_command_parser(subparsers=None):
     parser_process_hf_docs.add_argument(
         "--hf_ie_url",
         type=str,
-        help="Inference Endpoints URL (or set HF_IE_URL env var, required unless --skip-embeddings is set)",
+        help="Inference Endpoints URL (or set HF_IE_URL env var, required when selected documents need embeddings)",
         required=False,
     )
     parser_process_hf_docs.add_argument(
-        "--hf_ie_token", type=str, help="Hugging Face token (required unless --skip-embeddings is set)", required=False
+        "--hf_ie_token",
+        type=str,
+        help="Hugging Face token (required when selected documents need embeddings)",
+        required=False,
     )
     parser_process_hf_docs.add_argument(
         "--meilisearch_key",

--- a/src/doc_builder/meilisearch_helper.py
+++ b/src/doc_builder/meilisearch_helper.py
@@ -234,22 +234,23 @@ def generate_doc_id(library: str, page: str, text: str) -> str:
 @wait_for_task_completion
 def add_embeddings_to_db(client: Client, index_name: str, embeddings):
     index = client.index(index_name)
-    payload_data = [
-        {
-            "id": generate_doc_id(e.library, e.page, e.text),
-            "text": e.text,
-            "source_page_url": e.source_page_url,
-            "source_page_title": e.source_page_title,
-            "product": e.library,
-            "heading1": e.heading1,
-            "heading2": e.heading2,
-            "heading3": e.heading3,
-            "heading4": e.heading4,
-            "heading5": e.heading5,
-            "_vectors": {VECTOR_NAME: e.embedding},
+    payload_data = []
+    for embedding in embeddings:
+        document = {
+            "id": generate_doc_id(embedding.library, embedding.page, embedding.text),
+            "text": embedding.text,
+            "source_page_url": embedding.source_page_url,
+            "source_page_title": embedding.source_page_title,
+            "product": embedding.library,
+            "heading1": embedding.heading1,
+            "heading2": embedding.heading2,
+            "heading3": embedding.heading3,
+            "heading4": embedding.heading4,
+            "heading5": embedding.heading5,
         }
-        for e in embeddings
-    ]
+        if embedding.embedding is not None:
+            document["_vectors"] = {VECTOR_NAME: embedding.embedding}
+        payload_data.append(document)
     task_info = index.add_documents(payload_data)
     return client, task_info
 

--- a/src/doc_builder/process_hf_docs.py
+++ b/src/doc_builder/process_hf_docs.py
@@ -23,17 +23,53 @@ import json
 import os
 import tempfile
 import zipfile
+from math import ceil
 from pathlib import Path
+from urllib.parse import urljoin
 
 import httpx
 from packaging import version as package_version
 from tqdm import tqdm
 
+from .api_docs import extract_api_docstrings
 from .build_embeddings import Chunk, split_markdown_by_headings
 
 HF_DATASET_REPO = "hf-doc-build/doc-build"
 HF_DATASET_API_URL = f"https://huggingface.co/api/datasets/{HF_DATASET_REPO}/tree/main"
 HF_DATASET_BASE_URL = f"https://huggingface.co/datasets/{HF_DATASET_REPO}/resolve/main"
+HF_BLOG_API_URL = "https://huggingface.co/api/blog"
+HF_BASE_URL = "https://huggingface.co"
+
+
+def get_public_library_name(library_name: str) -> str:
+    return "llm-course" if library_name == "course" else library_name
+
+
+def get_dataset_library_name(library_name: str) -> str:
+    return "course" if library_name == "llm-course" else library_name
+
+
+def is_learning_library(library_name: str) -> bool:
+    library_name = library_name.lower()
+    return "course" in library_name or "cookbook" in library_name
+
+
+def is_compact_api_page(library_name: str, page_path: str) -> bool:
+    page_path = page_path.split("#", 1)[0].removesuffix(".md").removesuffix(".mdx")
+    if library_name == "transformers":
+        return page_path == "model_doc" or page_path.startswith("model_doc/")
+    if library_name == "diffusers":
+        return any(
+            page_path == prefix or page_path.startswith(prefix + "/") for prefix in ("api/models", "api/pipelines")
+        )
+    return False
+
+
+def should_embed_chunk(chunk: Chunk) -> bool:
+    library_name = chunk.package_name.lower()
+    if library_name == "blog" or is_learning_library(library_name):
+        return False
+    return not is_compact_api_page(library_name, chunk.page)
 
 
 def get_latest_version_zip(library_name: str) -> str | None:
@@ -203,8 +239,11 @@ def markdown_file_to_url(file_path: Path, library_name: str, base_dir: Path) -> 
     # Convert to URL format
     url_path = str(path_without_ext).replace(os.sep, "/")
 
-    # Build URL
-    url = f"https://huggingface.co/docs/{library_name}/{url_path}"
+    public_library_name = get_public_library_name(library_name)
+    if is_learning_library(public_library_name):
+        url = f"{HF_BASE_URL}/learn/{public_library_name}/en/{url_path}"
+    else:
+        url = f"{HF_BASE_URL}/docs/{public_library_name}/{url_path}"
 
     return url
 
@@ -253,6 +292,8 @@ def process_markdown_file(
         base_url = markdown_file_to_url(file_path, library_name, base_dir)
         page_title = get_page_title(file_path)
 
+        public_library_name = get_public_library_name(library_name)
+
         # Convert sections to Chunks
         chunks = []
         for section in sections:
@@ -292,7 +333,7 @@ def process_markdown_file(
                     text=excerpt,
                     source_page_url=url,
                     source_page_title=page_title,
-                    package_name=library_name,
+                    package_name=public_library_name,
                     headings=heading_list,
                     page=page_path,
                 )
@@ -303,6 +344,90 @@ def process_markdown_file(
     except Exception as e:
         print(f"    ⚠️  Error processing {file_path.name}: {e}")
         return []
+
+
+def process_api_html_file(file_path: Path, library_name: str, base_dir: Path) -> list[Chunk]:
+    html_file = file_path.with_suffix(".html")
+    if not html_file.exists():
+        raise FileNotFoundError(f"Missing rendered HTML for API page: {html_file}")
+
+    with open(html_file, encoding="utf-8") as f:
+        api_docstrings = extract_api_docstrings(f.read())
+
+    base_url = markdown_file_to_url(file_path, library_name, base_dir)
+    page_path = str(file_path.relative_to(base_dir).with_suffix("")).replace(os.sep, "/")
+    chunks = []
+    seen_names = set()
+    for name, description in api_docstrings:
+        if not name:
+            raise ValueError(f"API docstring without an id in {html_file}")
+        if name in seen_names:
+            continue
+        seen_names.add(name)
+        text = f"{name}\n\n{description}" if description else name
+        chunks.append(
+            Chunk(
+                text=text,
+                source_page_url=f"{base_url}#{name}",
+                source_page_title=name,
+                package_name=get_public_library_name(library_name),
+                headings=[f"# {name}"],
+                page=f"{page_path}#{name}",
+            )
+        )
+    return chunks
+
+
+def fetch_blog_chunks() -> list[Chunk]:
+    first_response = httpx.get(HF_BLOG_API_URL, params={"p": 0}, timeout=60, follow_redirects=True)
+    first_response.raise_for_status()
+    first_page = first_response.json()
+
+    total_items = first_page["numTotalItems"]
+    items_per_page = first_page["numItemsPerPage"]
+    if not isinstance(total_items, int) or not isinstance(items_per_page, int) or items_per_page <= 0:
+        raise ValueError("Blog API returned invalid pagination metadata")
+
+    pages = [first_page]
+    for page_index in range(1, ceil(total_items / items_per_page)):
+        response = httpx.get(
+            HF_BLOG_API_URL,
+            params={"p": page_index},
+            timeout=60,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        pages.append(response.json())
+
+    blog_items = []
+    for page in pages:
+        all_blogs = page.get("allBlogs")
+        if not isinstance(all_blogs, list):
+            raise ValueError("Blog API response is missing allBlogs")
+        blog_items.extend(all_blogs)
+
+    unique_items = {}
+    for item in blog_items:
+        title = item.get("title")
+        blog_url = item.get("url")
+        if not isinstance(title, str) or not title.strip() or not isinstance(blog_url, str) or not blog_url:
+            raise ValueError("Blog API returned an item without a title or URL")
+        unique_items[blog_url] = title.strip()
+
+    if len(unique_items) != total_items:
+        raise ValueError(f"Blog API returned {len(unique_items)} unique allBlogs items, expected {total_items}")
+
+    return [
+        Chunk(
+            text=title,
+            source_page_url=urljoin(HF_BASE_URL, blog_url),
+            source_page_title=title,
+            package_name="blog",
+            headings=[f"# {title}"],
+            page=blog_url,
+        )
+        for blog_url, title in unique_items.items()
+    ]
 
 
 def process_library(
@@ -366,13 +491,11 @@ def process_library(
     all_chunks = []
     print("  Processing markdown files...")
     for md_file in tqdm(markdown_files, desc=f"  {library_name}", unit="file"):
-        # Skip model_doc pages for transformers library and api/models for diffusers
         page_path = str(md_file.relative_to(base_dir)).replace(os.sep, "/")
-        if library_name == "transformers" and "model_doc" in page_path:
-            continue
-        if library_name == "diffusers" and ("api/models" in page_path or "api/pipelines" in page_path):
-            continue
-        chunks = process_markdown_file(md_file, library_name, base_dir, excerpts_max_length)
+        if is_compact_api_page(library_name, page_path):
+            chunks = process_api_html_file(md_file, library_name, base_dir)
+        else:
+            chunks = process_markdown_file(md_file, library_name, base_dir, excerpts_max_length)
         all_chunks.extend(chunks)
 
     print(f"  ✅ Generated {len(all_chunks)} chunks from {len(markdown_files)} files")
@@ -405,29 +528,19 @@ def process_all_libraries(
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Fetch library directories
-    directories = fetch_library_directories()
+    include_blog = libraries is None or "blog" in libraries
+    requested_dataset_libraries = None
+    if libraries:
+        requested_dataset_libraries = {get_dataset_library_name(name) for name in libraries if name != "blog"}
+
+    directories = (
+        fetch_library_directories() if requested_dataset_libraries is None or requested_dataset_libraries else []
+    )
 
     # Filter if specific libraries requested
-    if libraries:
-        directories = [d for d in directories if d["path"] in libraries]
+    if requested_dataset_libraries is not None:
+        directories = [d for d in directories if d["path"] in requested_dataset_libraries]
         print(f"Processing {len(directories)} requested libraries: {libraries}")
-
-    # Skip libraries containing "course" or "cookbook" (case-insensitive)
-    skipped_libraries = []
-    filtered_directories = []
-    for directory in directories:
-        library_name = directory["path"]
-        library_name_lower = library_name.lower()
-        if "course" in library_name_lower or "cookbook" in library_name_lower:
-            skipped_libraries.append(library_name)
-        else:
-            filtered_directories.append(directory)
-
-    if skipped_libraries:
-        print(f"Skipping {len(skipped_libraries)} libraries: {skipped_libraries}")
-
-    directories = filtered_directories
 
     # Process each library
     results = {}
@@ -435,6 +548,10 @@ def process_all_libraries(
         library_name = directory["path"]
         chunks = process_library(library_name, output_dir, excerpts_max_length, skip_download)
         results[library_name] = chunks
+
+    if include_blog:
+        print("\n📝 Processing blog titles")
+        results["blog"] = fetch_blog_chunks()
 
     # Summary
     print("\n" + "=" * 80)

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -1,0 +1,105 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from doc_builder.api_docs import extract_api_docstrings
+
+
+def test_extracts_top_level_and_nested_docstrings_without_details():
+    html = """
+    <div class="docstring border-l-2">
+      <div>
+        <span id="transformers.BertModel">
+          <h3>class transformers.BertModel</h3>
+          <a href="source.py">source</a>
+        </span>
+        <p class="font-mono">(config, add_pooling_layer=True)</p>
+        <div class="docstring-details">
+          <p>Parameters</p>
+          <ul><li>config: the model configuration</li></ul>
+          <p>Returns</p>
+          <p>A tensor.</p>
+        </div>
+      </div>
+      <p>The bare <code>BERT</code> model transformer.</p>
+      <p>It can act as an encoder or decoder.</p>
+      <div class="docstring border-l-2">
+        <div>
+          <span id="transformers.BertModel.forward"><h4>forward</h4></span>
+          <p class="font-mono">(input_ids)</p>
+          <div class="docstring-details"><p>Parameters</p></div>
+        </div>
+        <p>Runs the model forward pass.</p>
+      </div>
+    </div>
+    """
+
+    assert extract_api_docstrings(html) == [
+        (
+            "transformers.BertModel",
+            "The bare BERT model transformer.\nIt can act as an encoder or decoder.",
+        ),
+        ("transformers.BertModel.forward", "Runs the model forward pass."),
+    ]
+
+
+def test_truncates_examples_and_keeps_empty_descriptions():
+    html = """
+    <div class="docstring">
+      <div>
+        <span id="diffusers.FluxPipeline"><h3>class diffusers.FluxPipeline</h3></span>
+        <div class="docstring-details"><p>Parameters</p></div>
+      </div>
+      <p>The <code>FluxPipeline</code> generates images from text.</p>
+      <pre>pipe = FluxPipeline.from_pretrained(...)</pre>
+      <p>It supports several model variants.</p>
+      <p><strong>Examples:</strong></p>
+      <pre>image = pipe("a cat").images[0]</pre>
+    </div>
+    <div class="docstring docstring-wide">
+      <div><span id="diffusers.EmptyModel"><h3>class diffusers.EmptyModel</h3></span></div>
+    </div>
+    <div class="docstring">
+      <div><span id="diffusers.StructuredModel"><h3>class diffusers.StructuredModel</h3></span></div>
+      <p>A compact model description.</p>
+      <p><strong>Components:</strong></p>
+      <ul><li>tokenizer: the tokenizer argument</li></ul>
+      <p>Inputs:</p>
+      <p>prompt: text to render</p>
+    </div>
+    <div class="docstring">
+      <div><span id="diffusers.CopiedExample"><h3>class diffusers.CopiedExample</h3></span></div>
+      <p>A description before generated example code.</p>
+      <p>Copied</p>
+      <p>Traceback (most recent call last):</p>
+    </div>
+    <div class="docstring">
+      <div><span id="transformers.FlattenedArgs"><h3>transformers.FlattenedArgs</h3></span></div>
+      <p>Runs the flattened API.</p>
+      <p>last_hidden_state (torch.FloatTensor of shape (batch, length)) — The final hidden state.</p>
+      <p>input_ids (torch.Tensor, optional): The input token ids.</p>
+      <p>return_dict (bool, optional, defaults to True) — Whether to return a dictionary.</p>
+    </div>
+    <div class="docstring-details"><div id="not.an.api.object">ignored</div></div>
+    """
+
+    assert extract_api_docstrings(html) == [
+        (
+            "diffusers.FluxPipeline",
+            "The FluxPipeline generates images from text.\nIt supports several model variants.",
+        ),
+        ("diffusers.EmptyModel", ""),
+        ("diffusers.StructuredModel", "A compact model description."),
+        ("diffusers.CopiedExample", "A description before generated example code."),
+        ("transformers.FlattenedArgs", "Runs the flattened API."),
+    ]

--- a/tests/test_meilisearch_helper.py
+++ b/tests/test_meilisearch_helper.py
@@ -1,0 +1,65 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from doc_builder.build_embeddings import Chunk, chunks_to_documents
+from doc_builder.meilisearch_helper import VECTOR_NAME, add_embeddings_to_db
+
+
+class FakeIndex:
+    def __init__(self):
+        self.payload = None
+
+    def add_documents(self, payload):
+        self.payload = payload
+        return SimpleNamespace(task_uid=7)
+
+    def get_task(self, task_uid):
+        assert task_uid == 7
+        return SimpleNamespace(status="succeeded")
+
+
+class FakeClient:
+    def __init__(self):
+        self.index_instance = FakeIndex()
+
+    def index(self, index_name):
+        assert index_name == "test-index"
+        return self.index_instance
+
+
+def make_chunk(text: str) -> Chunk:
+    return Chunk(
+        text=text,
+        source_page_url=f"https://huggingface.co/docs/test/{text}",
+        source_page_title=text,
+        package_name="test",
+        headings=[f"# {text}"],
+        page=text,
+    )
+
+
+def test_add_embeddings_to_db_omits_vectors_only_for_none():
+    chunks = [make_chunk("vectorized"), make_chunk("vectorless"), make_chunk("empty-vector")]
+    documents = chunks_to_documents(chunks, [[0.1, 0.2], None, []])
+    client = FakeClient()
+
+    add_embeddings_to_db(client, "test-index", documents)
+
+    payload_by_text = {document["text"]: document for document in client.index_instance.payload}
+    assert payload_by_text["vectorized"]["_vectors"] == {VECTOR_NAME: [0.1, 0.2]}
+    assert "_vectors" not in payload_by_text["vectorless"]
+    assert payload_by_text["empty-vector"]["_vectors"] == {VECTOR_NAME: []}
+    assert all(document["product"] == "test" for document in payload_by_text.values())

--- a/tests/test_search_ingestion.py
+++ b/tests/test_search_ingestion.py
@@ -1,0 +1,325 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from doc_builder.build_embeddings import Chunk, chunks_to_documents
+from doc_builder.commands import embeddings as embeddings_command
+from doc_builder.process_hf_docs import (
+    HF_BLOG_API_URL,
+    fetch_blog_chunks,
+    markdown_file_to_url,
+    process_all_libraries,
+    process_api_html_file,
+    process_markdown_file,
+    should_embed_chunk,
+)
+
+
+def make_chunk(package_name: str, page: str, text: str = "Searchable text") -> Chunk:
+    return Chunk(
+        text=text,
+        source_page_url=f"https://huggingface.co/{page}",
+        source_page_title="Page title",
+        package_name=package_name,
+        headings=["# Page title"],
+        page=page,
+    )
+
+
+@pytest.mark.parametrize(
+    ("package_name", "page", "expected"),
+    [
+        ("transformers", "model_doc/bert", False),
+        ("transformers", "model_doc/bert.mdx", False),
+        ("transformers", "main_classes/trainer", True),
+        ("diffusers", "api/models/autoencoder_kl", False),
+        ("diffusers", "api/pipelines/stable_diffusion/pipeline", False),
+        ("diffusers", "api/schedulers/ddim", True),
+        ("course", "chapter1/1", False),
+        ("llm-course", "chapter1/1", False),
+        ("agents-course", "unit0/introduction", False),
+        ("cookbook", "notebooks/example", False),
+        ("blog", "/blog/search-post", False),
+        ("datasets", "about_dataset_features", True),
+    ],
+)
+def test_should_embed_chunk_policy(package_name, page, expected):
+    assert should_embed_chunk(make_chunk(package_name, page)) is expected
+
+
+def test_course_uses_public_product_name_and_learn_url(tmp_path):
+    page = tmp_path / "chapter1" / "lesson.md"
+    page.parent.mkdir()
+    page.write_text("# Lesson\n\nCourse content.", encoding="utf-8")
+
+    assert markdown_file_to_url(page, "course", tmp_path) == (
+        "https://huggingface.co/learn/llm-course/en/chapter1/lesson"
+    )
+
+    chunks = process_markdown_file(page, "course", tmp_path)
+
+    assert chunks
+    assert {chunk.package_name for chunk in chunks} == {"llm-course"}
+    assert {chunk.page for chunk in chunks} == {"chapter1/lesson"}
+    assert all(
+        chunk.source_page_url.startswith("https://huggingface.co/learn/llm-course/en/chapter1/lesson")
+        for chunk in chunks
+    )
+
+
+def test_api_page_becomes_one_vectorless_record_per_docstring(tmp_path):
+    page = tmp_path / "model_doc" / "bert.md"
+    page.parent.mkdir()
+    page.write_text("# BERT", encoding="utf-8")
+    page.with_suffix(".html").write_text(
+        """
+        <div class="docstring">
+          <div>
+            <span id="transformers.BertModel"><h3>transformers.BertModel</h3></span>
+            <p>(config, add_pooling_layer=True)</p>
+            <div class="docstring-details"><p>Returns a tensor.</p></div>
+          </div>
+          <p>The bare BERT model transformer.</p>
+        </div>
+        """,
+        encoding="utf-8",
+    )
+
+    chunks = process_api_html_file(page, "transformers", tmp_path)
+
+    assert len(chunks) == 1
+    assert chunks[0].text == "transformers.BertModel\n\nThe bare BERT model transformer."
+    assert chunks[0].source_page_url.endswith("/docs/transformers/model_doc/bert#transformers.BertModel")
+    assert chunks[0].source_page_title == "transformers.BertModel"
+    assert chunks[0].headings == ["# transformers.BertModel"]
+    assert chunks[0].page == "model_doc/bert#transformers.BertModel"
+    assert should_embed_chunk(chunks[0]) is False
+
+
+def test_process_all_libraries_keeps_courses_and_adds_blog(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "doc_builder.process_hf_docs.fetch_library_directories",
+        lambda: [{"path": "course"}, {"path": "datasets"}],
+    )
+    processed_libraries = []
+
+    def fake_process_library(library_name, *args, **kwargs):
+        processed_libraries.append(library_name)
+        return []
+
+    monkeypatch.setattr("doc_builder.process_hf_docs.process_library", fake_process_library)
+    monkeypatch.setattr("doc_builder.process_hf_docs.fetch_blog_chunks", lambda: [make_chunk("blog", "/blog/post")])
+
+    results = process_all_libraries(output_dir=tmp_path)
+
+    assert processed_libraries == ["course", "datasets"]
+    assert results["blog"][0].package_name == "blog"
+
+
+def test_process_all_libraries_can_target_blog_without_fetching_dataset(monkeypatch, tmp_path):
+    def fail_dataset_fetch():
+        pytest.fail("The doc-build dataset should not be fetched for a blog-only run")
+
+    monkeypatch.setattr("doc_builder.process_hf_docs.fetch_library_directories", fail_dataset_fetch)
+    monkeypatch.setattr("doc_builder.process_hf_docs.fetch_blog_chunks", lambda: [make_chunk("blog", "/blog/post")])
+
+    results = process_all_libraries(output_dir=tmp_path, libraries=["blog"])
+
+    assert list(results) == ["blog"]
+
+
+def test_process_all_libraries_maps_llm_course_to_dataset_name(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "doc_builder.process_hf_docs.fetch_library_directories",
+        lambda: [{"path": "course"}, {"path": "datasets"}],
+    )
+    processed_libraries = []
+
+    def fake_process_library(library_name, *args, **kwargs):
+        processed_libraries.append(library_name)
+        return []
+
+    monkeypatch.setattr("doc_builder.process_hf_docs.process_library", fake_process_library)
+
+    results = process_all_libraries(output_dir=tmp_path, libraries=["llm-course"])
+
+    assert processed_libraries == ["course"]
+    assert list(results) == ["course"]
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+def test_fetch_blog_chunks_paginates_and_uses_only_all_blogs(monkeypatch):
+    pages = {
+        0: {
+            "numTotalItems": 3,
+            "numItemsPerPage": 2,
+            "allBlogs": [
+                {
+                    "title": "First post",
+                    "url": "/blog/first-post",
+                    "summary": "This body must not be indexed.",
+                    "canonical": True,
+                },
+                {
+                    "title": "Namespaced post",
+                    "url": "/blog/acme/namespaced-post",
+                    "canonical": False,
+                },
+            ],
+            "communityBlogPosts": [{"title": "Ignored community post", "url": "/blog/user/ignored"}],
+        },
+        1: {
+            "allBlogs": [{"title": "Last post", "url": "/blog/last-post"}],
+            "communityBlogPosts": [{"title": "Also ignored", "url": "/blog/user/also-ignored"}],
+        },
+    }
+    calls = []
+
+    def fake_get(url, *, params, timeout, follow_redirects):
+        calls.append((url, params, timeout, follow_redirects))
+        return FakeResponse(pages[params["p"]])
+
+    monkeypatch.setattr("doc_builder.process_hf_docs.httpx.get", fake_get)
+
+    chunks = fetch_blog_chunks()
+
+    assert calls == [
+        (HF_BLOG_API_URL, {"p": 0}, 60, True),
+        (HF_BLOG_API_URL, {"p": 1}, 60, True),
+    ]
+    assert [chunk.text for chunk in chunks] == ["First post", "Namespaced post", "Last post"]
+    assert [chunk.source_page_url for chunk in chunks] == [
+        "https://huggingface.co/blog/first-post",
+        "https://huggingface.co/blog/acme/namespaced-post",
+        "https://huggingface.co/blog/last-post",
+    ]
+    assert all(chunk.package_name == "blog" for chunk in chunks)
+    assert all(chunk.text == chunk.source_page_title for chunk in chunks)
+    assert all(chunk.headings == [f"# {chunk.text}"] for chunk in chunks)
+    assert "Ignored community post" not in {chunk.text for chunk in chunks}
+    assert "This body must not be indexed." not in {chunk.text for chunk in chunks}
+
+
+def test_fetch_blog_chunks_rejects_incomplete_results(monkeypatch):
+    response = FakeResponse(
+        {
+            "numTotalItems": 2,
+            "numItemsPerPage": 2,
+            "allBlogs": [{"title": "Only post", "url": "/blog/only-post"}],
+            "communityBlogPosts": [{"title": "Not a replacement", "url": "/blog/user/community"}],
+        }
+    )
+    monkeypatch.setattr("doc_builder.process_hf_docs.httpx.get", lambda *args, **kwargs: response)
+
+    with pytest.raises(ValueError, match="returned 1 unique allBlogs items, expected 2"):
+        fetch_blog_chunks()
+
+
+def test_chunks_to_documents_uses_none_for_vectorless_chunks():
+    chunk = make_chunk("blog", "blog/vectorless", text="Open R1: Update #4")._replace(
+        source_page_title="Open R1: Update #4",
+        headings=["# Open R1: Update #4"],
+    )
+
+    documents = chunks_to_documents([chunk])
+
+    assert len(documents) == 1
+    assert documents[0].embedding is None
+    assert documents[0].library == "blog"
+    assert documents[0].heading1 == "Open R1: Update #4"
+    assert documents[0].source_page_url == chunk.source_page_url
+
+
+def test_chunks_to_search_documents_embeds_only_eligible_chunks(monkeypatch):
+    regular_chunk = make_chunk("datasets", "about_dataset_features", text="Regular docs")
+    api_chunk = make_chunk("transformers", "model_doc/bert", text="API docs")
+    course_chunk = make_chunk("llm-course", "chapter1/1", text="Course docs")
+    inference_calls = []
+
+    def fake_inference(chunks, hf_ie_url, hf_ie_token, is_python_module):
+        inference_calls.append((chunks, hf_ie_url, hf_ie_token, is_python_module))
+        return chunks_to_documents(chunks, [[0.1, 0.2]])
+
+    monkeypatch.setattr(embeddings_command, "call_embedding_inference", fake_inference)
+
+    documents = embeddings_command._chunks_to_search_documents(
+        [regular_chunk, api_chunk, course_chunk], "https://inference.test", "token"
+    )
+
+    assert inference_calls == [([regular_chunk], "https://inference.test", "token", False)]
+    documents_by_text = {document.text: document for document in documents}
+    assert documents_by_text["Regular docs"].embedding == [0.1, 0.2]
+    assert documents_by_text["API docs"].embedding is None
+    assert documents_by_text["Course docs"].embedding is None
+
+
+def test_chunks_to_search_documents_skips_inference_when_every_chunk_is_vectorless(monkeypatch):
+    chunks = [
+        make_chunk("blog", "/blog/post", text="Blog title"),
+        make_chunk("diffusers", "api/models/autoencoder_kl", text="API docs"),
+    ]
+
+    def fail_inference(*args, **kwargs):
+        pytest.fail("Embedding inference should not be called for full-text-only chunks")
+
+    monkeypatch.setattr(embeddings_command, "call_embedding_inference", fail_inference)
+
+    documents = embeddings_command._chunks_to_search_documents(chunks, None, None)
+
+    assert [document.text for document in documents] == ["Blog title", "API docs"]
+    assert all(document.embedding is None for document in documents)
+
+
+def test_incremental_course_scope_uses_public_product_prefix(monkeypatch):
+    existing_ids = {"llm-course-old-page-a1b2c3d4", "course-legacy-page-a1b2c3d4", "datasets-page-a1b2c3d4"}
+    deleted_batches = []
+    saved_trackers = []
+
+    monkeypatch.setattr("doc_builder.embeddings_tracker.load_tracker", lambda token: existing_ids)
+    monkeypatch.setattr(
+        "doc_builder.embeddings_tracker.save_tracker", lambda ids, token: saved_trackers.append((ids, token))
+    )
+    monkeypatch.setattr(
+        "doc_builder.meilisearch_helper.delete_documents_from_db",
+        lambda client, index, ids: deleted_batches.append(ids),
+    )
+    monkeypatch.setattr("meilisearch.Client", lambda *args: object())
+
+    embeddings_command._run_incremental(
+        SimpleNamespace(libraries=["course"], hf_token=None),
+        [],
+        None,
+        None,
+        "meili-key",
+        "https://meili.test",
+        5000,
+    )
+
+    assert deleted_batches == [["llm-course-old-page-a1b2c3d4"]]
+    assert saved_trackers == [
+        ({"course-legacy-page-a1b2c3d4", "datasets-page-a1b2c3d4"}, None),
+    ]


### PR DESCRIPTION
## Summary

- ingest Transformers model API pages and Diffusers model/pipeline API pages as compact full-text-only records
- ingest courses and the cookbook with normal chunking but without embedding generation
- ingest paginated Hub blog titles from `allBlogs` while ignoring `communityBlogPosts`
- allow vectorized and vectorless documents to coexist in the semantic docs index

## Behavior

API records are extracted from rendered `.docstring` HTML so each record contains only the fully qualified API name and its description. Signature blocks, parameters, returns, structured input/output sections, and examples are excluded. The API name is stored in the highest-priority heading and text fields for lexical matching.

The doc-build dataset name `course` maps to the public `llm-course` product and `/learn/llm-course/en/...` URLs. Other course and cookbook URLs also use `/learn/...`.

Blog ingestion paginates `https://huggingface.co/api/blog`, indexes one title-only record for every `allBlogs` item, preserves the returned blog URL, and never reads `communityBlogPosts`.

This PR is limited to doc-builder ingestion. The Moon Landing query/backend switch will follow separately.

## Validation

- `215 passed` across the complete pytest suite
- Ruff lint and formatting checks pass for the complete repository
- validated the compact extractor against 522 Transformers API pages and 213 Diffusers API pages (7,467 docstring records), with no structured-detail or preformatted-example leakage
- validated all 853 current `allBlogs` records from the live paginated endpoint