### PR TITLE
Key the workflow template concurrency group on the pull request number

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ doc-builder notebook-to-mdx {path to notebook file or folder containing notebook
 * `upload_pr_documentation.yml`: responsible for uploading the PR artifacts to the Hugging Face Hub.
 * `delete_doc_comment_trigger.yml`: responsible for removing the comments from the `HuggingFaceDocBuilder` bot that provides a URL to the PR docs.
 
-Within each workflow, the main thing to include is a pointer from the `uses` field to the corresponding workflow in `doc-builder`. For example, this is what the PR workflow looks like in the `datasets` library:
+Within each workflow, the main thing to include is a pointer from the `uses` field to the corresponding workflow in `doc-builder`. For example, this is what the PR workflow looks like:
 
 ```yaml
 name: Build PR Documentation

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

The `build_pr_documentation.yml` template keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks whose branches share a name therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

Shared names are common, because many contributors push to their fork's default branch instead of creating one: in `transformers`, 154 of the 1589 currently open PRs share a head branch name with another open PR, 84 of them on `main` and 41 on `patch-1`. I did not find a realized cancellation in the 1200 most recent runs of that doc build, so this is hardening rather than a fix for something currently failing.

`github.event.pull_request.number` is unique per pull request. The template only triggers on `pull_request`, so the `github.run_id` fallback is never reached, but keeping it means that a consumer who later adds another trigger falls back to never cancelling rather than to grouping by branch name.

The snippet has been copied widely: 41 of the 42 repositories in the organization that have a `build_pr_documentation.yml` carry this line byte for byte, and it has also been copied into test and benchmark workflows, where a cancelled run costs runner minutes rather than a doc preview.

It also drops the reference to the `datasets` library from the sentence introducing the snippet. That claim did not hold anyway: `datasets` pins the `uses` field to a commit SHA while the snippet shows `@main`, so the section reads better as a template than as a copy of one repository's workflow.

See my original PR in `trl`:
- https://github.com/huggingface/trl/pull/7174