### PR TITLE
fix(kit): stop expanding /learn course links to /docs paths on click

### DIFF
--- a/kit/src/lib/hfDocPaths.js
+++ b/kit/src/lib/hfDocPaths.js
@@ -6,6 +6,11 @@
  * currently built library/version/language, so that they can be treated as
  * internal SvelteKit routes (partial loading) instead of full page reloads.
  *
+ * Course pages (hf.co/learn/course/page) are deliberately left alone: the Hub
+ * serves them through its own /api/learn/... handler, and rewriting their
+ * anchors to /docs/course/main/lang/page makes the Hub request a
+ * /api/docs/... path that does not exist for courses.
+ *
  * `__DOCS_LIBRARY__` & co are compile-time constants injected via Vite `define`
  * (see vite.config.ts) from the DOCS_LIBRARY/DOCS_VERSION/DOCS_LANGUAGE env vars.
  *
@@ -14,12 +19,11 @@
  * not belong to the currently built library/version/language
  */
 export function getHfDocFullPath(pathname) {
-	if (/^\/(docs|learn)/.test(pathname)) {
+	if (/^\/docs\//.test(pathname)) {
 		const params = pathname.slice(1).split("/");
-		const _docType = params.shift();
+		params.shift(); // "docs"
 		const _library = params.shift();
-		const isCourse = _docType === "learn";
-		const versionRegex = isCourse ? /^(?:pr_\d+)$/ : /^(?:(master|main)|v[\d.]+(rc\d+)?|pr_\d+)$/;
+		const versionRegex = /^(?:(master|main)|v[\d.]+(rc\d+)?|pr_\d+)$/;
 		const _version = versionRegex.test(params[0]) ? params.shift() : __DOCS_VERSION__;
 		const _lang = /^[a-z]{2}(-[A-Za-z]{2})?$/.test(params[0]) ? params.shift() : __DOCS_LANGUAGE__;
 		const newChapterId = params.join("/");


### PR DESCRIPTION
# What does this PR do?

Fixes in-page navigation on course pages served at `hf.co/learn/...` when built with the current kit. On huggingface/agents-course, rebuilt on 2026-09-09 (first course rebuilt since the Svelte 5 migration), every sidebar and next-page click ends on a 404: huggingface/agents-course#736, huggingface/agents-course#737.

Since #794 the click listener in `+layout.svelte` rewrites the clicked anchor's `pathname` in the DOM through `getHfDocFullPath` ($lib/hfDocPaths.js), which also matched `/learn/...`. On a course page, a click on `/learn/agents-course/unit1/tools` becomes `/docs/agents-course/main/en/unit1/tools` before the Hub's own link handler reads it. The Hub then fetches `/api/docs/agents-course/main/en/unit1/tools`, which is a 404 (courses are only served under `/api/learn/<course>/<page>`), and falls back to a full navigation to the `/docs` URL, which is also a 404 for courses:

```
click /learn/agents-course/unit1/what-are-agents
  -> anchor rewritten to /docs/agents-course/main/en/unit1/what-are-agents
  -> fetch /api/docs/agents-course/main/en/unit1/what-are-agents   404
  -> location = /docs/agents-course/main/en/unit1/what-are-agents  404
```

Before #792 the same expansion lived inside the `svelteKitCustomClient` fork and only mutated SvelteKit's internal URL object, never the DOM anchor, so the Hub always saw the original `/learn` href.

Changes:
- `getHfDocFullPath` only expands `/docs/...` shorthand paths. `/learn/...` links are left untouched, so the Hub handles them via `/api/learn/<course>/<page>` as before.

The `reroute` hook never receives `/learn` URLs (SvelteKit treats URLs outside `base` as external before consulting it), so the removed branch was only reachable from the click listener.

Verified on the live agents-course page with `fetch`/`beforeunload` instrumented, blocking the anchor `pathname` write to emulate this change:

```
before:  fetch /api/docs/agents-course/main/en/unit1/what-are-agents 404, full navigation, Hub 404 page
after:   fetch /api/learn/agents-course/unit1/what-are-agents 200, lands on /learn/agents-course/unit1/what-are-agents
```

and the helper itself with node: `/learn/agents-course/unit1/tools` -> `undefined`, `/docs/agents-course/unit1/tools` -> `/docs/agents-course/main/en/unit1/tools`, `/docs/trl/quickstart` (other library) -> `undefined`. Prettier clean. `kit/` has no JS test runner, so there is no unit test to add here without pulling in one.

Only agents-course is affected today. Every other course's bucket is still on a pre-#792 build, and each will break the same way on its first rebuild until this lands. After merging, agents-course needs a rebuild (re-run `build_documentation.yml`) to pick up the fixed kit, no agents-course-side change needed since the reusable workflow checks out doc-builder from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
