### PR TITLE
Fix vectorless Meilisearch document payload

### DIFF
--- a/src/doc_builder/meilisearch_helper.py
+++ b/src/doc_builder/meilisearch_helper.py
@@ -247,9 +247,8 @@ def add_embeddings_to_db(client: Client, index_name: str, embeddings):
             "heading3": embedding.heading3,
             "heading4": embedding.heading4,
             "heading5": embedding.heading5,
+            "_vectors": {VECTOR_NAME: embedding.embedding},
         }
-        if embedding.embedding is not None:
-            document["_vectors"] = {VECTOR_NAME: embedding.embedding}
         payload_data.append(document)
     task_info = index.add_documents(payload_data)
     return client, task_info

--- a/tests/test_meilisearch_helper.py
+++ b/tests/test_meilisearch_helper.py
@@ -51,7 +51,7 @@ def make_chunk(text: str) -> Chunk:
     )
 
 
-def test_add_embeddings_to_db_omits_vectors_only_for_none():
+def test_add_embeddings_to_db_marks_none_as_vectorless():
     chunks = [make_chunk("vectorized"), make_chunk("vectorless"), make_chunk("empty-vector")]
     documents = chunks_to_documents(chunks, [[0.1, 0.2], None, []])
     client = FakeClient()
@@ -60,6 +60,6 @@ def test_add_embeddings_to_db_omits_vectors_only_for_none():
 
     payload_by_text = {document["text"]: document for document in client.index_instance.payload}
     assert payload_by_text["vectorized"]["_vectors"] == {VECTOR_NAME: [0.1, 0.2]}
-    assert "_vectors" not in payload_by_text["vectorless"]
+    assert payload_by_text["vectorless"]["_vectors"] == {VECTOR_NAME: None}
     assert payload_by_text["empty-vector"]["_vectors"] == {VECTOR_NAME: []}
     assert all(document["product"] == "test" for document in payload_by_text.values())


### PR DESCRIPTION
## Summary

- always include the configured embedder entry in `_vectors`
- serialize vectorless documents as `_vectors.embeddings: null`, the explicit Meilisearch opt-out
- cover vectorized, vectorless, and empty-vector payloads with a regression test

This fixes the `source: userProvided` failure from [workflow run 33557385541](https://github.com/huggingface/doc-builder/actions/runs/33557385541/job/100021441603).

## Validation

- `python -m pytest -n 1 --dist=loadfile -q ./tests/` (215 passed)
- `ruff check .`
- `ruff format --check .`
- `git diff --check`